### PR TITLE
SDK changes to pass in the cache id header.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_CACHE_ID: dummy
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_CACHE_ID: dummy
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Java sdk customers can use to interact with our ecosystem
         * Must have AWS Access Key ID and AWS Secret Key belonging to the Cell under test
       * Run the following command and it will generate and print an `<auth token>`
         * `AWS_ACCESS_KEY_ID=<ACCESS_KEY> AWS_SECRET_ACCESS_KEY=<SECRET_KEY> mm keys generate-api-key <test_key_name> --cell <cell_name>`
-    * `TEST_AUTH_TOKEN=<auth token> TEST_ENDPOINT=<endpoint> ./gradlew integrationTest`
+    * `TEST_AUTH_TOKEN=<auth token> TEST_CACHE_ID=<cache id> TEST_ENDPOINT=<endpoint> ./gradlew integrationTest`
+      * `TEST_CACHE_ID` is required. Give it any string value for now. TODO - Add a way of getting this per environment
       * `TEST_ENDPOINT` is optional and defaults to alpha. TEST_ENDPOINT must belong to the cell where the auth token was generated.
    
 ## How to import into your project

--- a/momento-sdk-java-scs/src/intTest/java/momento/scs/ScsClientTest.java
+++ b/momento-sdk-java-scs/src/intTest/java/momento/scs/ScsClientTest.java
@@ -43,6 +43,9 @@ class ScsClientTest {
         if (System.getenv("TEST_AUTH_TOKEN") == null) {
             throw new IllegalArgumentException("Integration tests require TEST_AUTH_TOKEN env var; see README for more details.");
         }
+        if (System.getenv("TEST_CACHE_ID") == null) {
+            throw new IllegalArgumentException("Integration tests require TEST_CACHE_ID env var; see README for more details.");
+        }
     }
 
     @BeforeEach
@@ -51,16 +54,16 @@ class ScsClientTest {
     }
 
     ScsClient getScsClient(Optional<OpenTelemetry> openTelemetry) {
-        return getScsClient(System.getenv("TEST_AUTH_TOKEN"), openTelemetry);
+        return getScsClient(System.getenv("TEST_AUTH_TOKEN"), System.getenv("TEST_CACHE_ID"), openTelemetry);
     }
 
-    ScsClient getScsClient(String authToken, Optional<OpenTelemetry> openTelemetry) {
+    ScsClient getScsClient(String authToken, String cacheId, Optional<OpenTelemetry> openTelemetry) {
         String endpoint = System.getenv("TEST_ENDPOINT");
         if (endpoint == null) {
             endpoint = "alpha.cacheservice.com";
         }
 
-        return new ScsClient(authToken, openTelemetry, endpoint, System.getenv("TEST_SSL_INSECURE") != null);
+        return new ScsClient(authToken, cacheId, openTelemetry, endpoint, System.getenv("TEST_SSL_INSECURE") != null);
     }
 
     @AfterEach
@@ -219,7 +222,7 @@ class ScsClientTest {
 
     @Test
     void testBadAuthToken() {
-        ScsClient badCredClient = getScsClient("BAD_TOKEN", Optional.empty());
+        ScsClient badCredClient = getScsClient("BAD_TOKEN", "dummy", Optional.empty());
         testBadAuthToken(badCredClient);
     }
 
@@ -227,7 +230,7 @@ class ScsClientTest {
     void testBadAuthTokenWithTracing() throws Exception{
         startIntegrationTestOtel();
         OpenTelemetrySdk openTelemetry = setOtelSDK();
-        ScsClient client = getScsClient("BAD_TOKEN", Optional.of(openTelemetry));
+        ScsClient client = getScsClient("BAD_TOKEN", "dummy", Optional.of(openTelemetry));
         testBadAuthToken(client);
         // To accommodate for delays in tracing logs to appear in docker
         Thread.sleep(1000);

--- a/momento-sdk-java-scs/src/main/java/org/momento/scs/CacheIdInterceptor.java
+++ b/momento-sdk-java-scs/src/main/java/org/momento/scs/CacheIdInterceptor.java
@@ -1,0 +1,34 @@
+package org.momento.scs;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+
+public class CacheIdInterceptor implements ClientInterceptor {
+
+    private Metadata.Key<String> cacheHeaderKey = Metadata.Key.of("cacheId", ASCII_STRING_MARSHALLER);
+    private String cacheId;
+
+    public CacheIdInterceptor(String inputCacheId) {
+        cacheId = inputCacheId;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                channel.newCall(methodDescriptor, callOptions)) {
+            @Override
+            public void start(Listener<RespT> listener, Metadata metadata) {
+                metadata.put(cacheHeaderKey, cacheId);
+                super.start(listener, metadata);
+            }
+        };
+    }
+}

--- a/momento-sdk-java-scs/src/main/java/org/momento/scs/ScsClient.java
+++ b/momento-sdk-java-scs/src/main/java/org/momento/scs/ScsClient.java
@@ -50,8 +50,8 @@ public class ScsClient {
      *
      * @param authToken Token to authenticate with SCS
      */
-    public ScsClient(String authToken) {
-        this(authToken, Optional.empty());
+    public ScsClient(String authToken, String cacheId) {
+        this(authToken, cacheId, Optional.empty());
     }
 
     /**
@@ -59,8 +59,8 @@ public class ScsClient {
      * @param authToken Token to authenticate with SCS
      * @param openTelemetry Open telemetry instance to hook into client traces
      */
-    public ScsClient(String authToken, Optional<OpenTelemetry> openTelemetry) {
-        this(authToken, openTelemetry, "alpha.cacheservice.com");
+    public ScsClient(String authToken, String cacheId, Optional<OpenTelemetry> openTelemetry) {
+        this(authToken, cacheId, openTelemetry, "alpha.cacheservice.com");
     }
 
     /**
@@ -70,8 +70,8 @@ public class ScsClient {
      * @param openTelemetry Open telemetry instance to hook into client traces
      * @param endpoint  SCS endpoint to make api calls to
      */
-    public ScsClient(String authToken, Optional<OpenTelemetry> openTelemetry, String endpoint) {
-        this(authToken, openTelemetry, endpoint, false);
+    public ScsClient(String authToken, String cacheId, Optional<OpenTelemetry> openTelemetry, String endpoint) {
+        this(authToken, cacheId, openTelemetry, endpoint, false);
     }
 
     /**
@@ -82,7 +82,7 @@ public class ScsClient {
      * @param endpoint  SCS endpoint to make api calls to
      * @param insecureSsl for overriding host validation
      */
-    public ScsClient(String authToken, Optional<OpenTelemetry> openTelemetry, String endpoint, boolean insecureSsl) {
+    public ScsClient(String authToken, String cacheId, Optional<OpenTelemetry> openTelemetry, String endpoint, boolean insecureSsl) {
         NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(
                 endpoint,
                 443
@@ -102,6 +102,7 @@ public class ScsClient {
         channelBuilder.disableRetry();
         List<ClientInterceptor> clientInterceptors = new ArrayList<>();
         clientInterceptors.add(new AuthInterceptor(authToken));
+        clientInterceptors.add(new CacheIdInterceptor(cacheId));
         openTelemetry.ifPresent(theOpenTelemetry -> clientInterceptors.add(new OpenTelemetryClientInterceptor(theOpenTelemetry)));
         channelBuilder.intercept(clientInterceptors);
         ManagedChannel channel = channelBuilder.build();


### PR DESCRIPTION
Plumbing so that the SDK starts passing in a cache id header as well. This is needed for https://github.com/momentohq/cacheservice/pull/160 where mr2 will fail requests if a cache id header is not passed

Currently we can pass in any string for the cache id as changes to integrate with that are still being done. 