### PR TITLE
chore: Help IntelliJ recognize generated message protos

### DIFF
--- a/messages/build.gradle.kts
+++ b/messages/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     id("com.google.protobuf") version "0.8.16"
     id("momento.artifactory-java-lib")
+    idea
 }
 
 dependencies {


### PR DESCRIPTION
It seems like adding the idea back to plugins section allows IntelliJ Editor to find and recognize the generated Java proto classes.