### PR TITLE
feat: Support creating ScsClient with named endpoint

### DIFF
--- a/momento-sdk-java-scs/src/main/java/org/momento/scs/ScsClient.java
+++ b/momento-sdk-java-scs/src/main/java/org/momento/scs/ScsClient.java
@@ -55,6 +55,16 @@ public class ScsClient {
     }
 
     /**
+     * Builds an instance of {@link ScsClient} that will interact with a specified endpoint
+     * @param authToken
+     * @param cacheId
+     * @param endpoint
+     */
+    public ScsClient(String authToken, String cacheId, String endpoint) {
+        this(authToken, cacheId, Optional.empty(), endpoint);
+    }
+
+    /**
      *
      * @param authToken Token to authenticate with SCS
      * @param openTelemetry Open telemetry instance to hook into client traces


### PR DESCRIPTION
Create a ScsClient with authToken, cache id and endpoint. It will use defaults for telemetry.