### PR TITLE
feat: Add endpoint override for Momento

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoTest.java
@@ -31,7 +31,7 @@ class MomentoTest {
       Momento m =
           Momento.builder()
               .authToken(System.getenv("TEST_AUTH_TOKEN"))
-              .endPointOverride("cell-alpha-dev.preprod.a.momentohq.com")
+              .endpointOverride("cell-alpha-dev.preprod.a.momentohq.com")
               .build();
       Cache cache = m.createCache(System.getenv("TEST_CACHE_NAME"));
 


### PR DESCRIPTION
The plan of record is to make endpoint (aka cell's hosted zone) available in the authToken. SDK will be parsing the authToken to determine the endpoint and then prefix it with `control.` to perform control operations and `cache.` to perform cache operations.

Currently, the endpoint isn't available in the authToken. Hence an endpointOverride option is added. Momento will prefer the endpointOverride option over the endpoint in the authToken. This is more of an advanced feature for customers who know what they are doing or have been specifically asked to use an override by us.

The change also switches Momento construction from init() to Builder pattern which is more consistent with other standard Java SDKs like those of other cloud providers.

Now the object construction will be:
```
Momento momento = Momento.builder()
                    .authToken("authToken")
                    .endpointOverride("developer-gautam-dev.preprod.a.momentohq.com")
                    .build();
```