### PR TITLE
Change overloaded private method name

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/Cache.java
+++ b/momento-sdk/src/main/java/momento/sdk/Cache.java
@@ -167,18 +167,18 @@ public final class Cache implements Closeable {
    * @throws IOException if an error occurs opening ByteBuffer for request body.
    */
   public CacheSetResponse set(String key, ByteBuffer value, int ttlSeconds) {
-    return set(convert(key), convert(value), ttlSeconds);
+    return sendSet(convert(key), convert(value), ttlSeconds);
   }
 
   public CacheSetResponse set(String key, String value, int ttlSeconds) {
-    return set(convert(key), convert(value), ttlSeconds);
+    return sendSet(convert(key), convert(value), ttlSeconds);
   }
 
   public CacheSetResponse set(byte[] key, byte[] value, int ttlSeconds) {
-    return set(convert(key), convert(value), ttlSeconds);
+    return sendSet(convert(key), convert(value), ttlSeconds);
   }
 
-  private CacheSetResponse set(ByteString key, ByteString value, int ttlSeconds) {
+  private CacheSetResponse sendSet(ByteString key, ByteString value, int ttlSeconds) {
     Optional<Span> span = buildSpan("java-sdk-set-request");
     try (Scope ignored = (span.map(ImplicitContextKeyed::makeCurrent).orElse(null))) {
       SetResponse rsp = blockingStub.set(buildSetRequest(key, value, ttlSeconds * 1000));


### PR DESCRIPTION
I am attempting to pull the sdk in another gradle package and the compile fails looking for ByteString 

```
/Users/gautamkanvinde/repos/client-sdk-examples/java-gradle/lib/src/main/java/momento/client/example/Library.java:11: error: cannot access ByteString
    CacheSetResponse resp = client.set("key", "value", 1000);
                                  ^
  class file for com.google.protobuf.ByteString not found
1 error
```

I have a theory that this is due to the overloaded methods and wanted to test this out quick.