### PR TITLE
feat: Value in Gets should be empty for Cache Miss

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoTest.java
@@ -50,12 +50,12 @@ final class MomentoTest {
     // Set Key sync
     CacheSetResponse setRsp =
         cache.set(key, ByteBuffer.wrap("bar".getBytes(StandardCharsets.UTF_8)), 2);
-    assertEquals(MomentoCacheResult.Ok, setRsp.getResult());
+    assertEquals(MomentoCacheResult.Ok, setRsp.result());
 
     // Get Key that was just set
     CacheGetResponse rsp = cache.get(key);
-    assertEquals(MomentoCacheResult.Hit, rsp.getResult());
-    assertEquals("bar", rsp.asStringUtf8());
+    assertEquals(MomentoCacheResult.Hit, rsp.result());
+    assertEquals("bar", rsp.asStringUtf8().get());
   }
 
   // TODO: Update this to be recreated each time and add a separate test case for Already Exists

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -2,7 +2,10 @@ package momento.sdk.messages;
 
 import com.google.protobuf.ByteString;
 import grpc.cache_client.ECacheResult;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Optional;
 
 public final class CacheGetResponse extends BaseResponse {
   private final ByteString body;
@@ -13,16 +16,22 @@ public final class CacheGetResponse extends BaseResponse {
     this.result = result;
   }
 
-  public MomentoCacheResult getResult() {
+  public MomentoCacheResult result() {
     return this.resultMapper(this.result);
   }
 
-  public byte[] asByteArray() {
-    return body.toByteArray();
+  public Optional<byte[]> asByteArray() {
+    if (result != ECacheResult.Hit) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(body.toByteArray());
   }
 
-  public ByteBuffer asByteBuffer() {
-    return body.asReadOnlyByteBuffer();
+  public Optional<ByteBuffer> asByteBuffer() {
+    if (result != ECacheResult.Hit) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(body.asReadOnlyByteBuffer());
   }
 
   /**
@@ -30,7 +39,25 @@ public final class CacheGetResponse extends BaseResponse {
    *
    * @return
    */
-  public String asStringUtf8() {
-    return body.toStringUtf8();
+  public Optional<String> asStringUtf8() {
+    if (result != ECacheResult.Hit) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(body.toStringUtf8());
+  }
+
+  public Optional<String> asString(Charset charset) {
+    if (result != ECacheResult.Hit) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(body.toString(charset));
+  }
+
+  public Optional<InputStream> asInputStream() {
+    if (result != ECacheResult.Hit) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(body.newInput());
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetResponse.java
@@ -9,7 +9,7 @@ public final class CacheSetResponse extends BaseResponse {
     this.result = result;
   }
 
-  public MomentoCacheResult getResult() {
+  public MomentoCacheResult result() {
     return this.resultMapper(this.result);
   }
 }


### PR DESCRIPTION
Previously this method return the default ByteString.EMPTY value on cache misses. So, the onus was on customers to check the hit/miss status before getting the value.

Before:
```
String value = null;
if (resp.getResult() == MomentoResult.Hit) {
   value = rsp.asStringUtf8();
}
```

Now with optionals, customers can choose how they want to handle cache misses without having to check `MomentoResult`
e.g.
```
String value = rsp.asStringUtf8().orElse(MY_DEFAULT_VALUE);
```
or
```
String value = rsp.asStringUtf8().orElseThrow(() -> new ItemNotFoundException());
```