### PR TITLE
feat: Make Cache constructors package default

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/Cache.java
+++ b/momento-sdk/src/main/java/momento/sdk/Cache.java
@@ -40,9 +40,6 @@ import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheSetResponse;
 
 /** Client to perform operations on cache. */
-// TODO: https://github.com/momentohq/client-sdk-java/issues/24 - constructors should be visible
-// only in the package.
-// TODO: Also clean up the method and class comments
 public final class Cache implements Closeable {
   private final ScsGrpc.ScsBlockingStub blockingStub;
   private final ScsGrpc.ScsFutureStub futureStub;
@@ -55,7 +52,7 @@ public final class Cache implements Closeable {
    * @param authToken Token to authenticate with SCS
    * @param endpoint SCS endpoint to make api calls to
    */
-  public Cache(String authToken, String cacheName, String endpoint) {
+  Cache(String authToken, String cacheName, String endpoint) {
     this(authToken, cacheName, Optional.empty(), endpoint);
   }
 
@@ -66,7 +63,7 @@ public final class Cache implements Closeable {
    * @param openTelemetry Open telemetry instance to hook into client traces
    * @param endpoint SCS endpoint to make api calls to
    */
-  public Cache(
+  Cache(
       String authToken, String cacheName, Optional<OpenTelemetry> openTelemetry, String endpoint) {
     this(authToken, cacheName, openTelemetry, endpoint, false);
   }
@@ -79,7 +76,7 @@ public final class Cache implements Closeable {
    * @param endpoint SCS endpoint to make api calls to
    * @param insecureSsl for overriding host validation
    */
-  public Cache(
+  Cache(
       String authToken,
       String cacheName,
       Optional<OpenTelemetry> openTelemetry,


### PR DESCRIPTION
This will mean that customers can only access/create cache objects from Momento.