### PR TITLE
feat: createOrGet -> getOrCreate

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoTest.java
@@ -53,7 +53,7 @@ final class MomentoTest {
   @Test
   void recreatingCacheWithSameName_throwsAlreadyExists() {
     Momento momento = Momento.builder(authToken).build();
-    momento.createOrGetCache(cacheName);
+    momento.getOrCreateCache(cacheName);
     assertThrows(CacheAlreadyExistsException.class, () -> momento.createCache(cacheName));
   }
 
@@ -63,7 +63,7 @@ final class MomentoTest {
         Momento.builder(authToken).endpointOverride(DEFAULT_MOMENTO_HOSTED_ZONE_ENDPOINT).build();
 
     assertThrows(InvalidArgumentException.class, () -> momento.createCache("     "));
-    assertThrows(InvalidArgumentException.class, () -> momento.createOrGetCache("     "));
+    assertThrows(InvalidArgumentException.class, () -> momento.getOrCreateCache("     "));
   }
 
   @Test
@@ -90,7 +90,7 @@ final class MomentoTest {
   }
 
   private static void runHappyPathTest(Momento momento, String cacheName) {
-    Cache cache = momento.createOrGetCache(cacheName);
+    Cache cache = momento.getOrCreateCache(cacheName);
 
     String key = java.util.UUID.randomUUID().toString();
 

--- a/momento-sdk/src/main/java/momento/sdk/Momento.java
+++ b/momento-sdk/src/main/java/momento/sdk/Momento.java
@@ -107,7 +107,8 @@ public final class Momento implements Closeable {
    * @return {@link Cache} client to perform operations against the Momento Cache with the provided
    *     name.
    */
-  public Cache createOrGetCache(String cacheName) {
+  public Cache getOrCreateCache(String cacheName) {
+    // TODO: Switch this to do a get first followed by Create
     checkCacheNameValid(cacheName);
     try {
       createCache(cacheName);


### PR DESCRIPTION
implementation does a create followed by Get.This should be updated once metadata sync is sorted out. Then this will be implemented as
```
try {
    return getCache(cacheName);
} catch (CacheNotFoundException e) {
    createCache(cacheName);
    return getCache(cacheName);
}
```