### PR TITLE
chore: switch grpc-netty to grpc-netty-shaded

### DIFF
--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-api:$opentelemetryVersion")
     implementation("io.opentelemetry:opentelemetry-sdk:$opentelemetryVersion")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:$opentelemetryVersion")
-    implementation("io.grpc:grpc-netty:${rootProject.ext["grpcVersion"]}")
+    implementation("io.grpc:grpc-netty-shaded:${rootProject.ext["grpcVersion"]}")
 
     // For Auth token
     implementation("io.jsonwebtoken:jjwt-api:$jwtVersion")

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -4,7 +4,7 @@ import grpc.control_client.ScsControlGrpc;
 import io.grpc.ClientInterceptor;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -4,7 +4,7 @@ import grpc.cache_client.ScsGrpc;
 import io.grpc.ClientInterceptor;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.Closeable;
 import java.time.Duration;


### PR DESCRIPTION
There are many other libraries and frameworks out there that use Netty.
Users will continually run into version conflicts if we pin their
dependency closure to a particular Netty, and we will reduce our ability
to update our own sdk's netty version (because of knowing that users
depend on our netty version). So instead, let's consume the shaded
version [as recommended](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#tls-on-non-android)

We may yet need to do something else but this is closer to the blessed
path.
