### PR TITLE
chore: upgrade antique dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
-ext["grpcVersion"] = "1.39.0"
-ext["protobufVersion"] = "3.17.3"
+ext["grpcVersion"] = "1.47.0"
+ext["protobufVersion"] = "3.21.2"
 ext["opentelemetryVersion"] = "1.4.1"
 ext["jwtVersion"] = "0.11.2"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
There are some material changes in io.grpc netty methods that don't
work well with the older versions in here. No reason not to use the
newer versions we've tested on the service.

Integration tests pass locally against a momento endpoint.