### PR TITLE
chore: add shared build step in ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -27,6 +25,12 @@ jobs:
       with:
         java-version: 16
         distribution: 'adopt'
+
+    - name: Commitlint and Other Shared Build Steps
+      uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
identical pr to https://github.com/momentohq/client-sdk-javascript/pull/100

ensures that every commit shows up in the release