### PR TITLE
chore: fix otel dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 ext["grpcVersion"] = "1.47.0"
 ext["protobufVersion"] = "3.21.2"
-ext["opentelemetryVersion"] = "1.4.1"
+ext["opentelemetryVersion"] = "1.5.0"
 ext["jwtVersion"] = "0.11.2"
 
 allprojects {

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -12,10 +12,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testImplementation("commons-io:commons-io:2.11.0")
 
-    platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion")
-    implementation("io.opentelemetry:opentelemetry-api:$opentelemetryVersion")
-    implementation("io.opentelemetry:opentelemetry-sdk:$opentelemetryVersion")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:$opentelemetryVersion")
+    implementation(platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion"))
+    implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.grpc:grpc-netty-shaded:${rootProject.ext["grpcVersion"]}")
 
     // For Auth token
@@ -27,6 +25,9 @@ dependencies {
     implementation(project(":messages"))
 
     implementation("org.apache.commons:commons-lang3:3.0")
+
+    testImplementation("io.opentelemetry:opentelemetry-sdk:$opentelemetryVersion")
+    testImplementation("io.opentelemetry:opentelemetry-exporter-otlp:$opentelemetryVersion")
 }
 
 spotless {


### PR DESCRIPTION
we don't depend on anything other than otel apis in our implementation.
we should not have such a wide runtimeDependency closure as to take an
opinion about (e.g.) the exporter
