### PR TITLE
chore: update getCache response

### DIFF
--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -10,6 +10,7 @@ val jwtVersion = rootProject.ext["jwtVersion"]
 
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
+    testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("commons-io:commons-io:2.11.0")
 
     implementation(platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion"))

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
@@ -1,10 +1,10 @@
 package momento.sdk;
 
+import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import momento.sdk.exceptions.AuthenticationException;
 import momento.sdk.exceptions.InternalServerException;
@@ -61,10 +61,10 @@ final class SimpleCacheClientTest extends BaseTestClass {
 
   @Test
   public void createCacheGetSetDeleteValuesAndDeleteCache() {
-    final String cacheName = UUID.randomUUID().toString();
-    final String alternateCacheName = UUID.randomUUID().toString();
-    final String key = UUID.randomUUID().toString();
-    final String value = UUID.randomUUID().toString();
+    final String cacheName = randomString("name");
+    final String alternateCacheName = randomString("alternateName");
+    final String key = randomString("key");
+    final String value = randomString("value");
 
     target.createCache(cacheName);
     target.createCache(alternateCacheName);
@@ -89,10 +89,10 @@ final class SimpleCacheClientTest extends BaseTestClass {
 
   @Test
   public void shouldFlushCacheContents() {
-    String cacheName = UUID.randomUUID().toString();
-    String key = UUID.randomUUID().toString();
-    String value = UUID.randomUUID().toString();
-    long ttl1HourInSeconds = Duration.ofHours(1).getSeconds();
+    final String cacheName = randomString("name");
+    final String key = randomString("key");
+    final String value = randomString("value");
+    final long ttl1HourInSeconds = Duration.ofHours(1).getSeconds();
 
     target.createCache(cacheName);
     try {
@@ -136,22 +136,21 @@ final class SimpleCacheClientTest extends BaseTestClass {
       // Unable to hit control plane
       final InternalServerException e =
           assertThrows(
-              InternalServerException.class,
-              () -> client.createCache(UUID.randomUUID().toString()));
+              InternalServerException.class, () -> client.createCache(randomString("cacheName")));
       assertTrue(e.getMessage().contains("Unable to reach request endpoint."));
 
       // But gets a valid response from Data plane
       final CacheGetResponse getResponse = client.get("helloCache", "key");
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) getResponse).exception())
-          .isInstanceOf(AuthenticationException.class);
+      assertThat(((CacheGetResponse.Error) getResponse))
+          .hasCauseInstanceOf(AuthenticationException.class);
 
       assertThrows(AuthenticationException.class, () -> client.set("helloCache", "key", "value"));
 
       final CacheGetResponse asyncGetResponse = client.getAsync("helloCache", "key").join();
       assertThat(asyncGetResponse).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) asyncGetResponse).exception())
-          .isInstanceOf(AuthenticationException.class);
+      assertThat(((CacheGetResponse.Error) asyncGetResponse))
+          .hasCauseInstanceOf(AuthenticationException.class);
 
       final ExecutionException setException =
           assertThrows(
@@ -167,20 +166,20 @@ final class SimpleCacheClientTest extends BaseTestClass {
 
       // Can reach control plane.
       assertThrows(
-          AuthenticationException.class, () -> client.createCache(UUID.randomUUID().toString()));
+          AuthenticationException.class, () -> client.createCache(randomString("cacheName")));
 
       // Unable to reach data plane
       final CacheGetResponse getResponse = client.get("helloCache", "key");
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) getResponse).exception())
-          .isInstanceOf(InternalServerException.class);
+      assertThat(((CacheGetResponse.Error) getResponse))
+          .hasCauseInstanceOf(InternalServerException.class);
 
       assertThrows(InternalServerException.class, () -> client.set("helloCache", "key", "value"));
 
       final CacheGetResponse response = client.getAsync("helloCache", "key").join();
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(InternalServerException.class)
+      assertThat(((CacheGetResponse.Error) response))
+          .hasCauseInstanceOf(InternalServerException.class)
           .hasMessageContaining("Unable to reach request endpoint.");
 
       final ExecutionException setException =

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
@@ -73,7 +73,7 @@ final class SimpleCacheClientTest extends BaseTestClass {
 
       final CacheGetResponse getResponse = target.get(cacheName, key);
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Hit.class);
-      assertThat(((CacheGetResponse.Hit) getResponse).string()).isEqualTo(value);
+      assertThat(((CacheGetResponse.Hit) getResponse).valueString()).isEqualTo(value);
 
       target.delete(cacheName, key);
       final CacheGetResponse getAfterDeleteResponse = target.get(cacheName, key);
@@ -99,7 +99,7 @@ final class SimpleCacheClientTest extends BaseTestClass {
       target.set(cacheName, key, value, ttl1HourInSeconds);
       final CacheGetResponse getResponse = target.get(cacheName, key);
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Hit.class);
-      assertThat(((CacheGetResponse.Hit) getResponse).string()).isEqualTo(value);
+      assertThat(((CacheGetResponse.Hit) getResponse).valueString()).isEqualTo(value);
 
       // Execute Flush
       target.flushCache(cacheName);

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneAsyncTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneAsyncTest.java
@@ -160,7 +160,7 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
       client.setAsync(cacheName, emptyKey, emptyValue).get();
       final CacheGetResponse response = client.getAsync(cacheName, emptyKey).get();
       assertThat(response).isInstanceOf(CacheGetResponse.Hit.class);
-      assertThat(((CacheGetResponse.Hit) response).string()).isEqualTo(emptyValue);
+      assertThat(((CacheGetResponse.Hit) response).valueString()).isEqualTo(emptyValue);
     }
   }
 
@@ -173,7 +173,7 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
       client.setAsync(cacheName, key, value).get();
       final CacheGetResponse getResponse = client.getAsync(cacheName, key).get();
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Hit.class);
-      assertThat(((CacheGetResponse.Hit) getResponse).string()).isEqualTo(value);
+      assertThat(((CacheGetResponse.Hit) getResponse).valueString()).isEqualTo(value);
       client.deleteAsync(cacheName, key).get();
       final CacheGetResponse getAfterDeleteResponse = client.getAsync(cacheName, key).get();
       assertThat(getAfterDeleteResponse).isInstanceOf(CacheGetResponse.Miss.class);
@@ -204,7 +204,7 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
     // Successful Get with Hit
     final CacheGetResponse getResponse = target.getAsync(cacheName, key).get();
     assertThat(getResponse).isInstanceOf(CacheGetResponse.Hit.class);
-    assertThat(((CacheGetResponse.Hit) getResponse).string()).isEqualTo(value);
+    assertThat(((CacheGetResponse.Hit) getResponse).valueString()).isEqualTo(value);
   }
 
   private void runTtlTest(SimpleCacheClient target) throws Exception {

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneAsyncTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneAsyncTest.java
@@ -6,6 +6,7 @@ import static momento.sdk.OtelTestHelpers.stopIntegrationTestOtel;
 import static momento.sdk.OtelTestHelpers.verifyGetTrace;
 import static momento.sdk.OtelTestHelpers.verifySetTrace;
 import static momento.sdk.ScsDataTestHelper.assertSetResponse;
+import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import momento.sdk.exceptions.AuthenticationException;
@@ -114,8 +114,8 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
 
       final CacheGetResponse response = client.getAsync(cacheName, "").join();
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(AuthenticationException.class);
+      assertThat(((CacheGetResponse.Error) response))
+          .hasCauseInstanceOf(AuthenticationException.class);
     }
   }
 
@@ -123,12 +123,11 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
   public void nonExistentCacheNameReturnsErrorOnGetOrSet() {
     try (final SimpleCacheClient client =
         SimpleCacheClient.builder(authToken, DEFAULT_ITEM_TTL_SECONDS).build()) {
-      final String cacheName = UUID.randomUUID().toString();
+      final String cacheName = randomString("name");
 
       final CacheGetResponse response = client.getAsync(cacheName, "").join();
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(NotFoundException.class);
+      assertThat(((CacheGetResponse.Error) response)).hasCauseInstanceOf(NotFoundException.class);
 
       ExecutionException getException =
           assertThrows(
@@ -146,8 +145,7 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
 
       final CacheGetResponse response = client.getAsync("cache", "key").join();
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(TimeoutException.class);
+      assertThat(((CacheGetResponse.Error) response)).hasCauseInstanceOf(TimeoutException.class);
     }
   }
 
@@ -194,8 +192,8 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
   }
 
   private void runSetAndGetWithHitTest(SimpleCacheClient target) throws Exception {
-    final String key = UUID.randomUUID().toString();
-    final String value = UUID.randomUUID().toString();
+    final String key = randomString("key");
+    final String value = randomString("value");
 
     // Successful Set
     final CompletableFuture<CacheSetResponse> setResponse = target.setAsync(cacheName, key, value);
@@ -208,7 +206,7 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
   }
 
   private void runTtlTest(SimpleCacheClient target) throws Exception {
-    final String key = UUID.randomUUID().toString();
+    final String key = randomString("key");
 
     // Set Key sync
     target.setAsync(cacheName, key, "", 1);
@@ -222,8 +220,7 @@ final class SimpleCacheDataPlaneAsyncTest extends BaseTestClass {
 
   private void runMissTest(SimpleCacheClient target) throws Exception {
     // Get key that was not set
-    final CacheGetResponse response =
-        target.getAsync(cacheName, UUID.randomUUID().toString()).get();
+    final CacheGetResponse response = target.getAsync(cacheName, randomString("key")).get();
     assertThat(response).isInstanceOf(CacheGetResponse.Miss.class);
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneBlockingTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneBlockingTest.java
@@ -142,7 +142,7 @@ final class SimpleCacheDataPlaneBlockingTest extends BaseTestClass {
 
       final CacheGetResponse getResponse = cache.get(cacheName, key);
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Hit.class);
-      assertThat(((CacheGetResponse.Hit) getResponse).byteArray()).isEqualTo(value);
+      assertThat(((CacheGetResponse.Hit) getResponse).valueByteArray()).isEqualTo(value);
 
       cache.delete(cacheName, key);
       final CacheGetResponse getAfterDeleteResponse = cache.get(cacheName, key);
@@ -182,7 +182,7 @@ final class SimpleCacheDataPlaneBlockingTest extends BaseTestClass {
       client.set(cacheName, emptyKey, emptyValue);
       final CacheGetResponse response = client.get(cacheName, emptyKey);
       assertThat(response).isInstanceOf(CacheGetResponse.Hit.class);
-      assertThat(((CacheGetResponse.Hit) response).string()).isEqualTo(emptyValue);
+      assertThat(((CacheGetResponse.Hit) response).valueString()).isEqualTo(emptyValue);
     }
   }
 
@@ -197,7 +197,7 @@ final class SimpleCacheDataPlaneBlockingTest extends BaseTestClass {
     // Successful Get with Hit
     final CacheGetResponse getResponse = target.get(cacheName, key);
     assertThat(getResponse).isInstanceOf(CacheGetResponse.Hit.class);
-    assertThat(((CacheGetResponse.Hit) getResponse).string()).isEqualTo(value);
+    assertThat(((CacheGetResponse.Hit) getResponse).valueString()).isEqualTo(value);
   }
 
   private void runTtlTest(SimpleCacheClient target) throws Exception {

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneBlockingTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneBlockingTest.java
@@ -112,8 +112,8 @@ final class SimpleCacheDataPlaneBlockingTest extends BaseTestClass {
 
       final CacheGetResponse response = client.get(cacheName, "");
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(AuthenticationException.class);
+      assertThat(((CacheGetResponse.Error) response))
+          .hasCauseInstanceOf(AuthenticationException.class);
     }
   }
 
@@ -125,8 +125,7 @@ final class SimpleCacheDataPlaneBlockingTest extends BaseTestClass {
 
       final CacheGetResponse response = client.get(cacheName, "");
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(NotFoundException.class);
+      assertThat(((CacheGetResponse.Error) response)).hasCauseInstanceOf(NotFoundException.class);
 
       assertThrows(NotFoundException.class, () -> client.set(cacheName, "", "", 10));
     }
@@ -158,8 +157,7 @@ final class SimpleCacheDataPlaneBlockingTest extends BaseTestClass {
             .build()) {
       final CacheGetResponse response = client.get("cache", "key");
       assertThat(response).isInstanceOf(CacheGetResponse.Error.class);
-      assertThat(((CacheGetResponse.Error) response).exception())
-          .isInstanceOf(TimeoutException.class);
+      assertThat(((CacheGetResponse.Error) response)).hasCauseInstanceOf(TimeoutException.class);
     }
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/TestUtils.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/TestUtils.java
@@ -1,0 +1,10 @@
+package momento.sdk;
+
+import java.util.UUID;
+
+public class TestUtils {
+
+  public static String randomString(String prefix) {
+    return prefix + "-" + UUID.randomUUID();
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/SimpleCacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/SimpleCacheClient.java
@@ -10,7 +10,16 @@ import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.exceptions.BadRequestException;
 import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.NotFoundException;
-import momento.sdk.messages.*;
+import momento.sdk.messages.CacheDeleteResponse;
+import momento.sdk.messages.CacheGetResponse;
+import momento.sdk.messages.CacheSetResponse;
+import momento.sdk.messages.CreateCacheResponse;
+import momento.sdk.messages.CreateSigningKeyResponse;
+import momento.sdk.messages.DeleteCacheResponse;
+import momento.sdk.messages.FlushCacheResponse;
+import momento.sdk.messages.ListCachesResponse;
+import momento.sdk.messages.ListSigningKeysResponse;
+import momento.sdk.messages.RevokeSigningKeyResponse;
 
 /** Client to perform operations against the Simple Cache Service */
 public final class SimpleCacheClient implements Closeable {

--- a/momento-sdk/src/main/java/momento/sdk/SimpleCacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/SimpleCacheClient.java
@@ -10,16 +10,7 @@ import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.exceptions.BadRequestException;
 import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.NotFoundException;
-import momento.sdk.messages.CacheDeleteResponse;
-import momento.sdk.messages.CacheGetResponse;
-import momento.sdk.messages.CacheSetResponse;
-import momento.sdk.messages.CreateCacheResponse;
-import momento.sdk.messages.CreateSigningKeyResponse;
-import momento.sdk.messages.DeleteCacheResponse;
-import momento.sdk.messages.FlushCacheResponse;
-import momento.sdk.messages.ListCachesResponse;
-import momento.sdk.messages.ListSigningKeysResponse;
-import momento.sdk.messages.RevokeSigningKeyResponse;
+import momento.sdk.messages.*;
 
 /** Client to perform operations against the Simple Cache Service */
 public final class SimpleCacheClient implements Closeable {
@@ -168,10 +159,6 @@ public final class SimpleCacheClient implements Closeable {
    * @param key The key to get
    * @return {@link CacheGetResponse} containing the status of the get operation and the associated
    *     value data.
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws ClientSdkException if key is null
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
    */
   public CacheGetResponse get(String cacheName, String key) {
     return scsDataClient.get(cacheName, key);
@@ -184,10 +171,6 @@ public final class SimpleCacheClient implements Closeable {
    * @param key The key to get
    * @return {@link CacheGetResponse} containing the status of the get operation and the associated
    *     value data.
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws ClientSdkException if key is null
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
    */
   public CacheGetResponse get(String cacheName, byte[] key) {
     return scsDataClient.get(cacheName, key);
@@ -349,10 +332,6 @@ public final class SimpleCacheClient implements Closeable {
    * @param key The key to get
    * @return Future with {@link CacheGetResponse} containing the status of the get operation and the
    *     associated value data.
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws ClientSdkException if key is null
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
    */
   public CompletableFuture<CacheGetResponse> getAsync(String cacheName, byte[] key) {
     return scsDataClient.getAsync(cacheName, key);
@@ -365,10 +344,6 @@ public final class SimpleCacheClient implements Closeable {
    * @param key The key to get
    * @return Future with {@link CacheGetResponse} containing the status of the get operation and the
    *     associated value data.
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws ClientSdkException if key is null
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
    */
   public CompletableFuture<CacheGetResponse> getAsync(String cacheName, String key) {
     return scsDataClient.getAsync(cacheName, key);
@@ -400,8 +375,8 @@ public final class SimpleCacheClient implements Closeable {
    * @throws NotFoundException
    * @throws momento.sdk.exceptions.InternalServerException
    */
-  public CompletableFuture<CacheGetResponse> deleteAsync(String cacheName, byte[] key) {
-    return scsDataClient.getAsync(cacheName, key);
+  public CompletableFuture<CacheDeleteResponse> deleteAsync(String cacheName, byte[] key) {
+    return scsDataClient.deleteAsync(cacheName, key);
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -8,9 +8,9 @@ import java.nio.charset.StandardCharsets;
 import momento.sdk.exceptions.SdkException;
 
 /** Response for a cache get operation */
-public abstract class CacheGetResponse {
+public interface CacheGetResponse {
 
-  public static class Hit extends CacheGetResponse {
+  class Hit implements CacheGetResponse {
     private final ByteString value;
 
     public Hit(ByteString value) {
@@ -64,17 +64,12 @@ public abstract class CacheGetResponse {
     }
   }
 
-  public static class Miss extends CacheGetResponse {}
+  class Miss implements CacheGetResponse {}
 
-  public static class Error extends CacheGetResponse {
-    private final SdkException exception;
+  class Error extends SdkException implements CacheGetResponse {
 
-    public Error(SdkException exception) {
-      this.exception = exception;
-    }
-
-    public SdkException exception() {
-      return this.exception;
+    public Error(SdkException cause) {
+      super(cause.getMessage(), cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -11,56 +11,56 @@ import momento.sdk.exceptions.SdkException;
 public abstract class CacheGetResponse {
 
   public static class Hit extends CacheGetResponse {
-    private final ByteString body;
+    private final ByteString value;
 
-    public Hit(ByteString body) {
-      this.body = body;
+    public Hit(ByteString value) {
+      this.value = value;
     }
 
     /**
-     * Value stored in the cache as a byte array.
+     * Gets the retrieved value as a byte array.
      *
-     * @return Value stored for the given key.
+     * @return the value.
      */
-    public byte[] byteArray() {
-      return body.toByteArray();
+    public byte[] valueByteArray() {
+      return value.toByteArray();
     }
 
     /**
-     * Value stored in the cache as a {@link ByteBuffer}.
+     * Gets the retrieved value as a {@link ByteBuffer}.
      *
-     * @return Value stored for the given key.
+     * @return the value.
      */
-    public ByteBuffer byteBuffer() {
-      return body.asReadOnlyByteBuffer();
+    public ByteBuffer valueByteBuffer() {
+      return value.asReadOnlyByteBuffer();
     }
 
     /**
-     * Value stored in the cache as a UTF-8 {@link String}
+     * Gets the retrieved value as a UTF-8 {@link String}
      *
-     * @return Value stored for the given key.
+     * @return the value.
      */
-    public String string() {
-      return string(StandardCharsets.UTF_8);
+    public String valueString() {
+      return valueString(StandardCharsets.UTF_8);
     }
 
     /**
-     * Value stored in the cache as {@link String}.
+     * Gets the retrieved value as a {@link String}.
      *
-     * @param charset to express the bytes as String.
-     * @return Value stored for the given key.
+     * @param charset the string encoding to use.
+     * @return the value.
      */
-    public String string(Charset charset) {
-      return body.toString(charset);
+    public String valueString(Charset charset) {
+      return value.toString(charset);
     }
 
     /**
-     * Value as an {@link InputStream}
+     * Gets the retrieved value as an {@link InputStream}.
      *
-     * @return Value stored for the given key.
+     * @return the value.
      */
-    public InputStream inputStream() {
-      return body.newInput();
+    public InputStream valueInputStream() {
+      return value.newInput();
     }
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -1,109 +1,80 @@
 package momento.sdk.messages;
 
 import com.google.protobuf.ByteString;
-import grpc.cache_client.ECacheResult;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
-import momento.sdk.exceptions.InternalServerException;
+import momento.sdk.exceptions.SdkException;
 
 /** Response for a cache get operation */
-public final class CacheGetResponse {
-  private final ByteString body;
-  private final CacheGetStatus status;
+public abstract class CacheGetResponse {
 
-  public CacheGetResponse(ECacheResult status, ByteString body) {
-    this.body = body;
-    this.status = convert(status);
-  }
+  public static class Hit extends CacheGetResponse {
+    private final ByteString body;
 
-  /**
-   * Determine the result of the Get operation.
-   *
-   * <p>Valid values are {@link CacheGetStatus#HIT} and {@link CacheGetStatus#MISS}.
-   *
-   * @return The result of Cache Get Operation
-   */
-  public CacheGetStatus status() {
-    return status;
-  }
-
-  /**
-   * Value stored in the cache as a byte array.
-   *
-   * @return Value stored for the given key. {@link Optional#empty()} if the lookup resulted in a
-   *     cache miss.
-   */
-  public Optional<byte[]> byteArray() {
-    if (status != CacheGetStatus.HIT) {
-      return Optional.empty();
+    public Hit(ByteString body) {
+      this.body = body;
     }
-    return Optional.ofNullable(body.toByteArray());
-  }
 
-  /**
-   * Value stored in the cache as a {@link ByteBuffer}.
-   *
-   * @return Value stored for the given key. {@link Optional#empty()} if the lookup resulted in a
-   *     cache miss.
-   */
-  public Optional<ByteBuffer> byteBuffer() {
-    if (status != CacheGetStatus.HIT) {
-      return Optional.empty();
+    /**
+     * Value stored in the cache as a byte array.
+     *
+     * @return Value stored for the given key.
+     */
+    public byte[] byteArray() {
+      return body.toByteArray();
     }
-    return Optional.ofNullable(body.asReadOnlyByteBuffer());
-  }
 
-  /**
-   * Value stored in the cache as a UTF-8 {@link String}
-   *
-   * @return Value stored for the given key. {@link Optional#empty()} if the lookup resulted in a
-   *     cache miss.
-   */
-  public Optional<String> string() {
-    return string(StandardCharsets.UTF_8);
-  }
-
-  /**
-   * Value stored in the cache as {@link String}.
-   *
-   * @param charset to express the bytes as String.
-   * @return Value stored for the given key. {@link Optional#empty()} if the lookup resulted in a
-   *     cache miss.
-   */
-  public Optional<String> string(Charset charset) {
-    if (status != CacheGetStatus.HIT) {
-      return Optional.empty();
+    /**
+     * Value stored in the cache as a {@link ByteBuffer}.
+     *
+     * @return Value stored for the given key.
+     */
+    public ByteBuffer byteBuffer() {
+      return body.asReadOnlyByteBuffer();
     }
-    return Optional.ofNullable(body.toString(charset));
-  }
 
-  /**
-   * Value as an {@link InputStream}
-   *
-   * @return Value stored for the given key. {@link Optional#empty()} if the lookup resulted in a
-   *     cache miss.
-   */
-  public Optional<InputStream> inputStream() {
-    if (status != CacheGetStatus.HIT) {
-      return Optional.empty();
+    /**
+     * Value stored in the cache as a UTF-8 {@link String}
+     *
+     * @return Value stored for the given key.
+     */
+    public String string() {
+      return string(StandardCharsets.UTF_8);
     }
-    return Optional.ofNullable(body.newInput());
+
+    /**
+     * Value stored in the cache as {@link String}.
+     *
+     * @param charset to express the bytes as String.
+     * @return Value stored for the given key.
+     */
+    public String string(Charset charset) {
+      return body.toString(charset);
+    }
+
+    /**
+     * Value as an {@link InputStream}
+     *
+     * @return Value stored for the given key.
+     */
+    public InputStream inputStream() {
+      return body.newInput();
+    }
   }
 
-  private static CacheGetStatus convert(ECacheResult result) {
-    switch (result) {
-      case Hit:
-        return CacheGetStatus.HIT;
-      case Miss:
-        return CacheGetStatus.MISS;
-      default:
-        throw new InternalServerException(
-            String.format(
-                "Unexpected exception occurred while trying to fulfill the request. Found unsupported Cache result: %s",
-                result));
+  public static class Miss extends CacheGetResponse {}
+
+  public static class Error extends CacheGetResponse {
+    private final SdkException exception;
+
+    public Error(SdkException exception) {
+      this.exception = exception;
+    }
+
+    public SdkException exception() {
+      return this.exception;
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -1,9 +1,6 @@
 package momento.sdk.messages;
 
 import com.google.protobuf.ByteString;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import momento.sdk.exceptions.SdkException;
 
@@ -27,40 +24,12 @@ public interface CacheGetResponse {
     }
 
     /**
-     * Gets the retrieved value as a {@link ByteBuffer}.
-     *
-     * @return the value.
-     */
-    public ByteBuffer valueByteBuffer() {
-      return value.asReadOnlyByteBuffer();
-    }
-
-    /**
      * Gets the retrieved value as a UTF-8 {@link String}
      *
      * @return the value.
      */
     public String valueString() {
-      return valueString(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Gets the retrieved value as a {@link String}.
-     *
-     * @param charset the string encoding to use.
-     * @return the value.
-     */
-    public String valueString(Charset charset) {
-      return value.toString(charset);
-    }
-
-    /**
-     * Gets the retrieved value as an {@link InputStream}.
-     *
-     * @return the value.
-     */
-    public InputStream valueInputStream() {
-      return value.newInput();
+      return value.toString(StandardCharsets.UTF_8);
     }
   }
 


### PR DESCRIPTION
Update the response returned by the get and getAsync methods to match the pattern we have established in other SDKs. The response has three implementations: Hit, Miss, and Error, and it no longer throws. It is intended to be used with pattern matching.

Change the deleteAsync method to delete instead of getting.

Add a test dependency on AssertJ, a neat fluent assertion library.