### PR TITLE
feat: convert responses to new pattern part deux

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneClientSideTest.java
@@ -12,13 +12,12 @@ import org.junit.jupiter.api.Test;
 final class SimpleCacheDataPlaneClientSideTest extends BaseTestClass {
 
   private static final int DEFAULT_ITEM_TTL_SECONDS = 60;
-  private String authToken;
   private String cacheName;
   private SimpleCacheClient client;
 
   @BeforeEach
   void setup() {
-    authToken = System.getenv("TEST_AUTH_TOKEN");
+    final String authToken = System.getenv("TEST_AUTH_TOKEN");
     cacheName = System.getenv("TEST_CACHE_NAME");
     client = SimpleCacheClient.builder(authToken, DEFAULT_ITEM_TTL_SECONDS).build();
   }

--- a/momento-sdk/src/main/java/momento/sdk/SimpleCacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/SimpleCacheClient.java
@@ -6,8 +6,6 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import momento.sdk.exceptions.ClientSdkException;
-import momento.sdk.exceptions.NotFoundException;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheSetResponse;
@@ -76,22 +74,9 @@ public final class SimpleCacheClient implements Closeable {
     return scsControlClient.flushCache(cacheName);
   }
 
-  /**
-   * Lists all caches for the provided auth token.
-   *
-   * <pre>{@code
-   * Optional<String> nextPageToken = Optional.empty();
-   * do {
-   *     ListCachesResponse response = simpleCacheClient.listCaches(nextPageToken);
-   *
-   *     // Your code here to use the response
-   *
-   *     nextPageToken = response.nextPageToken();
-   * } while(nextPageToken.isPresent());
-   * }</pre>
-   */
-  public ListCachesResponse listCaches(Optional<String> nextToken) {
-    return scsControlClient.listCaches(nextToken);
+  /** Lists all caches. */
+  public ListCachesResponse listCaches() {
+    return scsControlClient.listCaches();
   }
 
   /**
@@ -99,10 +84,6 @@ public final class SimpleCacheClient implements Closeable {
    *
    * @param ttlMinutes The key's time-to-live in minutes
    * @return The created key and its metadata
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
-   * @throws ClientSdkException if the {@code ttlMinutes} is invalid.
    */
   public CreateSigningKeyResponse createSigningKey(int ttlMinutes) {
     return scsControlClient.createSigningKey(ttlMinutes, scsDataClient.getEndpoint());
@@ -112,38 +93,18 @@ public final class SimpleCacheClient implements Closeable {
    * Revokes a Momento signing key, all tokens signed by which will be invalid
    *
    * @param keyId The id of the key to revoke
-   * @return
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
-   * @throws ClientSdkException if the {@code keyId} is null.
    */
   public RevokeSigningKeyResponse revokeSigningKey(String keyId) {
     return scsControlClient.revokeSigningKey(keyId);
   }
 
   /**
-   * Lists all Momento signing keys for the provided auth token.
+   * Lists all Momento signing keys.
    *
-   * <pre>{@code
-   * Optional<String> nextToken = Optional.empty();
-   * do {
-   *    ListSigningKeysResponse response = simpleCacheClient.listSigningKeys(nextToken);
-   *
-   *    // Your code here to use the response
-   *
-   *    nextToken = response.nextToken();
-   * } while (nextToken.isPresent());
-   * }</pre>
-   *
-   * @param nextToken Optional pagination token
    * @return A list of Momento signing keys along with a pagination token (if present)
-   * @throws momento.sdk.exceptions.PermissionDeniedException
-   * @throws NotFoundException
-   * @throws momento.sdk.exceptions.InternalServerException
    */
-  public ListSigningKeysResponse listSigningKeys(Optional<String> nextToken) {
-    return scsControlClient.listSigningKeys(nextToken, scsDataClient.getEndpoint());
+  public ListSigningKeysResponse listSigningKeys() {
+    return scsControlClient.listSigningKeys(scsDataClient.getEndpoint());
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CreateSigningKeyResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CreateSigningKeyResponse.java
@@ -1,33 +1,52 @@
 package momento.sdk.messages;
 
 import java.util.Date;
+import momento.sdk.exceptions.SdkException;
 
-public class CreateSigningKeyResponse {
-  public CreateSigningKeyResponse(String keyId, String endpoint, String key, Date expiresAt) {
-    this.keyId = keyId;
-    this.endpoint = endpoint;
-    this.key = key;
-    this.expiresAt = expiresAt;
+/** Response for a create signing key operation */
+public interface CreateSigningKeyResponse {
+
+  /** A successful create signing key operation. Contains the new signing key and metadata. */
+  class Success implements CreateSigningKeyResponse {
+
+    private final String keyId;
+    private final String endpoint;
+    private final String key;
+    private final Date expiresAt;
+
+    public Success(String keyId, String endpoint, String key, Date expiresAt) {
+      this.keyId = keyId;
+      this.endpoint = endpoint;
+      this.key = key;
+      this.expiresAt = expiresAt;
+    }
+
+    public String getKeyId() {
+      return keyId;
+    }
+
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public Date getExpiresAt() {
+      return expiresAt;
+    }
   }
 
-  public String getKeyId() {
-    return keyId;
-  }
+  /**
+   * A failed signing key creation operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements CreateSigningKeyResponse {
 
-  public String getEndpoint() {
-    return endpoint;
+    public Error(SdkException cause) {
+      super(cause.getMessage(), cause);
+    }
   }
-
-  public String getKey() {
-    return key;
-  }
-
-  public Date getExpiresAt() {
-    return expiresAt;
-  }
-
-  private final String keyId;
-  private final String endpoint;
-  private final String key;
-  private final Date expiresAt;
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/ListCachesResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/ListCachesResponse.java
@@ -1,34 +1,33 @@
 package momento.sdk.messages;
 
 import java.util.List;
-import java.util.Optional;
-import momento.sdk.SimpleCacheClient;
+import momento.sdk.exceptions.SdkException;
 
-/** Response object for list of caches. */
-public final class ListCachesResponse {
+/** Response for a list caches operation. */
+public interface ListCachesResponse {
 
-  private final List<CacheInfo> caches;
-  private final Optional<String> nextPageToken;
+  /** A successful list caches operation. Contains the discovered caches. */
+  class Success implements ListCachesResponse {
+    private final List<CacheInfo> caches;
 
-  public ListCachesResponse(List<CacheInfo> caches, Optional<String> nextPageToken) {
-    this.caches = caches;
-    this.nextPageToken = nextPageToken;
-  }
+    public Success(List<CacheInfo> caches) {
+      this.caches = caches;
+    }
 
-  public List<CacheInfo> caches() {
-    return caches;
+    public List<CacheInfo> getCaches() {
+      return caches;
+    }
   }
 
   /**
-   * Next Page Token returned by Simple Cache Service along with the list of caches.
-   *
-   * <p>If nextPageToken().isPresent(), then this token must be provided in the next call to
-   * continue paginating through the list. This is done by setting the value in {@link
-   * SimpleCacheClient#listCaches(Optional)}
-   *
-   * <p>When not present, there are no more caches to return.
+   * A failed list caches operation. The response itself is an exception, so it can be directly
+   * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
+   * copy of the message of the cause.
    */
-  public Optional<String> nextPageToken() {
-    return nextPageToken;
+  class Error extends SdkException implements ListCachesResponse {
+
+    public Error(SdkException cause) {
+      super(cause.getMessage(), cause);
+    }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/ListSigningKeysResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/ListSigningKeysResponse.java
@@ -1,34 +1,34 @@
 package momento.sdk.messages;
 
 import java.util.List;
-import java.util.Optional;
-import momento.sdk.SimpleCacheClient;
+import momento.sdk.exceptions.SdkException;
 
-/** Response object for list of signing keys. */
-public final class ListSigningKeysResponse {
+/** Response for a list signing keys operation. */
+public interface ListSigningKeysResponse {
 
-  private final List<SigningKey> signingKeys;
-  private final Optional<String> nextPageToken;
+  /** A successful list signing keys operation. Contains the discovered signing keys. */
+  class Success implements ListSigningKeysResponse {
 
-  public ListSigningKeysResponse(List<SigningKey> signingKeys, Optional<String> nextPageToken) {
-    this.signingKeys = signingKeys;
-    this.nextPageToken = nextPageToken;
-  }
+    private final List<SigningKey> signingKeys;
 
-  public List<SigningKey> signingKeys() {
-    return signingKeys;
+    public Success(List<SigningKey> signingKeys) {
+      this.signingKeys = signingKeys;
+    }
+
+    public List<SigningKey> signingKeys() {
+      return signingKeys;
+    }
   }
 
   /**
-   * Next Page Token returned by Simple Cache Service along with the list of signing keys.
-   *
-   * <p>If nextPageToken().isPresent(), then this token must be provided in the next call to
-   * continue paginating through the list. This is done by setting the value in {@link
-   * SimpleCacheClient#listSigningKeys(Optional)}
-   *
-   * <p>When not present, there are no more signingKeys to return.
+   * A failed list signing keys operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
    */
-  public Optional<String> nextPageToken() {
-    return nextPageToken;
+  class Error extends SdkException implements ListSigningKeysResponse {
+
+    public Error(SdkException cause) {
+      super(cause.getMessage(), cause);
+    }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/RevokeSigningKeyResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/RevokeSigningKeyResponse.java
@@ -1,3 +1,22 @@
 package momento.sdk.messages;
 
-public final class RevokeSigningKeyResponse {}
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a revoke signing key operation. */
+public interface RevokeSigningKeyResponse {
+
+  /** A successful revoke signing key operation. */
+  class Success implements RevokeSigningKeyResponse {}
+
+  /**
+   * A failed revoke signing key operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements RevokeSigningKeyResponse {
+
+    public Error(SdkException cause) {
+      super(cause.getMessage(), cause);
+    }
+  }
+}


### PR DESCRIPTION
Convert CreateSigningKeyResponse, ListCachesResponse ListSigningKeysResponse, and RevokeSigningKeyResponse.

Remove page tokens from list caches and list signing keys, following the precedent set in the other SDKs.