### PR TITLE
feat: update error handling

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
@@ -2,7 +2,7 @@ package momento.sdk;
 
 import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import momento.sdk.exceptions.AuthenticationException;
@@ -135,9 +135,8 @@ final class SimpleCacheClientTest extends BaseTestClass {
   @Test
   public void throwsExceptionWhenClientUsesNegativeDefaultTtl() {
     //noinspection resource
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> SimpleCacheClient.builder(System.getenv("TEST_AUTH_TOKEN"), -1).build());
+    assertThatExceptionOfType(InvalidArgumentException.class)
+        .isThrownBy(() -> SimpleCacheClient.builder(System.getenv("TEST_AUTH_TOKEN"), -1).build());
   }
 
   @Test
@@ -155,7 +154,9 @@ final class SimpleCacheClientTest extends BaseTestClass {
       final CacheGetResponse getResponse = client.get("helloCache", "key").join();
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Error.class);
       assertThat(((CacheGetResponse.Error) getResponse))
-          .hasCauseInstanceOf(AuthenticationException.class);
+          .hasCauseInstanceOf(AuthenticationException.class)
+          .extracting(e -> e.getTransportErrorDetails().orElse(null))
+          .isNotNull();
 
       final CacheSetResponse setResponse = client.set("helloCache", "key", "value").join();
       assertThat(setResponse).isInstanceOf(CacheSetResponse.Error.class);

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheClientTest.java
@@ -6,9 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import momento.sdk.exceptions.AuthenticationException;
-import momento.sdk.exceptions.InternalServerException;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.exceptions.NotFoundException;
+import momento.sdk.exceptions.ServerUnavailableException;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheSetResponse;
@@ -147,8 +147,8 @@ final class SimpleCacheClientTest extends BaseTestClass {
       final CreateCacheResponse createResponse = client.createCache(randomString("cacheName"));
       assertThat(createResponse).isInstanceOf(CreateCacheResponse.Error.class);
       assertThat(((CreateCacheResponse.Error) createResponse))
-          .hasCauseInstanceOf(InternalServerException.class)
-          .hasMessageContaining("Unable to reach request endpoint.");
+          .hasCauseInstanceOf(ServerUnavailableException.class)
+          .hasMessageContaining("server was unable to handle the request");
 
       // But gets a valid response from Data plane
       final CacheGetResponse getResponse = client.get("helloCache", "key").join();
@@ -180,14 +180,14 @@ final class SimpleCacheClientTest extends BaseTestClass {
       final CacheSetResponse setResponse = client.set("helloCache", "key", "value").join();
       assertThat(setResponse).isInstanceOf(CacheSetResponse.Error.class);
       assertThat(((CacheSetResponse.Error) setResponse))
-          .hasCauseInstanceOf(InternalServerException.class)
-          .hasMessageContaining("Unable to reach request endpoint.");
+          .hasCauseInstanceOf(ServerUnavailableException.class)
+          .hasMessageContaining("server was unable to handle the request");
 
       final CacheGetResponse getResponse = client.get("helloCache", "key").join();
       assertThat(getResponse).isInstanceOf(CacheGetResponse.Error.class);
       assertThat(((CacheGetResponse.Error) getResponse))
-          .hasCauseInstanceOf(InternalServerException.class)
-          .hasMessageContaining("Unable to reach request endpoint.");
+          .hasCauseInstanceOf(ServerUnavailableException.class)
+          .hasMessageContaining("server was unable to handle the request");
     }
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheControlPlaneTest.java
@@ -2,7 +2,7 @@ package momento.sdk;
 
 import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import momento.sdk.exceptions.AlreadyExistsException;
@@ -158,29 +158,34 @@ final class SimpleCacheControlPlaneTest extends BaseTestClass {
 
   @Test
   public void throwsInvalidArgumentForZeroRequestTimeout() {
-    assertThrows(
-        InvalidArgumentException.class,
-        () ->
-            SimpleCacheClient.builder(authToken, DEFAULT_TTL_SECONDS)
-                .requestTimeout(Duration.ofMillis(0))
-                .build());
+    //noinspection resource
+    assertThatExceptionOfType(InvalidArgumentException.class)
+        .isThrownBy(
+            () ->
+                SimpleCacheClient.builder(authToken, DEFAULT_TTL_SECONDS)
+                    .requestTimeout(Duration.ofMillis(0))
+                    .build());
   }
 
   @Test
   public void throwsInvalidArgumentForNegativeRequestTimeout() {
-    assertThrows(
-        InvalidArgumentException.class,
-        () ->
-            SimpleCacheClient.builder(authToken, DEFAULT_TTL_SECONDS)
-                .requestTimeout(Duration.ofMillis(-1))
-                .build());
+    //noinspection resource
+    assertThatExceptionOfType(InvalidArgumentException.class)
+        .isThrownBy(
+            () ->
+                SimpleCacheClient.builder(authToken, DEFAULT_TTL_SECONDS)
+                    .requestTimeout(Duration.ofMillis(-1))
+                    .build());
   }
 
   @Test
   public void throwsInvalidArgumentForNullRequestTimeout() {
-    assertThrows(
-        InvalidArgumentException.class,
-        () ->
-            SimpleCacheClient.builder(authToken, DEFAULT_TTL_SECONDS).requestTimeout(null).build());
+    //noinspection resource
+    assertThatExceptionOfType(InvalidArgumentException.class)
+        .isThrownBy(
+            () ->
+                SimpleCacheClient.builder(authToken, DEFAULT_TTL_SECONDS)
+                    .requestTimeout(null)
+                    .build());
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SimpleCacheDataPlaneClientSideTest.java
@@ -1,9 +1,12 @@
 package momento.sdk;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import momento.sdk.exceptions.InvalidArgumentException;
+import momento.sdk.messages.CacheDeleteResponse;
+import momento.sdk.messages.CacheGetResponse;
+import momento.sdk.messages.CacheSetResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,65 +31,107 @@ final class SimpleCacheDataPlaneClientSideTest extends BaseTestClass {
   }
 
   @Test
-  public void nullKeyGetThrowsException() {
-    String nullKeyString = null;
-    assertThrows(InvalidArgumentException.class, () -> client.get(cacheName, nullKeyString));
+  public void nullKeyGetReturnsError() {
+    final CacheGetResponse stringResponse = client.get(cacheName, (String) null).join();
+    assertThat(stringResponse).isInstanceOf(CacheGetResponse.Error.class);
+    assertThat((CacheGetResponse.Error) stringResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    byte[] nullByteKey = null;
-    assertThrows(InvalidArgumentException.class, () -> client.get(cacheName, nullByteKey));
+    final CacheGetResponse byteResponse = client.get(cacheName, (byte[]) null).join();
+    assertThat(byteResponse).isInstanceOf(CacheGetResponse.Error.class);
+    assertThat((CacheGetResponse.Error) byteResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
   }
 
   @Test
-  public void nullKeyDeleteThrowsException() {
-    String nullKeyString = null;
-    assertThrows(InvalidArgumentException.class, () -> client.delete(cacheName, nullKeyString));
+  public void nullKeyDeleteReturnsError() {
+    final CacheDeleteResponse stringKeyResponse = client.delete(cacheName, (String) null).join();
+    assertThat(stringKeyResponse).isInstanceOf(CacheDeleteResponse.Error.class);
+    assertThat((CacheDeleteResponse.Error) stringKeyResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    byte[] nullByteKey = null;
-    assertThrows(InvalidArgumentException.class, () -> client.delete(cacheName, nullByteKey));
+    final CacheDeleteResponse byteKeyResponse = client.delete(cacheName, (byte[]) null).join();
+    assertThat(byteKeyResponse).isInstanceOf(CacheDeleteResponse.Error.class);
+    assertThat((CacheDeleteResponse.Error) byteKeyResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
   }
 
   @Test
-  public void nullKeySetThrowsException() {
-    String nullKeyString = null;
-    // Async String key set
-    assertThrows(
-        InvalidArgumentException.class, () -> client.set(cacheName, nullKeyString, "hello", 10));
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> client.set(cacheName, nullKeyString, ByteBuffer.allocate(1), 10));
+  public void nullKeySetReturnsError() {
+    final CacheSetResponse stringSetResponse = client.set(cacheName, null, "hello", 10).join();
+    assertThat(stringSetResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) stringSetResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    byte[] nullByteKey = null;
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> client.set(cacheName, nullByteKey, new byte[] {0x00}, 10));
+    final CacheSetResponse byteBufferSetResponse =
+        client.set(cacheName, null, ByteBuffer.allocate(1), 10).join();
+    assertThat(byteBufferSetResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) byteBufferSetResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheSetResponse byteKeySetResponse =
+        client.set(cacheName, null, new byte[] {0x00}, 10).join();
+    assertThat(byteKeySetResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) byteKeySetResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
   }
 
   @Test
-  public void nullValueSetThrowsException() {
-    assertThrows(
-        InvalidArgumentException.class, () -> client.set(cacheName, "hello", (String) null, 10));
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> client.set(cacheName, "hello", (ByteBuffer) null, 10));
-    assertThrows(
-        InvalidArgumentException.class, () -> client.set(cacheName, new byte[] {}, null, 10));
+  public void nullValueSetReturnsError() {
+    final CacheSetResponse stringResponse =
+        client.set(cacheName, "hello", (String) null, 10).join();
+    assertThat(stringResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) stringResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheSetResponse byteBufferResponse =
+        client.set(cacheName, "hello", (ByteBuffer) null, 10).join();
+    assertThat(byteBufferResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) byteBufferResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheSetResponse byteArrayResponse =
+        client.set(cacheName, new byte[] {}, null, 10).join();
+    assertThat(byteArrayResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) byteArrayResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
   }
 
   @Test
-  public void ttlMustNotBeNegativeThrowsException() {
-    assertThrows(InvalidArgumentException.class, () -> client.set(cacheName, "hello", "", -1));
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> client.set(cacheName, "hello", ByteBuffer.allocate(1), -1));
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> client.set(cacheName, new byte[] {}, new byte[] {}, -1));
+  public void ttlMustNotBeNegativeReturnsError() {
+    final CacheSetResponse stringSetResponse = client.set(cacheName, "hello", "", -1).join();
+    assertThat(stringSetResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) stringSetResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheSetResponse byteBufferSetResponse =
+        client.set(cacheName, "hello", ByteBuffer.allocate(1), -1).join();
+    assertThat(byteBufferSetResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) byteBufferSetResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheSetResponse byteArraySetResponse =
+        client.set(cacheName, new byte[] {}, new byte[] {}, -1).join();
+    assertThat(byteArraySetResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) byteArraySetResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
   }
 
   @Test
-  public void nullCacheNameThrowsException() {
-    assertThrows(InvalidArgumentException.class, () -> client.get(null, "").get());
-    assertThrows(InvalidArgumentException.class, () -> client.delete(null, "").get());
-    assertThrows(InvalidArgumentException.class, () -> client.set(null, "", "", 10).get());
+  public void nullCacheNameReturnsError() {
+    final CacheGetResponse getResponse = client.get(null, "").join();
+    assertThat(getResponse).isInstanceOf(CacheGetResponse.Error.class);
+    assertThat((CacheGetResponse.Error) getResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheDeleteResponse deleteResponse = client.delete(null, "").join();
+    assertThat(deleteResponse).isInstanceOf(CacheDeleteResponse.Error.class);
+    assertThat((CacheDeleteResponse.Error) deleteResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
+
+    final CacheSetResponse setResponse = client.set(null, "", "", 10).join();
+    assertThat(setResponse).isInstanceOf(CacheSetResponse.Error.class);
+    assertThat((CacheSetResponse.Error) setResponse)
+        .hasCauseInstanceOf(InvalidArgumentException.class);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
+import momento.sdk.exceptions.MomentoErrorMetadata;
 import momento.sdk.messages.CacheInfo;
 import momento.sdk.messages.CreateCacheResponse;
 import momento.sdk.messages.CreateSigningKeyResponse;
@@ -45,10 +46,13 @@ final class ScsControlClient implements Closeable {
     try {
       checkCacheNameValid(cacheName);
       //noinspection ResultOfMethodCallIgnored
+
       controlGrpcStubsManager.getBlockingStub().createCache(buildCreateCacheRequest(cacheName));
       return new CreateCacheResponse.Success();
     } catch (Exception e) {
-      return new CreateCacheResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new CreateCacheResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 
@@ -59,7 +63,9 @@ final class ScsControlClient implements Closeable {
       controlGrpcStubsManager.getBlockingStub().deleteCache(buildDeleteCacheRequest(cacheName));
       return new DeleteCacheResponse.Success();
     } catch (Exception e) {
-      return new DeleteCacheResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new DeleteCacheResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 
@@ -70,7 +76,9 @@ final class ScsControlClient implements Closeable {
       controlGrpcStubsManager.getBlockingStub().flushCache(buildFlushCacheRequest(cacheName));
       return new FlushCacheResponse.Success();
     } catch (Exception e) {
-      return new FlushCacheResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new FlushCacheResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 
@@ -79,7 +87,9 @@ final class ScsControlClient implements Closeable {
       final _ListCachesRequest request = _ListCachesRequest.newBuilder().setNextToken("").build();
       return convert(controlGrpcStubsManager.getBlockingStub().listCaches(request));
     } catch (Exception e) {
-      return new ListCachesResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new ListCachesResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 
@@ -92,7 +102,9 @@ final class ScsControlClient implements Closeable {
               .createSigningKey(buildCreateSigningKeyRequest(ttlMinutes)),
           endpoint);
     } catch (Exception e) {
-      return new CreateSigningKeyResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new CreateSigningKeyResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 
@@ -104,7 +116,9 @@ final class ScsControlClient implements Closeable {
           .revokeSigningKey(buildRevokeSigningKeyRequest(keyId));
       return new RevokeSigningKeyResponse.Success();
     } catch (Exception e) {
-      return new RevokeSigningKeyResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new RevokeSigningKeyResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 
@@ -114,7 +128,9 @@ final class ScsControlClient implements Closeable {
           _ListSigningKeysRequest.newBuilder().setNextToken("").build();
       return convert(controlGrpcStubsManager.getBlockingStub().listSigningKeys(request), endpoint);
     } catch (Exception e) {
-      return new ListSigningKeysResponse.Error(CacheServiceExceptionMapper.convert(e));
+      return new ListSigningKeysResponse.Error(
+          CacheServiceExceptionMapper.convert(
+              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
     }
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -53,6 +53,11 @@ final class ScsControlGrpcStubsManager implements Closeable {
     return controlBlockingStub.withDeadlineAfter(DEADLINE.getSeconds(), TimeUnit.SECONDS);
   }
 
+  /** Return the length in seconds of the deadline that a newly created stub will have. */
+  public long getDeadlineSeconds() {
+    return DEADLINE.getSeconds();
+  }
+
   @Override
   public void close() {
     channel.shutdown();

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -24,11 +24,11 @@ import io.opentelemetry.context.Scope;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.exceptions.InternalServerException;
+import momento.sdk.exceptions.MomentoErrorMetadata;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheSetResponse;
@@ -69,7 +69,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheGetResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -81,7 +83,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheGetResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -93,7 +97,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheDeleteResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -105,7 +111,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheDeleteResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -118,7 +126,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheSetResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -135,7 +145,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheSetResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -152,7 +164,9 @@ final class ScsDataClient implements Closeable {
       return CompletableFuture.completedFuture(
           new CacheSetResponse.Error(
               CacheServiceExceptionMapper.convert(
-                  e, Collections.singletonMap("cacheName", cacheName))));
+                  e,
+                  new MomentoErrorMetadata(
+                      scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
     }
   }
 
@@ -208,7 +222,7 @@ final class ScsDataClient implements Closeable {
             } else {
               response =
                   new CacheGetResponse.Error(
-                      new InternalServerException("Unsupported cache result " + result));
+                      new InternalServerException("Unsupported cache Get result: " + result));
             }
             returnFuture.complete(response);
             span.ifPresent(
@@ -224,7 +238,9 @@ final class ScsDataClient implements Closeable {
             returnFuture.complete(
                 new CacheGetResponse.Error(
                     CacheServiceExceptionMapper.convert(
-                        e, Collections.singletonMap("cacheName", cacheName))));
+                        e,
+                        new MomentoErrorMetadata(
+                            scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
             span.ifPresent(
                 theSpan -> {
                   theSpan.setStatus(StatusCode.ERROR);
@@ -282,7 +298,9 @@ final class ScsDataClient implements Closeable {
             returnFuture.complete(
                 new CacheDeleteResponse.Error(
                     CacheServiceExceptionMapper.convert(
-                        e, Collections.singletonMap("cacheName", cacheName))));
+                        e,
+                        new MomentoErrorMetadata(
+                            scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
             span.ifPresent(
                 theSpan -> {
                   theSpan.setStatus(StatusCode.ERROR);
@@ -342,7 +360,9 @@ final class ScsDataClient implements Closeable {
             returnFuture.complete(
                 new CacheSetResponse.Error(
                     CacheServiceExceptionMapper.convert(
-                        e, Collections.singletonMap("cacheName", cacheName))));
+                        e,
+                        new MomentoErrorMetadata(
+                            scsDataGrpcStubsManager.getDeadlineSeconds(), cacheName))));
             span.ifPresent(
                 theSpan -> {
                   theSpan.setStatus(StatusCode.ERROR);

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -24,6 +24,7 @@ import io.opentelemetry.context.Scope;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
@@ -61,29 +62,64 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheGetResponse> get(String cacheName, byte[] key) {
-    ensureValidKey(key);
-    return sendGet(cacheName, convert(key));
+    try {
+      ensureValidKey(key);
+      return sendGet(cacheName, convert(key));
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheGetResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheGetResponse> get(String cacheName, String key) {
-    ensureValidKey(key);
-    return sendGet(cacheName, convert(key));
+    try {
+      ensureValidKey(key);
+      return sendGet(cacheName, convert(key));
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheGetResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheDeleteResponse> delete(String cacheName, byte[] key) {
-    ensureValidKey(key);
-    return sendDelete(cacheName, convert(key));
+    try {
+      ensureValidKey(key);
+      return sendDelete(cacheName, convert(key));
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheDeleteResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheDeleteResponse> delete(String cacheName, String key) {
-    ensureValidKey(key);
-    return sendDelete(cacheName, convert(key));
+    try {
+      ensureValidKey(key);
+      return sendDelete(cacheName, convert(key));
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheDeleteResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheSetResponse> set(
       String cacheName, String key, ByteBuffer value, long ttlSeconds) {
-    ensureValidCacheSet(key, value, ttlSeconds);
-    return sendSet(cacheName, convert(key), convert(value), ttlSeconds);
+    try {
+      ensureValidCacheSet(key, value, ttlSeconds);
+      return sendSet(cacheName, convert(key), convert(value), ttlSeconds);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheSetResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheSetResponse> set(String cacheName, String key, ByteBuffer value) {
@@ -92,8 +128,15 @@ final class ScsDataClient implements Closeable {
 
   CompletableFuture<CacheSetResponse> set(
       String cacheName, byte[] key, byte[] value, long ttlSeconds) {
-    ensureValidCacheSet(key, value, ttlSeconds);
-    return sendSet(cacheName, convert(key), convert(value), ttlSeconds);
+    try {
+      ensureValidCacheSet(key, value, ttlSeconds);
+      return sendSet(cacheName, convert(key), convert(value), ttlSeconds);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheSetResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheSetResponse> set(String cacheName, byte[] key, byte[] value) {
@@ -102,8 +145,15 @@ final class ScsDataClient implements Closeable {
 
   CompletableFuture<CacheSetResponse> set(
       String cacheName, String key, String value, long ttlSeconds) {
-    ensureValidCacheSet(key, value, ttlSeconds);
-    return sendSet(cacheName, convert(key), convert(value), ttlSeconds);
+    try {
+      ensureValidCacheSet(key, value, ttlSeconds);
+      return sendSet(cacheName, convert(key), convert(value), ttlSeconds);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheSetResponse.Error(
+              CacheServiceExceptionMapper.convert(
+                  e, Collections.singletonMap("cacheName", cacheName))));
+    }
   }
 
   CompletableFuture<CacheSetResponse> set(String cacheName, String key, String value) {
@@ -172,7 +222,9 @@ final class ScsDataClient implements Closeable {
           @Override
           public void onFailure(Throwable e) {
             returnFuture.complete(
-                new CacheGetResponse.Error(CacheServiceExceptionMapper.convert(e)));
+                new CacheGetResponse.Error(
+                    CacheServiceExceptionMapper.convert(
+                        e, Collections.singletonMap("cacheName", cacheName))));
             span.ifPresent(
                 theSpan -> {
                   theSpan.setStatus(StatusCode.ERROR);
@@ -228,7 +280,9 @@ final class ScsDataClient implements Closeable {
           @Override
           public void onFailure(Throwable e) {
             returnFuture.complete(
-                new CacheDeleteResponse.Error(CacheServiceExceptionMapper.convert(e)));
+                new CacheDeleteResponse.Error(
+                    CacheServiceExceptionMapper.convert(
+                        e, Collections.singletonMap("cacheName", cacheName))));
             span.ifPresent(
                 theSpan -> {
                   theSpan.setStatus(StatusCode.ERROR);
@@ -286,7 +340,9 @@ final class ScsDataClient implements Closeable {
           @Override
           public void onFailure(Throwable e) {
             returnFuture.complete(
-                new CacheSetResponse.Error(CacheServiceExceptionMapper.convert(e)));
+                new CacheSetResponse.Error(
+                    CacheServiceExceptionMapper.convert(
+                        e, Collections.singletonMap("cacheName", cacheName))));
             span.ifPresent(
                 theSpan -> {
                   theSpan.setStatus(StatusCode.ERROR);

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -66,6 +66,11 @@ final class ScsDataGrpcStubsManager implements Closeable {
     return futureStub.withDeadlineAfter(deadline.getSeconds(), TimeUnit.SECONDS);
   }
 
+  /** Return the length in seconds of the deadline that a newly created stub will have. */
+  public long getDeadlineSeconds() {
+    return deadline.getSeconds();
+  }
+
   @Override
   public void close() {
     channel.shutdown();

--- a/momento-sdk/src/main/java/momento/sdk/SimpleCacheClientBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/SimpleCacheClientBuilder.java
@@ -2,7 +2,6 @@ package momento.sdk;
 
 import java.time.Duration;
 import java.util.Optional;
-import momento.sdk.exceptions.InvalidArgumentException;
 
 /** Builder for {@link momento.sdk.SimpleCacheClient} */
 public final class SimpleCacheClientBuilder {
@@ -18,9 +17,7 @@ public final class SimpleCacheClientBuilder {
   }
 
   public SimpleCacheClientBuilder requestTimeout(Duration requestTimeout) {
-    if (requestTimeout == null || requestTimeout.isNegative() || requestTimeout.isZero()) {
-      throw new InvalidArgumentException("Request timeout should be positive");
-    }
+    ValidationUtils.ensureRequestTimeoutValid(requestTimeout);
     this.requestTimeout = Optional.of(requestTimeout);
     return this;
   }

--- a/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
+++ b/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
@@ -1,12 +1,13 @@
 package momento.sdk;
 
+import java.time.Duration;
 import momento.sdk.exceptions.InvalidArgumentException;
 
 // Should rely on server for all validations. However, there are some that cannot be delegated and
 // instead fail in grpc client, like providing null inputs or a negative ttl.
-// TODO: validation should not let exceptions escape from cache methods
 final class ValidationUtils {
 
+  static final String REQUEST_TIMEOUT_MUST_BE_POSITIVE = "Request timeout must be positive";
   static final String CACHE_ITEM_TTL_CANNOT_BE_NEGATIVE = "Cache item TTL cannot be negative.";
   static final String A_NON_NULL_KEY_IS_REQUIRED = "A non-null key is required.";
   static final String A_NON_NULL_VALUE_IS_REQUIRED = "A non-null value is required.";
@@ -14,6 +15,12 @@ final class ValidationUtils {
   static final String SIGNING_KEY_TTL_CANNOT_BE_NEGATIVE = "Signing key TTL cannot be negative.";
 
   ValidationUtils() {}
+
+  static void ensureRequestTimeoutValid(Duration requestTimeout) {
+    if (requestTimeout == null || requestTimeout.isNegative() || requestTimeout.isZero()) {
+      throw new InvalidArgumentException(REQUEST_TIMEOUT_MUST_BE_POSITIVE);
+    }
+  }
 
   static void checkCacheNameValid(String cacheName) {
     if (cacheName == null) {

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
@@ -1,12 +1,33 @@
 package momento.sdk.exceptions;
 
+import java.util.Optional;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** A resource already exists. */
 public class AlreadyExistsException extends MomentoServiceException {
 
+  private static final String MESSAGE =
+      "A cache with the specified name already exists. To resolve this error, "
+          + "either delete the existing cache and make a new one, or use a different name.";
+
+  /**
+   * Constructs an AlreadyExistsException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public AlreadyExistsException(
-      String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(
+        MomentoErrorCode.ALREADY_EXISTS_ERROR,
+        completeMessage(transportErrorDetails),
+        cause,
+        transportErrorDetails);
+  }
+
+  private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
+    final Optional<String> nameOpt =
+        transportErrorDetails.getGrpcErrorDetails().getMetadata().getCacheName();
+    return nameOpt.map(s -> MESSAGE + " Cache name: " + s).orElse(MESSAGE);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
@@ -1,9 +1,12 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** A resource already exists. */
 public class AlreadyExistsException extends MomentoServiceException {
 
-  public AlreadyExistsException(String message) {
-    super(message);
+  public AlreadyExistsException(
+      String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/AuthenticationException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/AuthenticationException.java
@@ -4,8 +4,18 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Authentication token is not provided or is invalid. */
 public class AuthenticationException extends MomentoServiceException {
+
+  private static final String MESSAGE =
+      "Invalid authentication credentials to connect to the cache service.";
+
+  /**
+   * Constructs an AuthenticationException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public AuthenticationException(
-      String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.AUTHENTICATION_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/AuthenticationException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/AuthenticationException.java
@@ -1,8 +1,11 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Authentication token is not provided or is invalid. */
 public class AuthenticationException extends MomentoServiceException {
-  public AuthenticationException(String message) {
-    super(message);
+  public AuthenticationException(
+      String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/BadRequestException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/BadRequestException.java
@@ -1,8 +1,11 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Invalid parameters sent to Momento Services. */
 public class BadRequestException extends MomentoServiceException {
-  public BadRequestException(String message) {
-    super(message);
+
+  public BadRequestException(String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/BadRequestException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/BadRequestException.java
@@ -5,7 +5,15 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 /** Invalid parameters sent to Momento Services. */
 public class BadRequestException extends MomentoServiceException {
 
-  public BadRequestException(String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+  private static final String MESSAGE = "The request was invalid; please contact Momento";
+
+  /**
+   * Constructs a BadRequestException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public BadRequestException(Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.BAD_REQUEST_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -3,6 +3,10 @@ package momento.sdk.exceptions;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Map;
+import momento.sdk.internal.MomentoGrpcErrorDetails;
+import momento.sdk.internal.MomentoTransportErrorDetails;
 
 public final class CacheServiceExceptionMapper {
 
@@ -13,21 +17,31 @@ public final class CacheServiceExceptionMapper {
 
   private CacheServiceExceptionMapper() {}
 
+  public static SdkException convert(Throwable e) {
+    return convert(e, Collections.emptyMap());
+  }
+
   /**
    * Common Handler for converting exceptions encountered by the SDK.
    *
    * <p>Any specialized exception handling should be performed before calling this
    *
-   * @param e
+   * @param e to convert
    */
-  public static SdkException convert(Throwable e) {
+  public static SdkException convert(Throwable e, Map<String, String> metadata) {
     if (e instanceof SdkException) {
       return (SdkException) e;
     }
 
     if (e instanceof io.grpc.StatusRuntimeException) {
-      StatusRuntimeException grpcException = (StatusRuntimeException) e;
-      switch (grpcException.getStatus().getCode()) {
+      final StatusRuntimeException grpcException = (StatusRuntimeException) e;
+      final Status.Code statusCode = grpcException.getStatus().getCode();
+
+      final MomentoTransportErrorDetails errorDetails =
+          new MomentoTransportErrorDetails(
+              new MomentoGrpcErrorDetails(statusCode, grpcException.getMessage(), metadata));
+
+      switch (statusCode) {
         case INVALID_ARGUMENT:
           // fall through
         case UNIMPLEMENTED:
@@ -35,28 +49,28 @@ public final class CacheServiceExceptionMapper {
         case OUT_OF_RANGE:
           // fall through
         case FAILED_PRECONDITION:
-          return new BadRequestException(grpcException.getMessage());
+          return new BadRequestException(grpcException.getMessage(), errorDetails);
 
         case CANCELLED:
-          return new CancellationException(grpcException.getMessage());
+          return new CancellationException(grpcException.getMessage(), errorDetails);
 
         case DEADLINE_EXCEEDED:
-          return new TimeoutException(grpcException.getMessage());
+          return new TimeoutException(grpcException.getMessage(), errorDetails);
 
         case PERMISSION_DENIED:
-          return new PermissionDeniedException(grpcException.getMessage());
+          return new PermissionDeniedException(grpcException.getMessage(), errorDetails);
 
         case UNAUTHENTICATED:
-          return new AuthenticationException(grpcException.getMessage());
+          return new AuthenticationException(grpcException.getMessage(), errorDetails);
 
         case RESOURCE_EXHAUSTED:
-          return new LimitExceededException(grpcException.getMessage());
+          return new LimitExceededException(grpcException.getMessage(), errorDetails);
 
         case NOT_FOUND:
-          return new NotFoundException(grpcException.getMessage());
+          return new NotFoundException(grpcException.getMessage(), errorDetails);
 
         case ALREADY_EXISTS:
-          return new AlreadyExistsException(grpcException.getMessage());
+          return new AlreadyExistsException(grpcException.getMessage(), errorDetails);
 
         case UNKNOWN:
           // fall through
@@ -69,20 +83,21 @@ public final class CacheServiceExceptionMapper {
         case DATA_LOSS:
           // fall through
         default:
-          return convertUnhandledExceptions(grpcException);
+          return convertUnhandledExceptions(grpcException, errorDetails);
       }
     }
 
     return new ClientSdkException(SDK_FAILED_TO_PROCESS_THE_REQUEST, e);
   }
 
-  public static SdkException convertUnhandledExceptions(StatusRuntimeException e) {
+  public static SdkException convertUnhandledExceptions(
+      StatusRuntimeException e, MomentoTransportErrorDetails errorDetails) {
     if (isDnsUnreachable(e)) {
       return new InternalServerException(
-          String.format(
-              "Unable to reach request endpoint. Request failed with %s", e.getMessage()));
+          String.format("Unable to reach request endpoint. Request failed with %s", e.getMessage()),
+          errorDetails);
     }
-    return new InternalServerException(INTERNAL_SERVER_ERROR_MESSAGE, e);
+    return new InternalServerException(INTERNAL_SERVER_ERROR_MESSAGE, e, errorDetails);
   }
 
   private static boolean isDnsUnreachable(StatusRuntimeException e) {

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CancellationException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CancellationException.java
@@ -4,7 +4,18 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Operation was cancelled. */
 public class CancellationException extends MomentoServiceException {
-  public CancellationException(String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+
+  private static final String MESSAGE =
+      "The request was cancelled by the server; please contact Momento.";
+
+  /**
+   * Constructs a CancellationException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public CancellationException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.CANCELLED_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CancellationException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CancellationException.java
@@ -1,8 +1,10 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Operation was cancelled. */
 public class CancellationException extends MomentoServiceException {
-  public CancellationException(String message) {
-    super(message);
+  public CancellationException(String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/ClientSdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/ClientSdkException.java
@@ -10,11 +10,33 @@ package momento.sdk.exceptions;
  */
 public class ClientSdkException extends SdkException {
 
-  public ClientSdkException(String message, Throwable cause) {
-    super(message, cause);
+  /**
+   * Constructs a ClientSdkException with an error code, a detail message, and a cause.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   * @param cause the cause.
+   */
+  public ClientSdkException(MomentoErrorCode errorCode, String message, Throwable cause) {
+    super(errorCode, message, cause);
   }
 
+  /**
+   * Constructs a ClientSdkException with an error code and a detail message.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   */
+  public ClientSdkException(MomentoErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+
+  /**
+   * Constructs a ClientSdkException with a detail message.
+   *
+   * @param message the detail message.
+   */
   public ClientSdkException(String message) {
-    super(message);
+    super(MomentoErrorCode.UNKNOWN, message);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/InternalServerException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/InternalServerException.java
@@ -1,5 +1,7 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Momento Service encountered an unexpected exception while trying to fulfill the request. */
 public class InternalServerException extends MomentoServiceException {
 
@@ -7,7 +9,13 @@ public class InternalServerException extends MomentoServiceException {
     super(message);
   }
 
-  public InternalServerException(String message, Throwable cause) {
-    super(message, cause);
+  public InternalServerException(
+      String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
+  }
+
+  public InternalServerException(
+      String message, Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/InternalServerException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/InternalServerException.java
@@ -5,17 +5,26 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 /** Momento Service encountered an unexpected exception while trying to fulfill the request. */
 public class InternalServerException extends MomentoServiceException {
 
+  private static final String MESSAGE =
+      "An unexpected error occurred while trying to fulfill the request; please contact Momento.";
+
+  /**
+   * Constructs an InternalServerException with a detail message.
+   *
+   * @param message the detail message.
+   */
   public InternalServerException(String message) {
-    super(message);
+    super(MomentoErrorCode.INTERNAL_SERVER_ERROR, MESSAGE + " " + message);
   }
 
+  /**
+   * Constructs an InternalServerException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public InternalServerException(
-      String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
-  }
-
-  public InternalServerException(
-      String message, Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, cause, transportErrorDetails);
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.INTERNAL_SERVER_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/InvalidArgumentException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/InvalidArgumentException.java
@@ -2,11 +2,25 @@ package momento.sdk.exceptions;
 
 /** SDK client side validation fails. */
 public class InvalidArgumentException extends ClientSdkException {
+
+  private static final String MESSAGE_PREFIX = "Invalid argument passed to Momento client: ";
+
+  /**
+   * Constructs an InvalidArgumentException with a detail message and a cause.
+   *
+   * @param message the detail message.
+   * @param cause the cause.
+   */
   public InvalidArgumentException(String message, Throwable cause) {
-    super(message, cause);
+    super(MomentoErrorCode.INVALID_ARGUMENT_ERROR, MESSAGE_PREFIX + message, cause);
   }
 
+  /**
+   * Constructs an InvalidArgumentException with a detail message.
+   *
+   * @param message the detail message.
+   */
   public InvalidArgumentException(String message) {
-    super(message);
+    super(MomentoErrorCode.INVALID_ARGUMENT_ERROR, MESSAGE_PREFIX + message);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
@@ -4,8 +4,19 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Requested operation couldn't be completed because system limits were hit. */
 public class LimitExceededException extends MomentoServiceException {
+
+  private static final String MESSAGE =
+      "Request rate, bandwidth, or object size exceeded the limits for this account. To resolve this error, "
+          + "reduce your usage as appropriate or contact Momento to request a limit increase.";
+
+  /**
+   * Constructs a LimitExceededException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public LimitExceededException(
-      String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.LIMIT_EXCEEDED_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
@@ -1,8 +1,11 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Requested operation couldn't be completed because system limits were hit. */
 public class LimitExceededException extends MomentoServiceException {
-  public LimitExceededException(String message) {
-    super(message);
+  public LimitExceededException(
+      String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoErrorCode.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoErrorCode.java
@@ -1,0 +1,49 @@
+package momento.sdk.exceptions;
+
+/**
+ * A list of all available Momento error codes. These can be used to check for specific types of
+ * errors on a failure response.
+ */
+public enum MomentoErrorCode {
+  /** An invalid argument was passed to Momento client. */
+  INVALID_ARGUMENT_ERROR,
+
+  /** The service returned an unknown response. */
+  UNKNOWN_SERVICE_ERROR,
+
+  /** A cache with the specified name already exists. */
+  ALREADY_EXISTS_ERROR,
+
+  /** A cache with the specified name could not be found. */
+  NOT_FOUND_ERROR,
+
+  /** An unexpected server error occurred while trying to fulfill the request. */
+  INTERNAL_SERVER_ERROR,
+
+  /** Insufficient permissions to perform an operation. */
+  PERMISSION_ERROR,
+
+  /** Invalid authentication credentials to connect to the cache service. */
+  AUTHENTICATION_ERROR,
+
+  /** The request was cancelled by the server. */
+  CANCELLED_ERROR,
+
+  /** Request rate, bandwidth, or object size exceeded the limits for the account. */
+  LIMIT_EXCEEDED_ERROR,
+
+  /** The request was invalid. */
+  BAD_REQUEST_ERROR,
+
+  /** The client's configured timeout was exceeded. */
+  TIMEOUT_ERROR,
+
+  /** The server was temporarily unable to handle the request. */
+  SERVER_UNAVAILABLE,
+
+  /** A client resource (most likely memory) was exhausted. */
+  CLIENT_RESOURCE_EXHAUSTED,
+
+  /** Unknown or non-specific client-side error. */
+  UNKNOWN,
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoErrorMetadata.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoErrorMetadata.java
@@ -1,0 +1,32 @@
+package momento.sdk.exceptions;
+
+import java.util.Optional;
+
+/** Metadata about a failed Momento request. */
+public class MomentoErrorMetadata {
+  private final long requestTimeout;
+  private final String cacheName;
+
+  public MomentoErrorMetadata(long requestTimeout, String cacheName) {
+    this.requestTimeout = requestTimeout;
+    this.cacheName = cacheName;
+  }
+
+  /**
+   * Returns the cache name of the failed request if one is present.
+   *
+   * @return the cache name if the request was associated with one.
+   */
+  public Optional<String> getCacheName() {
+    return Optional.ofNullable(cacheName);
+  }
+
+  /**
+   * Returns the deadline of the failed request.
+   *
+   * @return the timeout in seconds.
+   */
+  public long getRequestTimeout() {
+    return requestTimeout;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoServiceException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoServiceException.java
@@ -1,5 +1,7 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Base type for all the exceptions resulting from invalid interactions with Momento Services. */
 public class MomentoServiceException extends SdkException {
 
@@ -7,7 +9,13 @@ public class MomentoServiceException extends SdkException {
     super(message);
   }
 
-  public MomentoServiceException(String message, Throwable cause) {
-    super(message, cause);
+  public MomentoServiceException(
+      String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
+  }
+
+  public MomentoServiceException(
+      String message, Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoServiceException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoServiceException.java
@@ -5,17 +5,38 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 /** Base type for all the exceptions resulting from invalid interactions with Momento Services. */
 public class MomentoServiceException extends SdkException {
 
-  public MomentoServiceException(String message) {
-    super(message);
+  public MomentoServiceException(MomentoErrorCode errorCode, String message) {
+    super(errorCode, message);
   }
 
+  /**
+   * Constructs a MomentoServiceException with an error code, a detail message, and error details.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   * @param transportErrorDetails details about the request and error.
+   */
   public MomentoServiceException(
-      String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+      MomentoErrorCode errorCode,
+      String message,
+      MomentoTransportErrorDetails transportErrorDetails) {
+    super(errorCode, message, transportErrorDetails);
   }
 
+  /**
+   * Constructs a MomentoServiceException with an error code, a detail message, a cause, and error
+   * details.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public MomentoServiceException(
-      String message, Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, cause, transportErrorDetails);
+      MomentoErrorCode errorCode,
+      String message,
+      Throwable cause,
+      MomentoTransportErrorDetails transportErrorDetails) {
+    super(errorCode, message, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
@@ -1,9 +1,11 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Requested resource or the resource on which an operation was requested doesn't exist. */
 public class NotFoundException extends MomentoServiceException {
 
-  public NotFoundException(String message) {
-    super(message);
+  public NotFoundException(String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
@@ -1,11 +1,32 @@
 package momento.sdk.exceptions;
 
+import java.util.Optional;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Requested resource or the resource on which an operation was requested doesn't exist. */
 public class NotFoundException extends MomentoServiceException {
 
-  public NotFoundException(String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+  private static final String MESSAGE =
+      "A cache with the specified name does not exist. To resolve this error, "
+          + "make sure you have created the cache before attempting to use it.";
+
+  /**
+   * Constructs a NotFoundException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public NotFoundException(Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(
+        MomentoErrorCode.NOT_FOUND_ERROR,
+        completeMessage(transportErrorDetails),
+        cause,
+        transportErrorDetails);
+  }
+
+  private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
+    final Optional<String> nameOpt =
+        transportErrorDetails.getGrpcErrorDetails().getMetadata().getCacheName();
+    return nameOpt.map(s -> MESSAGE + " Cache name: " + s).orElse(MESSAGE);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/PermissionDeniedException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/PermissionDeniedException.java
@@ -1,9 +1,12 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Insufficient permissions to execute an operation. */
 public class PermissionDeniedException extends MomentoServiceException {
 
-  public PermissionDeniedException(String message) {
-    super(message);
+  public PermissionDeniedException(
+      String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/PermissionDeniedException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/PermissionDeniedException.java
@@ -5,8 +5,17 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 /** Insufficient permissions to execute an operation. */
 public class PermissionDeniedException extends MomentoServiceException {
 
+  private static final String MESSAGE =
+      "Insufficient permissions to perform an operation on a cache.";
+
+  /**
+   * Constructs a PermissionDeniedException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public PermissionDeniedException(
-      String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.PERMISSION_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
@@ -6,27 +6,99 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 /** Base class for all exceptions thrown by the SDK */
 public class SdkException extends RuntimeException {
 
+  private final MomentoErrorCode errorCode;
   private final MomentoTransportErrorDetails transportErrorDetails;
 
+  /**
+   * Constructs an SdkException from another SdkException. The detail message, error code, and error
+   * details are copied from the given exception and the cause is set to the given exception.
+   *
+   * @param sdkException the exception to wrap.
+   */
+  public SdkException(SdkException sdkException) {
+    super(sdkException.getMessage(), sdkException);
+    this.errorCode = sdkException.errorCode;
+    this.transportErrorDetails = sdkException.transportErrorDetails;
+  }
+
+  /**
+   * Constructs an SdkException with an error code, a detail message, a cause, and error details.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
   public SdkException(
-      String message, Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+      MomentoErrorCode errorCode,
+      String message,
+      Throwable cause,
+      MomentoTransportErrorDetails transportErrorDetails) {
     super(message, cause);
+    this.errorCode = errorCode;
     this.transportErrorDetails = transportErrorDetails;
   }
 
-  public SdkException(String message, Throwable cause) {
+  /**
+   * Constructs an SdkException with an error code, a detail message, and a cause.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   * @param cause the cause.
+   */
+  public SdkException(MomentoErrorCode errorCode, String message, Throwable cause) {
     super(message, cause);
+    this.errorCode = errorCode;
     this.transportErrorDetails = null;
   }
 
-  public SdkException(String message, MomentoTransportErrorDetails transportErrorDetails) {
+  /**
+   * Constructs an SdkException with an error code, a detail message, and error details.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public SdkException(
+      MomentoErrorCode errorCode,
+      String message,
+      MomentoTransportErrorDetails transportErrorDetails) {
     super(message);
+    this.errorCode = errorCode;
     this.transportErrorDetails = transportErrorDetails;
   }
 
+  /**
+   * Constructs an SdkException with an error code and a detail message.
+   *
+   * @param errorCode the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   * @param message the detail message.
+   */
+  public SdkException(MomentoErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+    this.transportErrorDetails = null;
+  }
+
+  /**
+   * Constructs an SdkException with a detail message and an {@link MomentoErrorCode#UNKNOWN} error
+   * code.
+   *
+   * @param message the detail message.
+   */
   public SdkException(String message) {
     super(message);
+    this.errorCode = MomentoErrorCode.UNKNOWN;
     this.transportErrorDetails = null;
+  }
+
+  /**
+   * Returns the Momento error code.
+   *
+   * @return the error code, or {@link MomentoErrorCode#UNKNOWN} if none exists.
+   */
+  public MomentoErrorCode getErrorCode() {
+    return errorCode;
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
@@ -1,13 +1,41 @@
 package momento.sdk.exceptions;
 
+import java.util.Optional;
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Base class for all exceptions thrown by the SDK */
 public class SdkException extends RuntimeException {
 
+  private final MomentoTransportErrorDetails transportErrorDetails;
+
+  public SdkException(
+      String message, Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, cause);
+    this.transportErrorDetails = transportErrorDetails;
+  }
+
   public SdkException(String message, Throwable cause) {
     super(message, cause);
+    this.transportErrorDetails = null;
+  }
+
+  public SdkException(String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message);
+    this.transportErrorDetails = transportErrorDetails;
   }
 
   public SdkException(String message) {
     super(message);
+    this.transportErrorDetails = null;
+  }
+
+  /**
+   * Gets the optional internal error details. Contains information for debugging low-level
+   * transport layer issues.
+   *
+   * @return the error details if they exist.
+   */
+  public Optional<MomentoTransportErrorDetails> getTransportErrorDetails() {
+    return Optional.ofNullable(transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/ServerUnavailableException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/ServerUnavailableException.java
@@ -1,0 +1,21 @@
+package momento.sdk.exceptions;
+
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
+/** The server temporarily could not be reached. */
+public class ServerUnavailableException extends MomentoServiceException {
+
+  private static final String MESSAGE =
+      "The server was unable to handle the request; consider retrying. If the error persists, please contact Momento.";
+
+  /**
+   * Constructs a ServerUnavailableException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public ServerUnavailableException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.SERVER_UNAVAILABLE, MESSAGE, cause, transportErrorDetails);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/TimeoutException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/TimeoutException.java
@@ -4,7 +4,27 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Requested operation did not complete in allotted time. */
 public class TimeoutException extends MomentoServiceException {
-  public TimeoutException(String message, MomentoTransportErrorDetails transportErrorDetails) {
-    super(message, transportErrorDetails);
+
+  private static final String MESSAGE_PREFIX =
+      "The client's configured timeout was exceeded; you may need to use "
+          + "a Configuration with more lenient timeouts. Timeout value: ";
+
+  /**
+   * Constructs a TimeoutException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public TimeoutException(Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(
+        MomentoErrorCode.TIMEOUT_ERROR,
+        completeMessage(transportErrorDetails),
+        cause,
+        transportErrorDetails);
+  }
+
+  private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
+    return MESSAGE_PREFIX
+        + transportErrorDetails.getGrpcErrorDetails().getMetadata().getRequestTimeout();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/TimeoutException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/TimeoutException.java
@@ -1,8 +1,10 @@
 package momento.sdk.exceptions;
 
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
 /** Requested operation did not complete in allotted time. */
 public class TimeoutException extends MomentoServiceException {
-  public TimeoutException(String message) {
-    super(message);
+  public TimeoutException(String message, MomentoTransportErrorDetails transportErrorDetails) {
+    super(message, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/UnknownException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/UnknownException.java
@@ -1,0 +1,24 @@
+package momento.sdk.exceptions;
+
+/** Unrecognized error. */
+public class UnknownException extends MomentoServiceException {
+
+  /**
+   * Constructs an UnknownException with a detail message.
+   *
+   * @param message the detail message.
+   */
+  public UnknownException(String message) {
+    super(MomentoErrorCode.UNKNOWN, message, null);
+  }
+
+  /**
+   * Constructs an UnknownException with a detail message and cause.
+   *
+   * @param message the detail message.
+   * @param cause the cause.
+   */
+  public UnknownException(String message, Throwable cause) {
+    super(MomentoErrorCode.UNKNOWN, message, cause, null);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/UnknownServiceException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/UnknownServiceException.java
@@ -1,0 +1,21 @@
+package momento.sdk.exceptions;
+
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
+/** Service returned an unknown response. */
+public class UnknownServiceException extends MomentoServiceException {
+
+  private static final String MESSAGE =
+      "The service returned an unknown response; please contact Momento.";
+
+  /**
+   * Constructs an UnknownServiceException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public UnknownServiceException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(MomentoErrorCode.UNKNOWN_SERVICE_ERROR, MESSAGE, cause, transportErrorDetails);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/WrappedSdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/WrappedSdkException.java
@@ -1,0 +1,8 @@
+package momento.sdk.exceptions;
+
+/** An SdkException that is a wrapper around another SdkException. */
+public class WrappedSdkException extends SdkException {
+  public WrappedSdkException(SdkException cause) {
+    super(cause.getMessage(), cause, cause.getTransportErrorDetails().orElse(null));
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/WrappedSdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/WrappedSdkException.java
@@ -1,8 +1,0 @@
-package momento.sdk.exceptions;
-
-/** An SdkException that is a wrapper around another SdkException. */
-public class WrappedSdkException extends SdkException {
-  public WrappedSdkException(SdkException cause) {
-    super(cause.getMessage(), cause, cause.getTransportErrorDetails().orElse(null));
-  }
-}

--- a/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
@@ -1,16 +1,16 @@
 package momento.sdk.internal;
 
 import io.grpc.Status;
-import java.util.Map;
+import momento.sdk.exceptions.MomentoErrorMetadata;
 
 /** Captures gRPC-level information about an error. */
 public class MomentoGrpcErrorDetails {
   private final Status.Code statusCode;
   private final String details;
-  private final Map<String, String> metadata;
+  private final MomentoErrorMetadata metadata;
 
   public MomentoGrpcErrorDetails(
-      Status.Code statusCode, String details, Map<String, String> metadata) {
+      Status.Code statusCode, String details, MomentoErrorMetadata metadata) {
     this.statusCode = statusCode;
     this.details = details;
     this.metadata = metadata;
@@ -24,7 +24,7 @@ public class MomentoGrpcErrorDetails {
     return details;
   }
 
-  public Map<String, String> getMetadata() {
+  public MomentoErrorMetadata getMetadata() {
     return metadata;
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
@@ -1,0 +1,30 @@
+package momento.sdk.internal;
+
+import io.grpc.Status;
+import java.util.Map;
+
+/** Captures gRPC-level information about an error. */
+public class MomentoGrpcErrorDetails {
+  private final Status.Code statusCode;
+  private final String details;
+  private final Map<String, String> metadata;
+
+  public MomentoGrpcErrorDetails(
+      Status.Code statusCode, String details, Map<String, String> metadata) {
+    this.statusCode = statusCode;
+    this.details = details;
+    this.metadata = metadata;
+  }
+
+  public Status.Code getStatusCode() {
+    return statusCode;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/internal/MomentoTransportErrorDetails.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/MomentoTransportErrorDetails.java
@@ -1,0 +1,15 @@
+package momento.sdk.internal;
+
+/** Container for low-level error information, including details from the transport layer. */
+public class MomentoTransportErrorDetails {
+
+  private final MomentoGrpcErrorDetails grpcErrorDetails;
+
+  public MomentoTransportErrorDetails(MomentoGrpcErrorDetails grpcErrorDetails) {
+    this.grpcErrorDetails = grpcErrorDetails;
+  }
+
+  public MomentoGrpcErrorDetails getGrpcErrorDetails() {
+    return grpcErrorDetails;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/internal/StringHelpers.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/StringHelpers.java
@@ -1,0 +1,21 @@
+package momento.sdk.internal;
+
+/** Helper methods for working with strings. */
+public class StringHelpers {
+
+  public static String truncate(String input) {
+    return truncate(input, 20);
+  }
+
+  public static String truncate(String input, int maxLength) {
+    if (input == null) {
+      return null;
+    }
+
+    if (input.length() < maxLength) {
+      return input;
+    }
+
+    return input.substring(0, maxLength) + "...";
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDeleteResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDeleteResponse.java
@@ -1,6 +1,7 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a cache delete operation */
 public interface CacheDeleteResponse {
@@ -13,10 +14,10 @@ public interface CacheDeleteResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends SdkException implements CacheDeleteResponse {
+  class Error extends WrappedSdkException implements CacheDeleteResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDeleteResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDeleteResponse.java
@@ -1,7 +1,6 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a cache delete operation */
 public interface CacheDeleteResponse {
@@ -14,8 +13,13 @@ public interface CacheDeleteResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements CacheDeleteResponse {
+  class Error extends SdkException implements CacheDeleteResponse {
 
+    /**
+     * Constructs a cache delete error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -2,7 +2,10 @@ package momento.sdk.messages;
 
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
+import momento.sdk.internal.StringHelpers;
 
 /** Response for a cache get operation */
 public interface CacheGetResponse {
@@ -32,6 +35,21 @@ public interface CacheGetResponse {
     public String valueString() {
       return value.toString(StandardCharsets.UTF_8);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Truncates the internal fields to 20 characters to bound the size of the string.
+     */
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": valueString: \""
+          + StringHelpers.truncate(valueString())
+          + "\" valueByteArray: \""
+          + StringHelpers.truncate(Base64.getEncoder().encodeToString(valueByteArray()))
+          + "\"";
+    }
   }
 
   /** A successful get operation for a key that has no value. */
@@ -42,10 +60,10 @@ public interface CacheGetResponse {
    * the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of the
    * message of the cause.
    */
-  class Error extends SdkException implements CacheGetResponse {
+  class Error extends WrappedSdkException implements CacheGetResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheGetResponse.java
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 import momento.sdk.internal.StringHelpers;
 
 /** Response for a cache get operation */
@@ -14,6 +13,11 @@ public interface CacheGetResponse {
   class Hit implements CacheGetResponse {
     private final ByteString value;
 
+    /**
+     * Constructs a cache get hit with an encoded value.
+     *
+     * @param value the retrieved value.
+     */
     public Hit(ByteString value) {
       this.value = value;
     }
@@ -60,8 +64,13 @@ public interface CacheGetResponse {
    * the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of the
    * message of the cause.
    */
-  class Error extends WrappedSdkException implements CacheGetResponse {
+  class Error extends SdkException implements CacheGetResponse {
 
+    /**
+     * Constructs a cache get error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetResponse.java
@@ -2,7 +2,10 @@ package momento.sdk.messages;
 
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
+import momento.sdk.internal.StringHelpers;
 
 /** Response for a cache set operation */
 public interface CacheSetResponse {
@@ -32,6 +35,21 @@ public interface CacheSetResponse {
     public String valueString() {
       return value.toString(StandardCharsets.UTF_8);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Truncates the internal fields to 20 characters to bound the size of the string.
+     */
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": valueString: \""
+          + StringHelpers.truncate(valueString())
+          + "\" valueByteArray: \""
+          + StringHelpers.truncate(Base64.getEncoder().encodeToString(valueByteArray()))
+          + "\"";
+    }
   }
 
   /**
@@ -39,10 +57,10 @@ public interface CacheSetResponse {
    * the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of the
    * message of the cause.
    */
-  class Error extends SdkException implements CacheSetResponse {
+  class Error extends WrappedSdkException implements CacheSetResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetResponse.java
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 import momento.sdk.internal.StringHelpers;
 
 /** Response for a cache set operation */
@@ -14,6 +13,11 @@ public interface CacheSetResponse {
   class Success implements CacheSetResponse {
     private final ByteString value;
 
+    /**
+     * Constructs a cache set success with an encoded value.
+     *
+     * @param value the set value.
+     */
     public Success(ByteString value) {
       this.value = value;
     }
@@ -57,8 +61,13 @@ public interface CacheSetResponse {
    * the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of the
    * message of the cause.
    */
-  class Error extends WrappedSdkException implements CacheSetResponse {
+  class Error extends SdkException implements CacheSetResponse {
 
+    /**
+     * Constructs a cache set error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CreateCacheResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CreateCacheResponse.java
@@ -1,6 +1,7 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a create cache operation */
 public interface CreateCacheResponse {
@@ -13,10 +14,10 @@ public interface CreateCacheResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends SdkException implements CreateCacheResponse {
+  class Error extends WrappedSdkException implements CreateCacheResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CreateCacheResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CreateCacheResponse.java
@@ -1,7 +1,6 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a create cache operation */
 public interface CreateCacheResponse {
@@ -14,8 +13,13 @@ public interface CreateCacheResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements CreateCacheResponse {
+  class Error extends SdkException implements CreateCacheResponse {
 
+    /**
+     * Constructs a cache creation error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CreateSigningKeyResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CreateSigningKeyResponse.java
@@ -2,6 +2,7 @@ package momento.sdk.messages;
 
 import java.util.Date;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a create signing key operation */
 public interface CreateSigningKeyResponse {
@@ -36,6 +37,23 @@ public interface CreateSigningKeyResponse {
     public Date getExpiresAt() {
       return expiresAt;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Prints key metadata but not the key.
+     */
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": keyId: \""
+          + getKeyId()
+          + "\" endpoint: \""
+          + getEndpoint()
+          + "\" expiresAt: \""
+          + getExpiresAt()
+          + "\"";
+    }
   }
 
   /**
@@ -43,10 +61,10 @@ public interface CreateSigningKeyResponse {
    * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends SdkException implements CreateSigningKeyResponse {
+  class Error extends WrappedSdkException implements CreateSigningKeyResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CreateSigningKeyResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CreateSigningKeyResponse.java
@@ -2,7 +2,6 @@ package momento.sdk.messages;
 
 import java.util.Date;
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a create signing key operation */
 public interface CreateSigningKeyResponse {
@@ -61,8 +60,13 @@ public interface CreateSigningKeyResponse {
    * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements CreateSigningKeyResponse {
+  class Error extends SdkException implements CreateSigningKeyResponse {
 
+    /**
+     * Constructs a signing key creation error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/DeleteCacheResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/DeleteCacheResponse.java
@@ -1,7 +1,6 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a delete cache operation */
 public interface DeleteCacheResponse {
@@ -14,8 +13,13 @@ public interface DeleteCacheResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements DeleteCacheResponse {
+  class Error extends SdkException implements DeleteCacheResponse {
 
+    /**
+     * Constructs a delete cache error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/DeleteCacheResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/DeleteCacheResponse.java
@@ -1,6 +1,7 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a delete cache operation */
 public interface DeleteCacheResponse {
@@ -13,10 +14,10 @@ public interface DeleteCacheResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends SdkException implements DeleteCacheResponse {
+  class Error extends WrappedSdkException implements DeleteCacheResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/FlushCacheResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/FlushCacheResponse.java
@@ -1,7 +1,6 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a flush cache operation */
 public interface FlushCacheResponse {
@@ -14,8 +13,13 @@ public interface FlushCacheResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements FlushCacheResponse {
+  class Error extends SdkException implements FlushCacheResponse {
 
+    /**
+     * Constructs a cache flush error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/FlushCacheResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/FlushCacheResponse.java
@@ -1,6 +1,7 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a flush cache operation */
 public interface FlushCacheResponse {
@@ -13,10 +14,10 @@ public interface FlushCacheResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends SdkException implements FlushCacheResponse {
+  class Error extends WrappedSdkException implements FlushCacheResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/ListCachesResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/ListCachesResponse.java
@@ -1,7 +1,9 @@
 package momento.sdk.messages;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a list caches operation. */
 public interface ListCachesResponse {
@@ -17,6 +19,21 @@ public interface ListCachesResponse {
     public List<CacheInfo> getCaches() {
       return caches;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Limits the caches to 5 to bound the size of the string.
+     */
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": "
+          + getCaches().stream()
+              .map(CacheInfo::name)
+              .limit(5)
+              .collect(Collectors.joining("\", \"", "\"", "\"..."));
+    }
   }
 
   /**
@@ -24,10 +41,10 @@ public interface ListCachesResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends SdkException implements ListCachesResponse {
+  class Error extends WrappedSdkException implements ListCachesResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/ListCachesResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/ListCachesResponse.java
@@ -3,7 +3,6 @@ package momento.sdk.messages;
 import java.util.List;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a list caches operation. */
 public interface ListCachesResponse {
@@ -12,6 +11,11 @@ public interface ListCachesResponse {
   class Success implements ListCachesResponse {
     private final List<CacheInfo> caches;
 
+    /**
+     * Constructs a list caches success with a list of found caches.
+     *
+     * @param caches the retrieved caches.
+     */
     public Success(List<CacheInfo> caches) {
       this.caches = caches;
     }
@@ -41,8 +45,13 @@ public interface ListCachesResponse {
    * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
    * copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements ListCachesResponse {
+  class Error extends SdkException implements ListCachesResponse {
 
+    /**
+     * Constructs a list caches error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/ListSigningKeysResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/ListSigningKeysResponse.java
@@ -3,7 +3,6 @@ package momento.sdk.messages;
 import java.util.List;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a list signing keys operation. */
 public interface ListSigningKeysResponse {
@@ -13,10 +12,20 @@ public interface ListSigningKeysResponse {
 
     private final List<SigningKey> signingKeys;
 
+    /**
+     * Constructs a list signing keys success with a list of found keys
+     *
+     * @param signingKeys the retrieved keys.
+     */
     public Success(List<SigningKey> signingKeys) {
       this.signingKeys = signingKeys;
     }
 
+    /**
+     * Returns the retrieved signing keys.
+     *
+     * @return the keys.
+     */
     public List<SigningKey> signingKeys() {
       return signingKeys;
     }
@@ -43,8 +52,13 @@ public interface ListSigningKeysResponse {
    * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements ListSigningKeysResponse {
+  class Error extends SdkException implements ListSigningKeysResponse {
 
+    /**
+     * Constructs a signing key list error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }

--- a/momento-sdk/src/main/java/momento/sdk/messages/ListSigningKeysResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/ListSigningKeysResponse.java
@@ -1,7 +1,9 @@
 package momento.sdk.messages;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a list signing keys operation. */
 public interface ListSigningKeysResponse {
@@ -18,6 +20,22 @@ public interface ListSigningKeysResponse {
     public List<SigningKey> signingKeys() {
       return signingKeys;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Limits the keys to 5 to bound the size of the string. Prints the key ids instead of the
+     * keys.
+     */
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": keys: "
+          + signingKeys().stream()
+              .map(SigningKey::getKeyId)
+              .limit(5)
+              .collect(Collectors.joining("\", \"", "\"", "\"..."));
+    }
   }
 
   /**
@@ -25,10 +43,10 @@ public interface ListSigningKeysResponse {
    * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends SdkException implements ListSigningKeysResponse {
+  class Error extends WrappedSdkException implements ListSigningKeysResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/RevokeSigningKeyResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/RevokeSigningKeyResponse.java
@@ -1,6 +1,7 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a revoke signing key operation. */
 public interface RevokeSigningKeyResponse {
@@ -13,10 +14,10 @@ public interface RevokeSigningKeyResponse {
    * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends SdkException implements RevokeSigningKeyResponse {
+  class Error extends WrappedSdkException implements RevokeSigningKeyResponse {
 
     public Error(SdkException cause) {
-      super(cause.getMessage(), cause);
+      super(cause);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/RevokeSigningKeyResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/RevokeSigningKeyResponse.java
@@ -1,7 +1,6 @@
 package momento.sdk.messages;
 
 import momento.sdk.exceptions.SdkException;
-import momento.sdk.exceptions.WrappedSdkException;
 
 /** Response for a revoke signing key operation. */
 public interface RevokeSigningKeyResponse {
@@ -14,8 +13,13 @@ public interface RevokeSigningKeyResponse {
    * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends WrappedSdkException implements RevokeSigningKeyResponse {
+  class Error extends SdkException implements RevokeSigningKeyResponse {
 
+    /**
+     * Constructs a signing key revocation error with a cause.
+     *
+     * @param cause the cause.
+     */
     public Error(SdkException cause) {
       super(cause);
     }


### PR DESCRIPTION
Update the error handling to match other SDKs. Errors that occur during client creation should throw an exception. Errors that occur during a client call should never throw and should return an error response.

Add internal grpc error details to the exceptions.

Add toString() methods to the responses that contain data. Empty responses and error responses can use the default toString().