### PR TITLE
chore: update sdk dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,3 @@
-ext["grpcVersion"] = "1.47.0"
-ext["guavaVersion"] = "31.0.1-android" // This version is in sync with grpcVersion
-ext["protobufVersion"] = "3.21.2"
-ext["opentelemetryVersion"] = "1.5.0"
-ext["jwtVersion"] = "0.11.2"
-
 plugins {
     id("ca.cutterslade.analyze") version "1.9.0"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,35 @@
+[versions]
+assertj = "3.24.2"
+grpc = "1.53.0"
+protobuf = "3.22.2"
+jjwt = "0.11.5"
+junit = "5.9.2"
+gson = "2.10.1"
+guava = "31.1-android"
+java-protos = "0.54.1"
+opentelemetry = "1.24.0"
+
+[libraries]
+grpc-api = { module = "io.grpc:grpc-api", version.ref = "grpc"}
+grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
+
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }
+opentelemetry-context = { module = "io.opentelemetry:opentelemetry-context", version.ref = "opentelemetry" }
+
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
+jjwt-gson = { module = "io.jsonwebtoken:jjwt-gson", version.ref = "jjwt" }
+
+
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+momento-java-protos = { module = "software.momento.java:client-protos", version.ref = "java-protos" }
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+
+junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+[bundles]
+grpc = ["grpc-api", "grpc-stub", "grpc-netty-shaded"]
+opentelemetry = ["opentelemetry-api", "opentelemetry-context"]

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -5,32 +5,23 @@ plugins {
     id("com.diffplug.spotless") version "5.15.1"
 }
 
-val opentelemetryVersion = rootProject.ext["opentelemetryVersion"]
-val jwtVersion = rootProject.ext["jwtVersion"]
-val grpcVersion = rootProject.ext["grpcVersion"]
-val guavaVersion = rootProject.ext["guavaVersion"]
-
 dependencies {
-    implementation(platform("io.opentelemetry:opentelemetry-bom:$opentelemetryVersion"))
-    implementation("io.opentelemetry:opentelemetry-api")
-    implementation("io.grpc:grpc-netty-shaded:$grpcVersion")
-    implementation("com.google.guava:guava:$guavaVersion")
-    implementation("com.google.code.gson:gson:2.8.9")
-    implementation("com.google.protobuf:protobuf-java:3.21.2")
-    implementation("io.grpc:grpc-api:$grpcVersion")
-    implementation("io.grpc:grpc-stub:$grpcVersion")
-    implementation("io.opentelemetry:opentelemetry-context:$opentelemetryVersion")
+    implementation(libs.momento.java.protos)
+
+    implementation(libs.bundles.grpc)
+    implementation(libs.bundles.opentelemetry)
+    implementation(libs.protobuf.java)
+    implementation(libs.guava)
+    implementation(libs.gson)
 
     // For Auth token
-    implementation("io.jsonwebtoken:jjwt-api:$jwtVersion")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:$jwtVersion")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jwtVersion")
+    implementation(libs.jjwt.api)
+    runtimeOnly(libs.jjwt.impl)
+    runtimeOnly(libs.jjwt.gson)
 
-    // Internal Deps -------------------
-    implementation("software.momento.java:client-protos:0.54.0")
-
-    testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-    testImplementation("org.assertj:assertj-core:3.24.2")
+    // Test dependencies
+    testImplementation(libs.junit)
+    testImplementation(libs.assertj)
 }
 
 spotless {


### PR DESCRIPTION
Move dependency versions into a gradle catalog in libs.versions.toml.

Switch to the newest version of client-protos.

Switch jjwt-jackson to jjwt-gson because we already have a dependency on gson.

Update misc dependencies.