### PR TITLE
chore: Add support for setIfNotExists API

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheIncrementResponse;
+import momento.sdk.messages.CacheSetIfNotExistsResponse;
 import momento.sdk.messages.CacheSetResponse;
 import momento.sdk.messages.CreateCacheResponse;
 import momento.sdk.messages.CreateSigningKeyResponse;
@@ -251,6 +252,70 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheSetResponse> set(String cacheName, String key, String value) {
     return scsDataClient.set(cacheName, key, value);
+  }
+
+  /**
+   * Associates a key with a value. If a value for this key is already present it is not replaced by
+   * the new value.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param key {String} The key under which the value is to be added.
+   * @param value {String} The value to be stored.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(String, Duration)}
+   * @return Future containing the result of the set operation.
+   */
+  public CompletableFuture<CacheSetIfNotExistsResponse> setIfNotExists(
+      String cacheName, String key, String value, Duration ttl) {
+    return scsDataClient.setIfNotExists(cacheName, key, value, ttl);
+  }
+
+  /**
+   * Associates a key with a value. If a value for this key is already present it is not replaced by
+   * the new value.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param key {String} The key under which the value is to be added.
+   * @param value {Byte Array} The value to be stored.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(String, Duration)}
+   * @return Future containing the result of the set operation.
+   */
+  public CompletableFuture<CacheSetIfNotExistsResponse> setIfNotExists(
+      String cacheName, String key, byte[] value, Duration ttl) {
+    return scsDataClient.setIfNotExists(cacheName, key, value, ttl);
+  }
+
+  /**
+   * Associates a key with a value. If a value for this key is already present it is not replaced by
+   * the new value.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param key {Byte Array} The key under which the value is to be added.
+   * @param value {String} The value to be stored.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(String, Duration)}
+   * @return Future containing the result of the set operation.
+   */
+  public CompletableFuture<CacheSetIfNotExistsResponse> setIfNotExists(
+      String cacheName, byte[] key, String value, Duration ttl) {
+    return scsDataClient.setIfNotExists(cacheName, key, value, ttl);
+  }
+
+  /**
+   * Associates a key with a value. If a value for this key is already present it is not replaced by
+   * the new value.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param key {Byte Array} The key under which the value is to be added.
+   * @param value {Byte Array} The value to be stored.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(String, Duration)}
+   * @return Future containing the result of the set operation.
+   */
+  public CompletableFuture<CacheSetIfNotExistsResponse> setIfNotExists(
+      String cacheName, byte[] key, byte[] value, Duration ttl) {
+    return scsDataClient.setIfNotExists(cacheName, key, value, ttl);
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetIfNotExistsResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetIfNotExistsResponse.java
@@ -1,0 +1,101 @@
+package momento.sdk.messages;
+
+import com.google.protobuf.ByteString;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/**
+ * Parent response type for a cache setIfNotExists request. The response object is resolved to a
+ * type-safe object of one of the following subtypes: {Stored}, {NotStored}, {Error}
+ */
+public interface CacheSetIfNotExistsResponse {
+  class Stored implements CacheSetIfNotExistsResponse {
+    private ByteString value;
+
+    private ByteString key;
+
+    /**
+     * Indicates they key does not exist and the value was set for the desired key
+     *
+     * @param key The key to which the value is to be stored
+     * @param value The value of the key
+     */
+    public Stored(ByteString key, ByteString value) {
+      super();
+      this.key = key;
+      this.value = value;
+    }
+
+    /**
+     * Gets the retrieved key as a byte array.
+     *
+     * @return the key.
+     */
+    public byte[] keyByteArray() {
+      return key.toByteArray();
+    }
+
+    /**
+     * Gets the retrieved key as a UTF-8 {@link String}
+     *
+     * @return the key.
+     */
+    public String keyString() {
+      return key.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Gets the retrieved value as a byte array.
+     *
+     * @return the value.
+     */
+    public byte[] valueByteArray() {
+      return value.toByteArray();
+    }
+
+    /**
+     * Gets the retrieved value as a UTF-8 {@link String}
+     *
+     * @return the value.
+     */
+    public String valueString() {
+      return value.toString(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": keyString: \""
+          + StringHelpers.truncate(keyString())
+          + "\" keyByteArray: \""
+          + StringHelpers.truncate(Base64.getEncoder().encodeToString(keyByteArray()))
+          + ": valueString: \""
+          + StringHelpers.truncate(valueString())
+          + "\" valueByteArray: \""
+          + StringHelpers.truncate(Base64.getEncoder().encodeToString(valueByteArray()))
+          + "\"";
+    }
+  }
+
+  /** Indicates they key exist and the value was not set for the desired key */
+  class NotStored implements CacheSetIfNotExistsResponse {}
+
+  /**
+   * A failed setIfNotExists operation. The response itself is an exception, so it can be directly
+   * thrown, or the cause of the error can be retrieved with {@link #getClass()} ()}. The message is
+   * a copy of the message of the cause.
+   */
+  class Error extends SdkException implements CacheSetIfNotExistsResponse {
+
+    /**
+     * Constructs a cache setIfNotExists error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
- Add support for setIfNotExists API for
    - {String} key, {String} value
    - {String} key, {Byte Array} value, 
    - {Byte Array} key, {String} value
    - {Byte Array} key, {Byte Array} value
- Add corresponding integ tests

## Build
- `./gradlew :momento-sdk:spotlessApply && ./gradlew clean build`

## Issue
#154 