### PR TITLE
chore: use grpc metadata in errors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ opentelemetry = "1.24.0"
 [libraries]
 grpc-api = { module = "io.grpc:grpc-api", version.ref = "grpc"}
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
-grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
+grpc-nettyshaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
 
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }
 opentelemetry-context = { module = "io.opentelemetry:opentelemetry-context", version.ref = "opentelemetry" }
@@ -31,5 +31,4 @@ junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 
 [bundles]
-grpc = ["grpc-api", "grpc-stub", "grpc-netty-shaded"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-context"]

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -8,7 +8,9 @@ plugins {
 dependencies {
     implementation(libs.momento.java.protos)
 
-    implementation(libs.bundles.grpc)
+    api(libs.grpc.api) // Marked as api because SdkException contains classes from this dependency
+    implementation(libs.grpc.stub)
+    implementation(libs.grpc.nettyshaded)
     implementation(libs.bundles.opentelemetry)
     implementation(libs.protobuf.java)
     implementation(libs.guava)

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
-import momento.sdk.exceptions.MomentoErrorMetadata;
 import momento.sdk.messages.CacheInfo;
 import momento.sdk.messages.CreateCacheResponse;
 import momento.sdk.messages.CreateSigningKeyResponse;
@@ -51,9 +50,7 @@ final class ScsControlClient implements Closeable {
       controlGrpcStubsManager.getBlockingStub().createCache(buildCreateCacheRequest(cacheName));
       return new CreateCacheResponse.Success();
     } catch (Exception e) {
-      return new CreateCacheResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new CreateCacheResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 
@@ -64,9 +61,7 @@ final class ScsControlClient implements Closeable {
       controlGrpcStubsManager.getBlockingStub().deleteCache(buildDeleteCacheRequest(cacheName));
       return new DeleteCacheResponse.Success();
     } catch (Exception e) {
-      return new DeleteCacheResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new DeleteCacheResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 
@@ -77,9 +72,7 @@ final class ScsControlClient implements Closeable {
       controlGrpcStubsManager.getBlockingStub().flushCache(buildFlushCacheRequest(cacheName));
       return new FlushCacheResponse.Success();
     } catch (Exception e) {
-      return new FlushCacheResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new FlushCacheResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 
@@ -88,9 +81,7 @@ final class ScsControlClient implements Closeable {
       final _ListCachesRequest request = _ListCachesRequest.newBuilder().setNextToken("").build();
       return convert(controlGrpcStubsManager.getBlockingStub().listCaches(request));
     } catch (Exception e) {
-      return new ListCachesResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new ListCachesResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 
@@ -103,9 +94,7 @@ final class ScsControlClient implements Closeable {
               .createSigningKey(buildCreateSigningKeyRequest(ttl)),
           endpoint);
     } catch (Exception e) {
-      return new CreateSigningKeyResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new CreateSigningKeyResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 
@@ -117,9 +106,7 @@ final class ScsControlClient implements Closeable {
           .revokeSigningKey(buildRevokeSigningKeyRequest(keyId));
       return new RevokeSigningKeyResponse.Success();
     } catch (Exception e) {
-      return new RevokeSigningKeyResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new RevokeSigningKeyResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 
@@ -129,9 +116,7 @@ final class ScsControlClient implements Closeable {
           _ListSigningKeysRequest.newBuilder().setNextToken("").build();
       return convert(controlGrpcStubsManager.getBlockingStub().listSigningKeys(request), endpoint);
     } catch (Exception e) {
-      return new ListSigningKeysResponse.Error(
-          CacheServiceExceptionMapper.convert(
-              e, new MomentoErrorMetadata(controlGrpcStubsManager.getDeadlineSeconds(), null)));
+      return new ListSigningKeysResponse.Error(CacheServiceExceptionMapper.convert(e));
     }
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
@@ -1,6 +1,5 @@
 package momento.sdk.exceptions;
 
-import java.util.Optional;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** A resource already exists. */
@@ -26,8 +25,10 @@ public class AlreadyExistsException extends MomentoServiceException {
   }
 
   private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
-    final Optional<String> nameOpt =
-        transportErrorDetails.getGrpcErrorDetails().getMetadata().getCacheName();
-    return nameOpt.map(s -> MESSAGE + " Cache name: " + s).orElse(MESSAGE);
+    return transportErrorDetails
+        .getGrpcErrorDetails()
+        .getCacheName()
+        .map(s -> MESSAGE + " Cache name: " + s)
+        .orElse(MESSAGE);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -1,5 +1,6 @@
 package momento.sdk.exceptions;
 
+import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import momento.sdk.internal.MomentoGrpcErrorDetails;
@@ -19,7 +20,19 @@ public final class CacheServiceExceptionMapper {
    *
    * @param e to convert
    */
-  public static SdkException convert(Throwable e, MomentoErrorMetadata metadata) {
+  public static SdkException convert(Throwable e) {
+    return convert(e, null);
+  }
+
+  /**
+   * Common Handler for converting exceptions encountered by the SDK.
+   *
+   * <p>Any specialized exception handling should be performed before calling this
+   *
+   * @param e to convert
+   * @param metadata metadata from the grpc request that caused the error
+   */
+  public static SdkException convert(Throwable e, Metadata metadata) {
     if (e instanceof SdkException) {
       return (SdkException) e;
     }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
@@ -1,6 +1,5 @@
 package momento.sdk.exceptions;
 
-import java.util.Optional;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Requested resource or the resource on which an operation was requested doesn't exist. */
@@ -25,8 +24,10 @@ public class NotFoundException extends MomentoServiceException {
   }
 
   private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
-    final Optional<String> nameOpt =
-        transportErrorDetails.getGrpcErrorDetails().getMetadata().getCacheName();
-    return nameOpt.map(s -> MESSAGE + " Cache name: " + s).orElse(MESSAGE);
+    return transportErrorDetails
+        .getGrpcErrorDetails()
+        .getCacheName()
+        .map(s -> MESSAGE + " Cache name: " + s)
+        .orElse(MESSAGE);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/TimeoutException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/TimeoutException.java
@@ -5,9 +5,9 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 /** Requested operation did not complete in allotted time. */
 public class TimeoutException extends MomentoServiceException {
 
-  private static final String MESSAGE_PREFIX =
+  private static final String MESSAGE =
       "The client's configured timeout was exceeded; you may need to use "
-          + "a Configuration with more lenient timeouts. Timeout value: ";
+          + "a Configuration with more lenient timeouts.";
 
   /**
    * Constructs a TimeoutException with a cause and error details.
@@ -16,15 +16,6 @@ public class TimeoutException extends MomentoServiceException {
    * @param transportErrorDetails details about the request and error.
    */
   public TimeoutException(Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
-    super(
-        MomentoErrorCode.TIMEOUT_ERROR,
-        completeMessage(transportErrorDetails),
-        cause,
-        transportErrorDetails);
-  }
-
-  private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
-    return MESSAGE_PREFIX
-        + transportErrorDetails.getGrpcErrorDetails().getMetadata().getRequestTimeout();
+    super(MomentoErrorCode.TIMEOUT_ERROR, MESSAGE, cause, transportErrorDetails);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
@@ -1,16 +1,22 @@
 package momento.sdk.internal;
 
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+
+import io.grpc.Metadata;
 import io.grpc.Status;
-import momento.sdk.exceptions.MomentoErrorMetadata;
+import java.util.Optional;
 
 /** Captures gRPC-level information about an error. */
 public class MomentoGrpcErrorDetails {
   private final Status.Code statusCode;
   private final String details;
-  private final MomentoErrorMetadata metadata;
+  private final Metadata metadata;
 
-  public MomentoGrpcErrorDetails(
-      Status.Code statusCode, String details, MomentoErrorMetadata metadata) {
+  public MomentoGrpcErrorDetails(Status.Code statusCode, String details) {
+    this(statusCode, details, null);
+  }
+
+  public MomentoGrpcErrorDetails(Status.Code statusCode, String details, Metadata metadata) {
     this.statusCode = statusCode;
     this.details = details;
     this.metadata = metadata;
@@ -24,7 +30,12 @@ public class MomentoGrpcErrorDetails {
     return details;
   }
 
-  public MomentoErrorMetadata getMetadata() {
-    return metadata;
+  public Optional<Metadata> getMetadata() {
+    return Optional.ofNullable(metadata);
+  }
+
+  public Optional<String> getCacheName() {
+    return Optional.ofNullable(metadata)
+        .map(m -> m.get(Metadata.Key.of("cache", ASCII_STRING_MARSHALLER)));
   }
 }


### PR DESCRIPTION
Switch from a custom metadata object to the grpc class to match with the other sdks.

Make grpc-api an api dependency because several of its classes are exposed through the sdk's exceptions.

Clean up some non-final variables.