### PR TITLE
chore: Remove member variable optionals and fix warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ assertj = "3.24.2"
 grpc = "1.53.0"
 protobuf = "3.22.2"
 jjwt = "0.11.5"
+jsr305 = "3.0.2"
 junit = "5.9.2"
 gson = "2.10.1"
 guava = "31.1-android"
@@ -21,7 +22,7 @@ jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
 jjwt-gson = { module = "io.jsonwebtoken:jjwt-gson", version.ref = "jjwt" }
 
-
+jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 momento-java-protos = { module = "software.momento.java:client-protos", version.ref = "java-protos" }

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 dependencies {
     implementation(libs.momento.java.protos)
 
-    api(libs.grpc.api) // Marked as api because SdkException contains classes from this dependency
+    api(libs.jsr305) // Marked api because the annotations are used in sdk methods
+    api(libs.grpc.api) // Marked api because SdkException contains classes from this dependency
     implementation(libs.grpc.stub)
     implementation(libs.grpc.nettyshaded)
     implementation(libs.bundles.opentelemetry)

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -6,6 +6,8 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheIncrementResponse;
@@ -26,20 +28,16 @@ public final class CacheClient implements Closeable {
   private final ScsDataClient scsDataClient;
 
   CacheClient(
-      String authToken,
-      Duration itemDefaultTtl,
-      Optional<OpenTelemetry> telemetryOptional,
-      Optional<Duration> requestTimeout) {
+      @Nonnull String authToken,
+      @Nonnull Duration itemDefaultTtl,
+      @Nullable OpenTelemetry openTelemetry,
+      @Nullable Duration requestTimeout) {
     MomentoEndpointsResolver.MomentoEndpoints endpoints =
         MomentoEndpointsResolver.resolve(authToken, Optional.empty());
     this.scsControlClient = new ScsControlClient(authToken, endpoints.controlEndpoint());
     this.scsDataClient =
         new ScsDataClient(
-            authToken,
-            endpoints.cacheEndpoint(),
-            itemDefaultTtl,
-            telemetryOptional,
-            requestTimeout);
+            authToken, endpoints.cacheEndpoint(), itemDefaultTtl, openTelemetry, requestTimeout);
   }
 
   public static CacheClientBuilder builder(String authToken, Duration itemDefaultTtl) {

--- a/momento-sdk/src/main/java/momento/sdk/CacheClientBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClientBuilder.java
@@ -1,28 +1,28 @@
 package momento.sdk;
 
 import java.time.Duration;
-import java.util.Optional;
+import javax.annotation.Nonnull;
 
 /** Builder for {@link CacheClient} */
 public final class CacheClientBuilder {
 
   private final String authToken;
   private final Duration itemDefaultTtl;
-  private Optional<Duration> requestTimeout = Optional.empty();
+  private Duration requestTimeout = null;
 
-  CacheClientBuilder(String authToken, Duration itemDefaultTtl) {
+  CacheClientBuilder(@Nonnull String authToken, @Nonnull Duration itemDefaultTtl) {
     this.authToken = authToken;
     ValidationUtils.ensureValidTtl(itemDefaultTtl);
     this.itemDefaultTtl = itemDefaultTtl;
   }
 
-  public CacheClientBuilder requestTimeout(Duration requestTimeout) {
+  public CacheClientBuilder requestTimeout(@Nonnull Duration requestTimeout) {
     ValidationUtils.ensureRequestTimeoutValid(requestTimeout);
-    this.requestTimeout = Optional.of(requestTimeout);
+    this.requestTimeout = requestTimeout;
     return this;
   }
 
   public CacheClient build() {
-    return new CacheClient(authToken, itemDefaultTtl, Optional.empty(), requestTimeout);
+    return new CacheClient(authToken, itemDefaultTtl, null, requestTimeout);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import javax.annotation.Nonnull;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.messages.CacheInfo;
 import momento.sdk.messages.CreateCacheResponse;
@@ -38,7 +39,7 @@ final class ScsControlClient implements Closeable {
 
   private final ScsControlGrpcStubsManager controlGrpcStubsManager;
 
-  ScsControlClient(String authToken, String endpoint) {
+  ScsControlClient(@Nonnull String authToken, @Nonnull String endpoint) {
     this.controlGrpcStubsManager = new ScsControlGrpcStubsManager(authToken, endpoint);
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * Manager responsible for GRPC channels and stubs for the Control Plane.
@@ -24,7 +25,7 @@ final class ScsControlGrpcStubsManager implements Closeable {
   private final ManagedChannel channel;
   private final ScsControlGrpc.ScsControlBlockingStub controlBlockingStub;
 
-  ScsControlGrpcStubsManager(String authToken, String endpoint) {
+  ScsControlGrpcStubsManager(@Nonnull String authToken, @Nonnull String endpoint) {
     this.channel = setupConnection(authToken, endpoint);
     this.controlBlockingStub = ScsControlGrpc.newBlockingStub(channel);
   }
@@ -47,7 +48,7 @@ final class ScsControlGrpcStubsManager implements Closeable {
    * before the deadline expires. Hence, the stub returned from here should never be cached and the
    * safest behavior is for clients to request a new stub each time.
    *
-   * <p>more information: https://github.com/grpc/grpc-java/issues/1495
+   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
    */
   ScsControlGrpc.ScsControlBlockingStub getBlockingStub() {
     return controlBlockingStub.withDeadlineAfter(DEADLINE.getSeconds(), TimeUnit.SECONDS);


### PR DESCRIPTION
Remove member variable and method argument optionals. Java optionals are sad compared to Kotlin's and provide no null guarantees, so it is valid to supply a method that takes an optional with a null.

Add a jsr305 dependency to get access to @Nonnull and @Nullable annotations.

Annotate the cache client constructor chain with @Nullable and @Nonnull. These are the only places where the sdk can throw an exception if nulls are provided.

Fix a few misc warnings.