### PR TITLE
feat: Add setAddElement and setFetch methods

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
@@ -1,0 +1,175 @@
+package momento.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import momento.sdk.exceptions.InvalidArgumentException;
+import momento.sdk.messages.CacheSetAddElementResponse;
+import momento.sdk.messages.CacheSetFetchResponse;
+import momento.sdk.requests.CollectionTtl;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SetTest {
+  private static final Duration DEFAULT_TTL = Duration.ofSeconds(60);
+  private CacheClient client;
+  private String cacheName;
+
+  private final String setName = "test-set";
+
+  @BeforeEach
+  void setup() {
+    client = CacheClient.builder(System.getenv("TEST_AUTH_TOKEN"), DEFAULT_TTL).build();
+    cacheName = System.getenv("TEST_CACHE_NAME");
+    client.createCache(cacheName);
+  }
+
+  @AfterEach
+  void teardown() {
+    client.deleteCache(cacheName);
+    client.close();
+  }
+
+  @Test
+  public void setAddElementStringHappyPath() {
+    final String element1 = "1";
+    final String element2 = "2";
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetFetchResponse.Miss.class);
+
+    assertThat(client.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetAddElementResponse.Success.class);
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Hit.class))
+        .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
+
+    // Try to add the same element again
+    assertThat(client.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetAddElementResponse.Success.class);
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Hit.class))
+        .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
+
+    // Add a different element
+    assertThat(client.setAddElement(cacheName, setName, element2, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetAddElementResponse.Success.class);
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Hit.class))
+        .satisfies(
+            hit -> assertThat(hit.valueSetString()).hasSize(2).containsOnly(element1, element2));
+  }
+
+  @Test
+  public void setAddElementBytesHappyPath() {
+    final byte[] element1 = "one".getBytes();
+    final byte[] element2 = "two".getBytes();
+
+    assertThat(client.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetAddElementResponse.Success.class);
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Hit.class))
+        .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element1));
+
+    // Try to add the same element again
+    assertThat(client.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetAddElementResponse.Success.class);
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Hit.class))
+        .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element1));
+
+    // Add a different element
+    assertThat(client.setAddElement(cacheName, setName, element2, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .isInstanceOf(CacheSetAddElementResponse.Success.class);
+
+    assertThat(client.setFetch(cacheName, setName))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Hit.class))
+        .satisfies(
+            hit -> assertThat(hit.valueSetByteArray()).hasSize(2).containsOnly(element1, element2));
+  }
+
+  @Test
+  public void setAddElementReturnsErrorWithNullCacheName() {
+    final String elementString = "element";
+    final byte[] elementBytes = elementString.getBytes(StandardCharsets.UTF_8);
+
+    assertThat(client.setAddElement(null, setName, elementString, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    assertThat(client.setAddElement(null, setName, elementBytes, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void setAddElementReturnsErrorWithNullSetName() {
+    final String elementString = "element";
+    final byte[] elementBytes = elementString.getBytes(StandardCharsets.UTF_8);
+
+    assertThat(client.setAddElement(cacheName, null, elementString, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    assertThat(client.setAddElement(cacheName, null, elementBytes, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void setAddElementReturnsErrorWithNullElement() {
+    assertThat(
+            client.setAddElement(cacheName, cacheName, (String) null, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    assertThat(
+            client.setAddElement(cacheName, cacheName, (byte[]) null, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void setFetchReturnsErrorWithNullCacheName() {
+    assertThat(client.setFetch(null, "set"))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void setFetchReturnsErrorWithNullSetName() {
+    assertThat(client.setFetch(cacheName, null))
+        .succeedsWithin(5, TimeUnit.SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSetFetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -13,6 +13,8 @@ import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheIncrementResponse;
 import momento.sdk.messages.CacheListConcatenateBackResponse;
+import momento.sdk.messages.CacheSetAddElementResponse;
+import momento.sdk.messages.CacheSetFetchResponse;
 import momento.sdk.messages.CacheSetIfNotExistsResponse;
 import momento.sdk.messages.CacheSetResponse;
 import momento.sdk.messages.CreateCacheResponse;
@@ -347,6 +349,53 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheIncrementResponse> increment(
       String cacheName, byte[] field, long amount, Duration ttl) {
     return scsDataClient.increment(cacheName, field, amount, ttl);
+  }
+
+  /**
+   * Add an element to a set in the cache.
+   *
+   * <p>After this operation the set will contain the union of the element passed in and the
+   * original elements of the set.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param setName The set to add the element to.
+   * @param element The data to add to the set.
+   * @param ttl TTL for the set in cache. This TTL takes precedence over the TTL used when
+   *     initializing a cache client. Defaults to client TTL.
+   * @return Future containing the result of the add element operation.
+   */
+  public CompletableFuture<CacheSetAddElementResponse> setAddElement(
+      String cacheName, String setName, String element, CollectionTtl ttl) {
+    return scsDataClient.setAddElement(cacheName, setName, element, ttl);
+  }
+
+  /**
+   * Add an element to a set in the cache.
+   *
+   * <p>After this operation the set will contain the union of the element passed in and the
+   * original elements of the set.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param setName The set to add the element to.
+   * @param element The data to add to the set.
+   * @param ttl TTL for the set in cache. This TTL takes precedence over the TTL used when
+   *     initializing a cache client. Defaults to client TTL.
+   * @return Future containing the result of the add element operation.
+   */
+  public CompletableFuture<CacheSetAddElementResponse> setAddElement(
+      String cacheName, String setName, byte[] element, CollectionTtl ttl) {
+    return scsDataClient.setAddElement(cacheName, setName, element, ttl);
+  }
+
+  /**
+   * Fetch an entire set from the cache.
+   *
+   * @param cacheName Name of the cache to perform the lookup in
+   * @param setName The set to fetch.
+   * @return Future containing the result of the fetch operation.
+   */
+  public CompletableFuture<CacheSetFetchResponse> setFetch(String cacheName, String setName) {
+    return scsDataClient.setFetch(cacheName, setName);
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
+++ b/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
@@ -12,6 +12,8 @@ final class ValidationUtils {
   static final String A_NON_NULL_KEY_IS_REQUIRED = "A non-null key is required.";
   static final String A_NON_NULL_VALUE_IS_REQUIRED = "A non-null value is required.";
   static final String CACHE_NAME_IS_REQUIRED = "Cache name is required.";
+
+  static final String SET_NAME_CANNOT_BE_NULL = "Set name cannot be null.";
   static final String LIST_NAME_CANNOT_BE_NULL = "List name cannot be null.";
   static final String LIST_SLICE_START_END_INVALID =
       "endIndex (exclusive) must be larger than startIndex (inclusive).";
@@ -37,6 +39,12 @@ final class ValidationUtils {
     }
   }
 
+  static void checkSetNameValid(String setName) {
+    if (setName == null) {
+      throw new InvalidArgumentException(SET_NAME_CANNOT_BE_NULL);
+    }
+  }
+
   static void checkListSliceStartEndValid(Integer startIndex, Integer endIndex) {
     if (startIndex == null || endIndex == null) return;
     if (endIndex <= startIndex) {
@@ -46,15 +54,19 @@ final class ValidationUtils {
 
   static void ensureValidCacheSet(Object key, Object value, Duration ttl) {
     ensureValidKey(key);
-    if (value == null) {
-      throw new InvalidArgumentException(A_NON_NULL_VALUE_IS_REQUIRED);
-    }
+    ensureValidValue(value);
     ensureValidTtl(ttl);
   }
 
   static void ensureValidKey(Object key) {
     if (key == null) {
       throw new InvalidArgumentException(A_NON_NULL_KEY_IS_REQUIRED);
+    }
+  }
+
+  static void ensureValidValue(Object value) {
+    if (value == null) {
+      throw new InvalidArgumentException(A_NON_NULL_VALUE_IS_REQUIRED);
     }
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetAddElementResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetAddElementResponse.java
@@ -1,0 +1,27 @@
+package momento.sdk.messages;
+
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a set add element operation */
+public interface CacheSetAddElementResponse {
+
+  /** A successful set add element operation. */
+  class Success implements CacheSetAddElementResponse {}
+
+  /**
+   * A failed set add element operation. The response itself is an exception, so it can be directly
+   * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
+   * copy of the message of the cause.
+   */
+  class Error extends SdkException implements CacheSetAddElementResponse {
+
+    /**
+     * Constructs a set add element error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetFetchResponse.java
@@ -1,0 +1,108 @@
+package momento.sdk.messages;
+
+import com.google.common.base.Suppliers;
+import com.google.protobuf.ByteString;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/** Response for a set fetch operation */
+public interface CacheSetFetchResponse {
+
+  /** A successful set fetch operation that found elements. */
+  class Hit implements CacheSetFetchResponse {
+    private List<ByteString> byteStringValues;
+    private final Supplier<Set<byte[]>> byteArrayElementsSupplier =
+        Suppliers.memoize(
+                () ->
+                    byteStringValues.stream()
+                        .map(ByteString::toByteArray)
+                        .collect(Collectors.toSet()))
+            ::get;
+    private final Supplier<Set<String>> stringElementsSupplier =
+        Suppliers.memoize(
+                () ->
+                    byteStringValues.stream()
+                        .map(ByteString::toStringUtf8)
+                        .collect(Collectors.toSet()))
+            ::get;
+
+    /**
+     * Constructs a set fetch hit with a list of encoded values.
+     *
+     * @param values the retrieved values.
+     */
+    public Hit(List<ByteString> values) {
+      this.byteStringValues = values;
+    }
+
+    /**
+     * Gets the retrieved values as a set of byte arrays.
+     *
+     * @return the values.
+     */
+    public Set<byte[]> valueSetByteArray() {
+      return byteArrayElementsSupplier.get();
+    }
+
+    /**
+     * Gets the retrieved value as a set of UTF-8 Strings
+     *
+     * @return the values.
+     */
+    public Set<String> valueSetString() {
+      return stringElementsSupplier.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Truncates the internal fields to 20 characters to bound the size of the string.
+     */
+    @Override
+    public String toString() {
+      final String stringRepresentation =
+          valueSetString().stream()
+              .limit(5)
+              .map(StringHelpers::truncate)
+              .collect(Collectors.joining(", ", "\"", "\"..."));
+
+      final String bytesRepresentation =
+          valueSetByteArray().stream()
+              .limit(5)
+              .map(ba -> Base64.getEncoder().encodeToString(ba))
+              .map(StringHelpers::truncate)
+              .collect(Collectors.joining(", ", "\"", "\"..."));
+
+      return super.toString()
+          + ": valueSetString: "
+          + stringRepresentation
+          + " valueSetByteArray: "
+          + bytesRepresentation;
+    }
+  }
+
+  /** A successful set fetch operation that did not find elements. */
+  class Miss implements CacheSetFetchResponse {}
+
+  /**
+   * A failed set fetch operation. The response itself is an exception, so it can be directly
+   * thrown, or the cause of the error can be retrieved with {@link #getCause()}. The message is a
+   * copy of the message of the cause.
+   */
+  class Error extends SdkException implements CacheSetFetchResponse {
+
+    /**
+     * Constructs a set fetch error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/requests/CollectionTtl.java
+++ b/momento-sdk/src/main/java/momento/sdk/requests/CollectionTtl.java
@@ -1,6 +1,8 @@
 package momento.sdk.requests;
 
 import java.time.Duration;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Represents the desired behavior for managing the TTL on collection objects (dictionaries, lists,
@@ -17,17 +19,17 @@ public class CollectionTtl {
   private final Duration ttl;
   private final boolean refreshTtl;
 
-  public CollectionTtl(Duration ttl, boolean refreshTtl) {
+  public CollectionTtl(@Nullable Duration ttl, boolean refreshTtl) {
     this.refreshTtl = refreshTtl;
     this.ttl = ttl;
   }
 
-  public long ttlSeconds() {
-    return this.ttl.getSeconds();
+  public Optional<Long> toSeconds() {
+    return Optional.ofNullable(ttl).map(Duration::getSeconds);
   }
 
-  public long ttlMilliseconds() {
-    return ttl.toMillis();
+  public Optional<Long> toMilliseconds() {
+    return Optional.ofNullable(ttl).map(Duration::toMillis);
   }
 
   public boolean refreshTtl() {
@@ -51,7 +53,7 @@ public class CollectionTtl {
    * @param ttl
    * @return CollectionTtl
    */
-  public static CollectionTtl of(Duration ttl) {
+  public static CollectionTtl of(@Nullable Duration ttl) {
     return new CollectionTtl(ttl, true);
   }
 
@@ -61,7 +63,7 @@ public class CollectionTtl {
    * @param ttl
    * @return CollectionTtl
    */
-  public static CollectionTtl refreshTtlIfProvided(Duration ttl) {
+  public static CollectionTtl refreshTtlIfProvided(@Nullable Duration ttl) {
     return new CollectionTtl(ttl, ttl != null);
   }
 


### PR DESCRIPTION
Add setAddElement methods for string and byte[] elements.

Add setFetch.

Make seconds and milliseconds methods in CollectionTtl return Optionals because the internal ttl may be null.