### PR TITLE
feat: Add CacheListConcatenateFront API

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -50,7 +50,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBack(
+            target.listConcatenateBackString(
                 cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
@@ -60,18 +60,33 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(3).containsAll(oldValues));
 
-    // Add a new values list
+    // Add same list
     assertThat(
-            target.listConcatenateBack(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+            target.listConcatenateBackString(
+                cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
-    List<String> expectedList = Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6");
+    List<String> expectedList = Arrays.asList("val1", "val2", "val3", "val1", "val2", "val3");
     assertThat(target.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
+
+    // Add a new values list
+    assertThat(
+            target.listConcatenateBackString(
+                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
+
+    List<String> newExpectedList =
+        Arrays.asList("val1", "val2", "val3", "val1", "val2", "val3", "val4", "val5", "val6");
+    assertThat(target.listFetch(cacheName, listName, null, null))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
+        .satisfies(
+            hit -> assertThat(hit.valueListString()).hasSize(9).containsAll(newExpectedList));
   }
 
   @Test
@@ -84,7 +99,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBack(
+            target.listConcatenateBackByteArray(
                 cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
@@ -94,15 +109,39 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListByteArray()).hasSize(3).containsAll(oldValues));
 
-    // Add a new values list
+    // Add same list
     assertThat(
-            target.listConcatenateBack(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+            target.listConcatenateBackByteArray(
+                cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
     List<byte[]> expectedList =
         Arrays.asList(
+            "val1".getBytes(),
+            "val2".getBytes(),
+            "val3".getBytes(),
+            "val1".getBytes(),
+            "val2".getBytes(),
+            "val3".getBytes());
+    assertThat(target.listFetch(cacheName, listName, null, null))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
+        .satisfies(
+            hit -> assertThat(hit.valueListByteArray()).hasSize(6).containsAll(expectedList));
+
+    // Add a new values list
+    assertThat(
+            target.listConcatenateBackByteArray(
+                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
+
+    List<byte[]> newExpectedList =
+        Arrays.asList(
+            "val1".getBytes(),
+            "val2".getBytes(),
+            "val3".getBytes(),
             "val1".getBytes(),
             "val2".getBytes(),
             "val3".getBytes(),
@@ -113,7 +152,7 @@ public class ListTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(
-            hit -> assertThat(hit.valueListByteArray()).hasSize(6).containsAll(expectedList));
+            hit -> assertThat(hit.valueListByteArray()).hasSize(9).containsAll(newExpectedList));
   }
 
   @Test
@@ -123,14 +162,14 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
     assertThat(
-            target.listConcatenateBack(
+            target.listConcatenateBackString(
                 null, listName, stringValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            target.listConcatenateBack(
+            target.listConcatenateBackByteArray(
                 null, listName, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
@@ -144,14 +183,14 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
     assertThat(
-            target.listConcatenateBack(
+            target.listConcatenateBackString(
                 cacheName, null, stringValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            target.listConcatenateBack(
+            target.listConcatenateBackByteArray(
                 cacheName, null, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
@@ -162,7 +201,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithPositiveStartEndIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
+        .listConcatenateBackString(
+            cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
         .join();
 
     CacheListFetchResponse cacheListFetchResponse =
@@ -179,7 +219,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNegativeStartEndIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
+        .listConcatenateBackString(
+            cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
         .join();
 
     CacheListFetchResponse cacheListFetchResponse =
@@ -196,7 +237,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNullStartIndex() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
+        .listConcatenateBackString(
+            cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
         .join();
 
     // valid case for null startIndex and positive endIndex
@@ -223,7 +265,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNullEndIndex() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
+        .listConcatenateBackString(
+            cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
         .join();
 
     // valid case for positive startIndex and null endIndex
@@ -250,7 +293,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithInvalidIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
+        .listConcatenateBackString(
+            cacheName, listName, values, CollectionTtl.of(DEFAULT_TTL_SECONDS), 0)
         .join();
 
     // the positive startIndex is larger than the positive endIndex
@@ -280,7 +324,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateFront(
+            target.listConcatenateFrontString(
                 cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -290,18 +334,33 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(3).containsAll(oldValues));
 
-    // Add a new values list
+    // Add same list
     assertThat(
-            target.listConcatenateFront(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+            target.listConcatenateFrontString(
+                cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
-    List<String> expectedList = Arrays.asList("val4", "val5", "val6", "val1", "val2", "val3");
+    List<String> expectedList = Arrays.asList("val1", "val2", "val3", "val1", "val2", "val3");
     assertThat(target.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
+
+    // Add a new values list
+    assertThat(
+            target.listConcatenateFrontString(
+                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
+
+    List<String> newExpectedList =
+        Arrays.asList("val4", "val5", "val6", "val1", "val2", "val3", "val1", "val2", "val3");
+    assertThat(target.listFetch(cacheName, listName, null, null))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
+        .satisfies(
+            hit -> assertThat(hit.valueListString()).hasSize(9).containsAll(newExpectedList));
   }
 
   @Test
@@ -314,7 +373,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateFront(
+            target.listConcatenateFrontByteArray(
                 cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -324,18 +383,18 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListByteArray()).hasSize(3).containsAll(oldValues));
 
-    // Add a new values list
+    // Add same list
     assertThat(
-            target.listConcatenateFront(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+            target.listConcatenateFrontByteArray(
+                cacheName, listName, oldValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
     List<byte[]> expectedList =
         Arrays.asList(
-            "val4".getBytes(),
-            "val5".getBytes(),
-            "val6".getBytes(),
+            "val1".getBytes(),
+            "val2".getBytes(),
+            "val3".getBytes(),
             "val1".getBytes(),
             "val2".getBytes(),
             "val3".getBytes());
@@ -344,6 +403,30 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(
             hit -> assertThat(hit.valueListByteArray()).hasSize(6).containsAll(expectedList));
+
+    // Add a new values list
+    assertThat(
+            target.listConcatenateFrontByteArray(
+                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
+
+    List<byte[]> newExpectedList =
+        Arrays.asList(
+            "val4".getBytes(),
+            "val5".getBytes(),
+            "val6".getBytes(),
+            "val1".getBytes(),
+            "val2".getBytes(),
+            "val3".getBytes(),
+            "val1".getBytes(),
+            "val2".getBytes(),
+            "val3".getBytes());
+    assertThat(target.listFetch(cacheName, listName, null, null))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
+        .satisfies(
+            hit -> assertThat(hit.valueListByteArray()).hasSize(9).containsAll(newExpectedList));
   }
 
   @Test
@@ -353,14 +436,14 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
     assertThat(
-            target.listConcatenateFront(
+            target.listConcatenateFrontString(
                 null, listName, stringValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            target.listConcatenateFront(
+            target.listConcatenateFrontByteArray(
                 null, listName, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
@@ -374,14 +457,14 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
     assertThat(
-            target.listConcatenateFront(
+            target.listConcatenateFrontString(
                 cacheName, null, stringValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            target.listConcatenateFront(
+            target.listConcatenateFrontByteArray(
                 cacheName, null, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -14,6 +14,7 @@ import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheIncrementResponse;
 import momento.sdk.messages.CacheListConcatenateBackResponse;
+import momento.sdk.messages.CacheListConcatenateFrontResponse;
 import momento.sdk.messages.CacheListFetchResponse;
 import momento.sdk.messages.CacheSetAddElementResponse;
 import momento.sdk.messages.CacheSetAddElementsResponse;
@@ -504,6 +505,48 @@ public final class CacheClient implements Closeable {
       CollectionTtl ttl,
       int truncateFrontToSize) {
     return scsDataClient.listConcatenateBack(cacheName, listName, values, ttl, truncateFrontToSize);
+  }
+
+  /**
+   * Concatenates values to the front of the list.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param listName The list in which the value is to be added.
+   * @param values The elements to add to the list.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(String, Duration)}
+   * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list concatenate back operation.
+   */
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
+      String cacheName,
+      String listName,
+      List<String> values,
+      CollectionTtl ttl,
+      Integer truncateBackToSize) {
+    return scsDataClient.listConcatenateFront(cacheName, listName, values, ttl, truncateBackToSize);
+  }
+
+  /**
+   * Concatenates values to the front of the list.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param listName The list in which the value is to be added.
+   * @param values The elements to add to the list.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(String, Duration)}
+   * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list concatenate back operation.
+   */
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
+      String cacheName,
+      String listName,
+      List<byte[]> values,
+      CollectionTtl ttl,
+      int truncateBackToSize) {
+    return scsDataClient.listConcatenateFront(cacheName, listName, values, ttl, truncateBackToSize);
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -477,13 +477,14 @@ public final class CacheClient implements Closeable {
    *     list. Must be positive.
    * @return Future containing the result of the list concatenate back operation.
    */
-  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
+  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
       String cacheName,
       String listName,
       List<String> values,
       CollectionTtl ttl,
-      Integer truncateFrontToSize) {
-    return scsDataClient.listConcatenateBack(cacheName, listName, values, ttl, truncateFrontToSize);
+      int truncateFrontToSize) {
+    return scsDataClient.listConcatenateBackString(
+        cacheName, listName, values, ttl, truncateFrontToSize);
   }
 
   /**
@@ -498,13 +499,14 @@ public final class CacheClient implements Closeable {
    *     list. Must be positive.
    * @return Future containing the result of the list concatenate back operation.
    */
-  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
+  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
       String cacheName,
       String listName,
       List<byte[]> values,
       CollectionTtl ttl,
       int truncateFrontToSize) {
-    return scsDataClient.listConcatenateBack(cacheName, listName, values, ttl, truncateFrontToSize);
+    return scsDataClient.listConcatenateBackByteArray(
+        cacheName, listName, values, ttl, truncateFrontToSize);
   }
 
   /**
@@ -519,13 +521,14 @@ public final class CacheClient implements Closeable {
    *     list. Must be positive.
    * @return Future containing the result of the list concatenate back operation.
    */
-  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
       String cacheName,
       String listName,
       List<String> values,
       CollectionTtl ttl,
-      Integer truncateBackToSize) {
-    return scsDataClient.listConcatenateFront(cacheName, listName, values, ttl, truncateBackToSize);
+      int truncateBackToSize) {
+    return scsDataClient.listConcatenateFrontString(
+        cacheName, listName, values, ttl, truncateBackToSize);
   }
 
   /**
@@ -540,13 +543,14 @@ public final class CacheClient implements Closeable {
    *     list. Must be positive.
    * @return Future containing the result of the list concatenate back operation.
    */
-  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
       String cacheName,
       String listName,
       List<byte[]> values,
       CollectionTtl ttl,
       int truncateBackToSize) {
-    return scsDataClient.listConcatenateFront(cacheName, listName, values, ttl, truncateBackToSize);
+    return scsDataClient.listConcatenateFrontByteArray(
+        cacheName, listName, values, ttl, truncateBackToSize);
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -360,12 +360,12 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
+  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
       String cacheName,
       String listName,
       List<String> values,
       CollectionTtl ttl,
-      Integer truncateFrontToSize) {
+      int truncateFrontToSize) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -380,7 +380,7 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
+  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
       String cacheName,
       String listName,
       List<byte[]> values,
@@ -400,12 +400,12 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
+  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
       String cacheName,
       String listName,
       List<String> values,
       CollectionTtl ttl,
-      Integer truncateBackToSize) {
+      int truncateBackToSize) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -420,7 +420,7 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
+  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
       String cacheName,
       String listName,
       List<byte[]> values,
@@ -1031,7 +1031,7 @@ final class ScsDataClient implements Closeable {
       ByteString listName,
       List<ByteString> values,
       CollectionTtl ttl,
-      Integer truncateFrontToSize) {
+      int truncateFrontToSize) {
     final Optional<Span> span = buildSpan("java-sdk-listConcatenateBack-request");
     final Optional<Scope> scope = (span.map(ImplicitContextKeyed::makeCurrent));
 
@@ -1096,7 +1096,7 @@ final class ScsDataClient implements Closeable {
       ByteString listName,
       List<ByteString> values,
       CollectionTtl ttl,
-      Integer truncateBackToSize) {
+      int truncateBackToSize) {
     final Optional<Span> span = buildSpan("java-sdk-listConcatenateFront-request");
     final Optional<Scope> scope = (span.map(ImplicitContextKeyed::makeCurrent));
 

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheListConcatenateFrontResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheListConcatenateFrontResponse.java
@@ -3,14 +3,14 @@ package momento.sdk.messages;
 import momento.sdk.exceptions.SdkException;
 
 /**
- * Parent response type for a list concatenate back request. The response object is resolved to a
+ * Parent response type for a list concatenate front request. The response object is resolved to a
  * type-safe object of one of the following subtypes:
  *
  * <p>{Success}, {Error}
  */
-public interface CacheListConcatenateBackResponse {
-  /** A successful list concatenate back operation. */
-  class Success implements CacheListConcatenateBackResponse {
+public interface CacheListConcatenateFrontResponse {
+  /** A successful list concatenate front operation. */
+  class Success implements CacheListConcatenateFrontResponse {
     private int listLength;
 
     public Success(int listLength) {
@@ -29,14 +29,14 @@ public interface CacheListConcatenateBackResponse {
   }
 
   /**
-   * A failed list concatenate back operation. The response itself is an exception, so it can be
+   * A failed list concatenate front operation. The response itself is an exception, so it can be
    * directly thrown, or the cause of the error can be retrieved with {@link #getClass()} ()}. The
    * message is a copy of the message of the cause.
    */
-  class Error extends SdkException implements CacheListConcatenateBackResponse {
+  class Error extends SdkException implements CacheListConcatenateFrontResponse {
 
     /**
-     * Constructs a list concatenate back error with a cause.
+     * Constructs a list concatenate front error with a cause.
      *
      * @param cause the cause.
      */


### PR DESCRIPTION
## PR Description:
### Commit 1
- Add CacheListConcatenateFront API
- Refactor CacheListConcatenateBack to match the front api
- Add/Refactor integ tests

### Commit 2
- Fix Integer to int for truncateFrontToSize & TruncateBackToSize
- As a result of above, had to split the String and ByteArray function names to avoid methods with same erasure exception
- Add tests to validate that same list can be added to front/back of the list

## Build
`./gradlew :momento-sdk:spotlessApply && ./gradlew clean build`

## Issue
#170 