### PR TITLE
feat: Add method signatures that do not take ttl for list collections

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -78,10 +78,8 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
-    // Add a new values list
-    assertThat(
-            target.listConcatenateBackString(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new values list without specifying ttl
+    assertThat(target.listConcatenateBackString(cacheName, listName, newValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -135,10 +133,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(
             hit -> assertThat(hit.valueListByteArray()).hasSize(6).containsAll(expectedList));
 
-    // Add a new values list
-    assertThat(
-            target.listConcatenateBackByteArray(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new values list without specifying ttl
+    assertThat(target.listConcatenateBackByteArray(cacheName, listName, newValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -166,6 +162,7 @@ public class ListTest extends BaseTestClass {
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackString(
                 null, listName, stringValues, CollectionTtl.fromCacheTtl(), 0))
@@ -173,9 +170,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateBackString(null, listName, stringValues, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackByteArray(
                 null, listName, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateBackByteArray(null, listName, byteArrayValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -187,6 +197,7 @@ public class ListTest extends BaseTestClass {
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackString(
                 cacheName, null, stringValues, CollectionTtl.fromCacheTtl(), 0))
@@ -194,9 +205,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateBackString(cacheName, null, stringValues, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackByteArray(
                 cacheName, null, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateBackByteArray(cacheName, null, byteArrayValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -204,6 +228,7 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFailListConcatenateBackWhenNullElement() {
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackString(
                 cacheName, listName, null, CollectionTtl.fromCacheTtl(), 0))
@@ -211,9 +236,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateBackString(cacheName, listName, null, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackByteArray(
                 cacheName, listName, null, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateBackByteArray(cacheName, listName, null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -369,10 +407,8 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
-    // Add a new values list
-    assertThat(
-            target.listConcatenateFrontString(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new values list without specifying ttl
+    assertThat(target.listConcatenateFrontString(cacheName, listName, newValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -426,10 +462,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(
             hit -> assertThat(hit.valueListByteArray()).hasSize(6).containsAll(expectedList));
 
-    // Add a new values list
-    assertThat(
-            target.listConcatenateFrontByteArray(
-                cacheName, listName, newValues, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new values list without specifying ttl
+    assertThat(target.listConcatenateFrontByteArray(cacheName, listName, newValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -457,6 +491,7 @@ public class ListTest extends BaseTestClass {
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateFrontString(
                 null, listName, stringValues, CollectionTtl.fromCacheTtl(), 0))
@@ -464,6 +499,21 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateFrontString(null, listName, stringValues, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
+    assertThat(
+            target.listConcatenateFrontByteArray(
+                null, listName, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
     assertThat(
             target.listConcatenateFrontByteArray(
                 null, listName, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
@@ -478,6 +528,7 @@ public class ListTest extends BaseTestClass {
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateFrontString(
                 cacheName, null, stringValues, CollectionTtl.fromCacheTtl(), 0))
@@ -485,9 +536,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateFrontString(cacheName, null, stringValues, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateFrontByteArray(
                 cacheName, null, byteArrayValues, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateFrontByteArray(cacheName, null, byteArrayValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -495,6 +559,7 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFailListConcatenateFrontWhenNullElement() {
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateFrontString(
                 cacheName, listName, null, CollectionTtl.fromCacheTtl(), 0))
@@ -502,9 +567,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateFrontString(cacheName, listName, null, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listConcatenateFrontByteArray(
                 cacheName, listName, null, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listConcatenateFrontByteArray(cacheName, listName, null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -679,8 +757,8 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(2).containsAll(expectedList));
 
-    // Add a new value
-    assertThat(target.listPushBack(cacheName, listName, newValue, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new value without specifying ttl
+    assertThat(target.listPushBack(cacheName, listName, newValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -722,8 +800,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(
             hit -> assertThat(hit.valueListByteArray()).hasSize(2).containsAll(expectedList));
 
-    // Add a new value
-    assertThat(target.listPushBack(cacheName, listName, newValue, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new value without specifying ttl
+    assertThat(target.listPushBack(cacheName, listName, newValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -741,12 +819,26 @@ public class ListTest extends BaseTestClass {
     final String stringValue = "val1";
     final byte[] byteArrayValue = "val1".getBytes();
 
+    // With ttl specified in method signature
     assertThat(target.listPushBack(null, listName, stringValue, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listPushBack(null, listName, stringValue, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(target.listPushBack(null, listName, byteArrayValue, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listPushBack(null, listName, byteArrayValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -757,13 +849,27 @@ public class ListTest extends BaseTestClass {
     final String stringValue = "val1";
     final byte[] byteArrayValue = "val1".getBytes();
 
+    // With ttl specified in method signature
     assertThat(target.listPushBack(cacheName, null, stringValue, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listPushBack(cacheName, null, stringValue, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listPushBack(cacheName, null, byteArrayValue, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listPushBack(cacheName, null, byteArrayValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -771,6 +877,7 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFailListPushBackWhenNullElement() {
+    // With ttl specified in method signature
     assertThat(
             target.listPushBack(
                 cacheName, listName, (String) null, CollectionTtl.fromCacheTtl(), 0))
@@ -778,9 +885,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listPushBack(cacheName, listName, (String) null, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listPushBack(
                 cacheName, listName, (byte[]) null, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listPushBack(cacheName, listName, (byte[]) null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -815,8 +935,8 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(2).containsAll(expectedList));
 
-    // Add a new value
-    assertThat(target.listPushFront(cacheName, listName, newValue, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new value without specifying ttl
+    assertThat(target.listPushFront(cacheName, listName, newValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -858,8 +978,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(
             hit -> assertThat(hit.valueListByteArray()).hasSize(2).containsAll(expectedList));
 
-    // Add a new value
-    assertThat(target.listPushFront(cacheName, listName, newValue, CollectionTtl.fromCacheTtl(), 0))
+    // Add a new value without specifying ttl
+    assertThat(target.listPushFront(cacheName, listName, newValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -877,13 +997,27 @@ public class ListTest extends BaseTestClass {
     final String stringValue = "val1";
     final byte[] byteArrayValue = "val1".getBytes();
 
+    // With ttl specified in method signature
     assertThat(target.listPushFront(null, listName, stringValue, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listPushFront(null, listName, stringValue, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listPushFront(null, listName, byteArrayValue, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listPushFront(null, listName, byteArrayValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -894,13 +1028,27 @@ public class ListTest extends BaseTestClass {
     final String stringValue = "val1";
     final byte[] byteArrayValue = "val1".getBytes();
 
+    // With ttl specified in method signature
     assertThat(target.listPushFront(cacheName, null, stringValue, CollectionTtl.fromCacheTtl(), 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listPushFront(cacheName, null, stringValue, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listPushFront(cacheName, null, byteArrayValue, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listPushFront(cacheName, null, byteArrayValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -908,6 +1056,7 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFailListPushFrontWhenNullElement() {
+    // With ttl specified in method signature
     assertThat(
             target.listPushFront(
                 cacheName, listName, (String) null, CollectionTtl.fromCacheTtl(), 0))
@@ -915,9 +1064,22 @@ public class ListTest extends BaseTestClass {
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
+    // Without ttl specified in method signature
+    assertThat(target.listPushFront(cacheName, listName, (String) null, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
     assertThat(
             target.listPushFront(
                 cacheName, listName, (byte[]) null, CollectionTtl.fromCacheTtl(), 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(target.listPushFront(cacheName, listName, (byte[]) null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -522,6 +522,22 @@ public final class CacheClient implements Closeable {
    * @param cacheName Name of the cache to store the item in
    * @param listName The list in which the value is to be added.
    * @param values The elements to add to the list.
+   * @param truncateFrontToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list concatenate back operation.
+   */
+  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
+      String cacheName, String listName, List<String> values, int truncateFrontToSize) {
+    return scsDataClient.listConcatenateBackString(
+        cacheName, listName, values, truncateFrontToSize);
+  }
+
+  /**
+   * Concatenates values to the back of the list.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param listName The list in which the value is to be added.
+   * @param values The elements to add to the list.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(String, Duration)}
    * @param truncateFrontToSize If the list exceeds this length, remove excess from the front of the
@@ -536,6 +552,22 @@ public final class CacheClient implements Closeable {
       int truncateFrontToSize) {
     return scsDataClient.listConcatenateBackByteArray(
         cacheName, listName, values, ttl, truncateFrontToSize);
+  }
+
+  /**
+   * Concatenates values to the back of the list.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param listName The list in which the value is to be added.
+   * @param values The elements to add to the list.
+   * @param truncateFrontToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list concatenate back operation.
+   */
+  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
+      String cacheName, String listName, List<byte[]> values, int truncateFrontToSize) {
+    return scsDataClient.listConcatenateBackByteArray(
+        cacheName, listName, values, truncateFrontToSize);
   }
 
   /**
@@ -566,6 +598,22 @@ public final class CacheClient implements Closeable {
    * @param cacheName Name of the cache to store the item in
    * @param listName The list in which the value is to be added.
    * @param values The elements to add to the list.
+   * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list concatenate front operation.
+   */
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
+      String cacheName, String listName, List<String> values, int truncateBackToSize) {
+    return scsDataClient.listConcatenateFrontString(
+        cacheName, listName, values, truncateBackToSize);
+  }
+
+  /**
+   * Concatenates values to the front of the list.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param listName The list in which the value is to be added.
+   * @param values The elements to add to the list.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(String, Duration)}
    * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
@@ -580,6 +628,22 @@ public final class CacheClient implements Closeable {
       int truncateBackToSize) {
     return scsDataClient.listConcatenateFrontByteArray(
         cacheName, listName, values, ttl, truncateBackToSize);
+  }
+
+  /**
+   * Concatenates values to the front of the list.
+   *
+   * @param cacheName Name of the cache to store the item in
+   * @param listName The list in which the value is to be added.
+   * @param values The elements to add to the list.
+   * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list concatenate front operation.
+   */
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
+      String cacheName, String listName, List<byte[]> values, int truncateBackToSize) {
+    return scsDataClient.listConcatenateFrontByteArray(
+        cacheName, listName, values, truncateBackToSize);
   }
 
   /**
@@ -658,6 +722,21 @@ public final class CacheClient implements Closeable {
    * @param cacheName Name of the cache to store the value in
    * @param listName The list in which the value is to be added.
    * @param value The element to add to the list.
+   * @param truncateFrontToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list push back operation.
+   */
+  public CompletableFuture<CacheListPushBackResponse> listPushBack(
+      String cacheName, String listName, String value, int truncateFrontToSize) {
+    return scsDataClient.listPushBack(cacheName, listName, value, truncateFrontToSize);
+  }
+
+  /**
+   * Pushes a value to the back of the list.
+   *
+   * @param cacheName Name of the cache to store the value in
+   * @param listName The list in which the value is to be added.
+   * @param value The element to add to the list.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(String, Duration)}
    * @param truncateFrontToSize If the list exceeds this length, remove excess from the front of the
@@ -671,6 +750,21 @@ public final class CacheClient implements Closeable {
       @Nullable CollectionTtl ttl,
       int truncateFrontToSize) {
     return scsDataClient.listPushBack(cacheName, listName, value, ttl, truncateFrontToSize);
+  }
+
+  /**
+   * Pushes a value to the back of the list.
+   *
+   * @param cacheName Name of the cache to store the value in
+   * @param listName The list in which the value is to be added.
+   * @param value The element to add to the list.
+   * @param truncateFrontToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list push back operation.
+   */
+  public CompletableFuture<CacheListPushBackResponse> listPushBack(
+      String cacheName, String listName, byte[] value, int truncateFrontToSize) {
+    return scsDataClient.listPushBack(cacheName, listName, value, truncateFrontToSize);
   }
 
   /**
@@ -700,6 +794,21 @@ public final class CacheClient implements Closeable {
    * @param cacheName Name of the cache to store the value in
    * @param listName The list in which the value is to be added.
    * @param value The element to add to the list.
+   * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list push front operation.
+   */
+  public CompletableFuture<CacheListPushFrontResponse> listPushFront(
+      String cacheName, String listName, String value, int truncateBackToSize) {
+    return scsDataClient.listPushFront(cacheName, listName, value, truncateBackToSize);
+  }
+
+  /**
+   * Pushes a value to the front of the list.
+   *
+   * @param cacheName Name of the cache to store the value in
+   * @param listName The list in which the value is to be added.
+   * @param value The element to add to the list.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(String, Duration)}
    * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
@@ -713,6 +822,21 @@ public final class CacheClient implements Closeable {
       @Nullable CollectionTtl ttl,
       int truncateBackToSize) {
     return scsDataClient.listPushFront(cacheName, listName, value, ttl, truncateBackToSize);
+  }
+
+  /**
+   * Pushes a value to the front of the list.
+   *
+   * @param cacheName Name of the cache to store the value in
+   * @param listName The list in which the value is to be added.
+   * @param value The element to add to the list.
+   * @param truncateBackToSize If the list exceeds this length, remove excess from the front of the
+   *     list. Must be positive.
+   * @return Future containing the result of the list push front operation.
+   */
+  public CompletableFuture<CacheListPushFrontResponse> listPushFront(
+      String cacheName, String listName, byte[] value, int truncateBackToSize) {
+    return scsDataClient.listPushFront(cacheName, listName, value, truncateBackToSize);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -528,8 +528,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
       String cacheName, String listName, List<String> values, int truncateFrontToSize) {
-    return scsDataClient.listConcatenateBackString(
-        cacheName, listName, values, truncateFrontToSize);
+    return listConcatenateBackString(cacheName, listName, values, null, truncateFrontToSize);
   }
 
   /**
@@ -566,8 +565,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
       String cacheName, String listName, List<byte[]> values, int truncateFrontToSize) {
-    return scsDataClient.listConcatenateBackByteArray(
-        cacheName, listName, values, truncateFrontToSize);
+    return listConcatenateBackByteArray(cacheName, listName, values, null, truncateFrontToSize);
   }
 
   /**
@@ -604,8 +602,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
       String cacheName, String listName, List<String> values, int truncateBackToSize) {
-    return scsDataClient.listConcatenateFrontString(
-        cacheName, listName, values, truncateBackToSize);
+    return listConcatenateFrontString(cacheName, listName, values, null, truncateBackToSize);
   }
 
   /**
@@ -642,8 +639,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
       String cacheName, String listName, List<byte[]> values, int truncateBackToSize) {
-    return scsDataClient.listConcatenateFrontByteArray(
-        cacheName, listName, values, truncateBackToSize);
+    return listConcatenateFrontByteArray(cacheName, listName, values, null, truncateBackToSize);
   }
 
   /**
@@ -728,7 +724,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListPushBackResponse> listPushBack(
       String cacheName, String listName, String value, int truncateFrontToSize) {
-    return scsDataClient.listPushBack(cacheName, listName, value, truncateFrontToSize);
+    return listPushBack(cacheName, listName, value, null, truncateFrontToSize);
   }
 
   /**
@@ -764,7 +760,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListPushBackResponse> listPushBack(
       String cacheName, String listName, byte[] value, int truncateFrontToSize) {
-    return scsDataClient.listPushBack(cacheName, listName, value, truncateFrontToSize);
+    return listPushBack(cacheName, listName, value, null, truncateFrontToSize);
   }
 
   /**
@@ -800,7 +796,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListPushFrontResponse> listPushFront(
       String cacheName, String listName, String value, int truncateBackToSize) {
-    return scsDataClient.listPushFront(cacheName, listName, value, truncateBackToSize);
+    return listPushFront(cacheName, listName, value, null, truncateBackToSize);
   }
 
   /**
@@ -836,7 +832,7 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheListPushFrontResponse> listPushFront(
       String cacheName, String listName, byte[] value, int truncateBackToSize) {
-    return scsDataClient.listPushFront(cacheName, listName, value, truncateBackToSize);
+    return listPushFront(cacheName, listName, value, null, truncateBackToSize);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -408,6 +408,25 @@ final class ScsDataClient implements Closeable {
     }
   }
 
+  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
+      String cacheName, String listName, List<String> values, int truncateFrontToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(values);
+
+      return sendListConcatenateBack(
+          cacheName,
+          convert(listName),
+          convertStringList(values),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateFrontToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
   CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
       String cacheName,
       String listName,
@@ -425,6 +444,25 @@ final class ScsDataClient implements Closeable {
 
       return sendListConcatenateBack(
           cacheName, convert(listName), convertByteArrayList(values), ttl, truncateFrontToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
+      String cacheName, String listName, List<byte[]> values, int truncateFrontToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(values);
+
+      return sendListConcatenateBack(
+          cacheName,
+          convert(listName),
+          convertByteArrayList(values),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateFrontToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -454,6 +492,25 @@ final class ScsDataClient implements Closeable {
     }
   }
 
+  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
+      String cacheName, String listName, List<String> values, int truncateBackToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(values);
+
+      return sendListConcatenateFront(
+          cacheName,
+          convert(listName),
+          convertStringList(values),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateBackToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
   CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
       String cacheName,
       String listName,
@@ -471,6 +528,25 @@ final class ScsDataClient implements Closeable {
 
       return sendListConcatenateFront(
           cacheName, convert(listName), convertByteArrayList(values), ttl, truncateBackToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
+      String cacheName, String listName, List<byte[]> values, int truncateBackToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(values);
+
+      return sendListConcatenateFront(
+          cacheName,
+          convert(listName),
+          convertByteArrayList(values),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateBackToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -547,6 +623,25 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheListPushBackResponse> listPushBack(
+      String cacheName, String listName, String value, int truncateFrontToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(value);
+
+      return sendListPushBack(
+          cacheName,
+          convert(listName),
+          convert(value),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateFrontToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheListPushBackResponse> listPushBack(
       String cacheName,
       String listName,
       byte[] value,
@@ -563,6 +658,25 @@ final class ScsDataClient implements Closeable {
 
       return sendListPushBack(
           cacheName, convert(listName), convert(value), ttl, truncateFrontToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheListPushBackResponse> listPushBack(
+      String cacheName, String listName, byte[] value, int truncateFrontToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(value);
+
+      return sendListPushBack(
+          cacheName,
+          convert(listName),
+          convert(value),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateFrontToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -593,6 +707,25 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheListPushFrontResponse> listPushFront(
+      String cacheName, String listName, String value, int truncateBackToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(value);
+
+      return sendListPushFront(
+          cacheName,
+          convert(listName),
+          convert(value),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateBackToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheListPushFrontResponse> listPushFront(
       String cacheName,
       String listName,
       byte[] value,
@@ -609,6 +742,25 @@ final class ScsDataClient implements Closeable {
 
       return sendListPushFront(
           cacheName, convert(listName), convert(value), ttl, truncateBackToSize);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheListPushFrontResponse> listPushFront(
+      String cacheName, String listName, byte[] value, int truncateBackToSize) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkListNameValid(listName);
+      ensureValidValue(value);
+
+      return sendListPushFront(
+          cacheName,
+          convert(listName),
+          convert(value),
+          CollectionTtl.of(itemDefaultTtl),
+          truncateBackToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -408,25 +408,6 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
-      String cacheName, String listName, List<String> values, int truncateFrontToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(values);
-
-      return sendListConcatenateBack(
-          cacheName,
-          convert(listName),
-          convertStringList(values),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateFrontToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
   CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
       String cacheName,
       String listName,
@@ -444,25 +425,6 @@ final class ScsDataClient implements Closeable {
 
       return sendListConcatenateBack(
           cacheName, convert(listName), convertByteArrayList(values), ttl, truncateFrontToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
-      String cacheName, String listName, List<byte[]> values, int truncateFrontToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(values);
-
-      return sendListConcatenateBack(
-          cacheName,
-          convert(listName),
-          convertByteArrayList(values),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateFrontToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -492,25 +454,6 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
-      String cacheName, String listName, List<String> values, int truncateBackToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(values);
-
-      return sendListConcatenateFront(
-          cacheName,
-          convert(listName),
-          convertStringList(values),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateBackToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
   CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
       String cacheName,
       String listName,
@@ -528,25 +471,6 @@ final class ScsDataClient implements Closeable {
 
       return sendListConcatenateFront(
           cacheName, convert(listName), convertByteArrayList(values), ttl, truncateBackToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
-      String cacheName, String listName, List<byte[]> values, int truncateBackToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(values);
-
-      return sendListConcatenateFront(
-          cacheName,
-          convert(listName),
-          convertByteArrayList(values),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateBackToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -623,25 +547,6 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheListPushBackResponse> listPushBack(
-      String cacheName, String listName, String value, int truncateFrontToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(value);
-
-      return sendListPushBack(
-          cacheName,
-          convert(listName),
-          convert(value),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateFrontToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheListPushBackResponse> listPushBack(
       String cacheName,
       String listName,
       byte[] value,
@@ -658,25 +563,6 @@ final class ScsDataClient implements Closeable {
 
       return sendListPushBack(
           cacheName, convert(listName), convert(value), ttl, truncateFrontToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheListPushBackResponse> listPushBack(
-      String cacheName, String listName, byte[] value, int truncateFrontToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(value);
-
-      return sendListPushBack(
-          cacheName,
-          convert(listName),
-          convert(value),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateFrontToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -707,25 +593,6 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheListPushFrontResponse> listPushFront(
-      String cacheName, String listName, String value, int truncateBackToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(value);
-
-      return sendListPushFront(
-          cacheName,
-          convert(listName),
-          convert(value),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateBackToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheListPushFrontResponse> listPushFront(
       String cacheName,
       String listName,
       byte[] value,
@@ -742,25 +609,6 @@ final class ScsDataClient implements Closeable {
 
       return sendListPushFront(
           cacheName, convert(listName), convert(value), ttl, truncateBackToSize);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheListPushFrontResponse> listPushFront(
-      String cacheName, String listName, byte[] value, int truncateBackToSize) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkListNameValid(listName);
-      ensureValidValue(value);
-
-      return sendListPushFront(
-          cacheName,
-          convert(listName),
-          convert(value),
-          CollectionTtl.of(itemDefaultTtl),
-          truncateBackToSize);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));


### PR DESCRIPTION
## PR Description:
- Add method signatures that do not take ttl for list collections
- Refactor related integ tests

## Issue
#170, #201 

