### PR TITLE
feat: Add dictionarySetFields API

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -3,6 +3,9 @@ package momento.sdk;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.auth.EnvVarCredentialProvider;
@@ -10,6 +13,7 @@ import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.messages.CacheDictionaryFetchResponse;
 import momento.sdk.messages.CacheDictionarySetFieldResponse;
+import momento.sdk.messages.CacheDictionarySetFieldsResponse;
 import momento.sdk.requests.CollectionTtl;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +29,32 @@ public class DictionaryTest extends BaseTestClass {
       new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
   private final String dictionaryName = "test-dictionary";
+
+  AbstractMap.SimpleEntry<String, String> stringStringPair1 =
+      new AbstractMap.SimpleEntry<>("a", "b");
+  AbstractMap.SimpleEntry<String, String> stringStringPair2 =
+      new AbstractMap.SimpleEntry<>("aa", "bb");
+  AbstractMap.SimpleEntry<String, byte[]> stringBytesPair1 =
+      new AbstractMap.SimpleEntry<>("c", "d".getBytes());
+  AbstractMap.SimpleEntry<String, byte[]> stringBytesPair2 =
+      new AbstractMap.SimpleEntry<>("cc", "dd".getBytes());
+  AbstractMap.SimpleEntry<byte[], String> bytesStringPair1 =
+      new AbstractMap.SimpleEntry<>("e".getBytes(), "f");
+  AbstractMap.SimpleEntry<byte[], String> bytesStringPair2 =
+      new AbstractMap.SimpleEntry<>("ee".getBytes(), "ff");
+  AbstractMap.SimpleEntry<byte[], byte[]> bytesBytesPair1 =
+      new AbstractMap.SimpleEntry<>("g".getBytes(), "h".getBytes());
+  AbstractMap.SimpleEntry<byte[], byte[]> bytesBytesPair2 =
+      new AbstractMap.SimpleEntry<>("gg".getBytes(), "hh".getBytes());
+
+  List<AbstractMap.SimpleEntry<String, String>> stringStringPairList =
+      Arrays.asList(stringStringPair1, stringStringPair2);
+  List<AbstractMap.SimpleEntry<String, byte[]>> stringBytesPairList =
+      Arrays.asList(stringBytesPair1, stringBytesPair2);
+  List<AbstractMap.SimpleEntry<byte[], String>> bytesStringPairList =
+      Arrays.asList(bytesStringPair1, bytesStringPair2);
+  List<AbstractMap.SimpleEntry<byte[], byte[]>> bytesBytesPairList =
+      Arrays.asList(bytesBytesPair1, bytesBytesPair2);
 
   @BeforeEach
   void setup() {
@@ -250,7 +280,11 @@ public class DictionaryTest extends BaseTestClass {
     // String Key and Byte value
     assertThat(
             target.dictionarySetField(
-                cacheName, null, (String) null, "b".getBytes(), CollectionTtl.fromCacheTtl()))
+                cacheName,
+                dictionaryName,
+                (String) null,
+                "b".getBytes(),
+                CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -258,7 +292,7 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and String value
     assertThat(
             target.dictionarySetField(
-                cacheName, null, (byte[]) null, "b", CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, (byte[]) null, "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -266,7 +300,11 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and Byte value
     assertThat(
             target.dictionarySetField(
-                cacheName, null, (byte[]) null, "b".getBytes(), CollectionTtl.fromCacheTtl()))
+                cacheName,
+                dictionaryName,
+                (byte[]) null,
+                "b".getBytes(),
+                CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -285,7 +323,7 @@ public class DictionaryTest extends BaseTestClass {
     // String Key and Byte value
     assertThat(
             target.dictionarySetField(
-                cacheName, null, "a", (byte[]) null, CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, "a", (byte[]) null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -301,7 +339,11 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and Byte value
     assertThat(
             target.dictionarySetField(
-                cacheName, null, "a".getBytes(), (byte[]) null, CollectionTtl.fromCacheTtl()))
+                cacheName,
+                dictionaryName,
+                "a".getBytes(),
+                (byte[]) null,
+                CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -328,5 +370,255 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(target.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionaryFetchResponse.Miss.class);
+  }
+
+  @Test
+  public void dictionarySetFieldsAndDictionaryFetchAndHappyPath() {
+    // Set String key, String value
+    assertThat(
+            target.dictionarySetFieldsStringString(
+                cacheName, dictionaryName, stringStringPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<String, String> stringStringMap = hit.valueDictionaryStringString();
+              assertThat(stringStringMap.keySet()).hasSize(2).contains("a", "aa");
+              assertThat(stringStringMap.values()).contains("bb", "bb");
+            });
+
+    // Set String key, byte array value
+    assertThat(
+            target.dictionarySetFieldsStringBytes(
+                cacheName, dictionaryName, stringBytesPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<String, byte[]> stringBytesMap = hit.valueDictionaryStringBytes();
+              assertThat(stringBytesMap.keySet()).hasSize(4).contains("c", "cc");
+              assertThat(stringBytesMap.values()).contains("d".getBytes(), "dd".getBytes());
+            });
+
+    // Set byte array key, String value
+    assertThat(
+            target.dictionarySetFieldsBytesString(
+                cacheName, dictionaryName, bytesStringPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<byte[], String> bytesStringMap = hit.valueDictionaryBytesString();
+              assertThat(bytesStringMap.keySet())
+                  .hasSize(6)
+                  .contains("e".getBytes(), "ee".getBytes());
+              assertThat(bytesStringMap.values()).contains("f", "ff");
+            });
+
+    // Set byte array key, byte array value
+    assertThat(
+            target.dictionarySetFieldsBytesBytes(
+                cacheName, dictionaryName, bytesBytesPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<byte[], byte[]> bytesStringMap = hit.valueDictionaryBytesBytes();
+              assertThat(bytesStringMap.keySet())
+                  .hasSize(8)
+                  .contains("g".getBytes(), "gg".getBytes());
+              assertThat(bytesStringMap.values()).contains("h".getBytes(), "hh".getBytes());
+            });
+  }
+
+  @Test
+  public void dictionarySetFieldsAndDictionaryFetchAndHappyPathWithNoTtl() {
+    // Set String key, String value
+    assertThat(
+            target.dictionarySetFieldsStringString(cacheName, dictionaryName, stringStringPairList))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<String, String> stringStringMap = hit.valueDictionaryStringString();
+              assertThat(stringStringMap.keySet()).hasSize(2).contains("a", "aa");
+              assertThat(stringStringMap.values()).contains("b", "bb");
+            });
+
+    // Set String key, byte array value
+    assertThat(
+            target.dictionarySetFieldsStringBytes(cacheName, dictionaryName, stringBytesPairList))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<String, byte[]> stringBytesMap = hit.valueDictionaryStringBytes();
+              assertThat(stringBytesMap.keySet()).hasSize(4).contains("c", "cc");
+              assertThat(stringBytesMap.values()).contains("d".getBytes(), "dd".getBytes());
+            });
+
+    // Set byte array key, String value
+    assertThat(
+            target.dictionarySetFieldsBytesString(cacheName, dictionaryName, bytesStringPairList))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<byte[], String> bytesStringMap = hit.valueDictionaryBytesString();
+              assertThat(bytesStringMap.keySet())
+                  .hasSize(6)
+                  .contains("e".getBytes(), "ee".getBytes());
+              assertThat(bytesStringMap.values()).contains("f", "ff");
+            });
+
+    // Set byte array key, byte array value
+    assertThat(target.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, bytesBytesPairList))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
+
+    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final Map<byte[], byte[]> bytesStringMap = hit.valueDictionaryBytesBytes();
+              assertThat(bytesStringMap.keySet())
+                  .hasSize(8)
+                  .contains("g".getBytes(), "gg".getBytes());
+              assertThat(bytesStringMap.values()).contains("h".getBytes(), "hh".getBytes());
+            });
+  }
+
+  @Test
+  public void dictionarySetFieldsReturnsErrorWithNullCacheName() {
+    // String Key and String value
+    assertThat(
+            target.dictionarySetFieldsStringString(
+                null, dictionaryName, stringStringPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // String Key and Byte value
+    assertThat(
+            target.dictionarySetFieldsStringBytes(
+                null, dictionaryName, stringBytesPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Byte key and String value
+    assertThat(
+            target.dictionarySetFieldsBytesString(
+                null, dictionaryName, bytesStringPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Byte key and Byte value
+    assertThat(
+            target.dictionarySetFieldsBytesBytes(
+                null, dictionaryName, bytesBytesPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void dictionarySetFieldsReturnsErrorWithNullDictionaryName() {
+    // String Key and String value
+    assertThat(
+            target.dictionarySetFieldsStringString(
+                cacheName, null, stringStringPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // String Key and Byte value
+    assertThat(
+            target.dictionarySetFieldsStringBytes(
+                cacheName, null, stringBytesPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Byte key and String value
+    assertThat(
+            target.dictionarySetFieldsBytesString(
+                cacheName, null, bytesStringPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Byte key and Byte value
+    assertThat(
+            target.dictionarySetFieldsBytesBytes(
+                cacheName, null, bytesBytesPairList, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void dictionarySetFieldsReturnsErrorWithNullItem() {
+    // String Key and String value
+    assertThat(
+            target.dictionarySetFieldsStringString(
+                cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // String Key and Byte value
+    assertThat(
+            target.dictionarySetFieldsStringBytes(
+                cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Byte key and String value
+    assertThat(
+            target.dictionarySetFieldsBytesString(
+                cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Byte key and Byte value
+    assertThat(
+            target.dictionarySetFieldsBytesBytes(
+                cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -3,9 +3,7 @@ package momento.sdk;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.auth.EnvVarCredentialProvider;
@@ -30,31 +28,10 @@ public class DictionaryTest extends BaseTestClass {
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
   private final String dictionaryName = "test-dictionary";
 
-  AbstractMap.SimpleEntry<String, String> stringStringPair1 =
-      new AbstractMap.SimpleEntry<>("a", "b");
-  AbstractMap.SimpleEntry<String, String> stringStringPair2 =
-      new AbstractMap.SimpleEntry<>("aa", "bb");
-  AbstractMap.SimpleEntry<String, byte[]> stringBytesPair1 =
-      new AbstractMap.SimpleEntry<>("c", "d".getBytes());
-  AbstractMap.SimpleEntry<String, byte[]> stringBytesPair2 =
-      new AbstractMap.SimpleEntry<>("cc", "dd".getBytes());
-  AbstractMap.SimpleEntry<byte[], String> bytesStringPair1 =
-      new AbstractMap.SimpleEntry<>("e".getBytes(), "f");
-  AbstractMap.SimpleEntry<byte[], String> bytesStringPair2 =
-      new AbstractMap.SimpleEntry<>("ee".getBytes(), "ff");
-  AbstractMap.SimpleEntry<byte[], byte[]> bytesBytesPair1 =
-      new AbstractMap.SimpleEntry<>("g".getBytes(), "h".getBytes());
-  AbstractMap.SimpleEntry<byte[], byte[]> bytesBytesPair2 =
-      new AbstractMap.SimpleEntry<>("gg".getBytes(), "hh".getBytes());
-
-  List<AbstractMap.SimpleEntry<String, String>> stringStringPairList =
-      Arrays.asList(stringStringPair1, stringStringPair2);
-  List<AbstractMap.SimpleEntry<String, byte[]>> stringBytesPairList =
-      Arrays.asList(stringBytesPair1, stringBytesPair2);
-  List<AbstractMap.SimpleEntry<byte[], String>> bytesStringPairList =
-      Arrays.asList(bytesStringPair1, bytesStringPair2);
-  List<AbstractMap.SimpleEntry<byte[], byte[]>> bytesBytesPairList =
-      Arrays.asList(bytesBytesPair1, bytesBytesPair2);
+  Map<String, String> stringStringMap = new HashMap<>();
+  Map<String, byte[]> stringBytesMap = new HashMap<>();
+  Map<byte[], String> bytesStringMap = new HashMap<>();
+  Map<byte[], byte[]> bytesBytesMap = new HashMap<>();
 
   @BeforeEach
   void setup() {
@@ -374,10 +351,12 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionarySetFieldsAndDictionaryFetchAndHappyPath() {
+    populateTestMaps();
+
     // Set String key, String value
     assertThat(
             target.dictionarySetFieldsStringString(
-                cacheName, dictionaryName, stringStringPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -394,7 +373,7 @@ public class DictionaryTest extends BaseTestClass {
     // Set String key, byte array value
     assertThat(
             target.dictionarySetFieldsStringBytes(
-                cacheName, dictionaryName, stringBytesPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, stringBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -411,7 +390,7 @@ public class DictionaryTest extends BaseTestClass {
     // Set byte array key, String value
     assertThat(
             target.dictionarySetFieldsBytesString(
-                cacheName, dictionaryName, bytesStringPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, bytesStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -430,7 +409,7 @@ public class DictionaryTest extends BaseTestClass {
     // Set byte array key, byte array value
     assertThat(
             target.dictionarySetFieldsBytesBytes(
-                cacheName, dictionaryName, bytesBytesPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, bytesBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -449,9 +428,10 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionarySetFieldsAndDictionaryFetchAndHappyPathWithNoTtl() {
+    populateTestMaps();
+
     // Set String key, String value
-    assertThat(
-            target.dictionarySetFieldsStringString(cacheName, dictionaryName, stringStringPairList))
+    assertThat(target.dictionarySetFieldsStringString(cacheName, dictionaryName, stringStringMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -466,8 +446,7 @@ public class DictionaryTest extends BaseTestClass {
             });
 
     // Set String key, byte array value
-    assertThat(
-            target.dictionarySetFieldsStringBytes(cacheName, dictionaryName, stringBytesPairList))
+    assertThat(target.dictionarySetFieldsStringBytes(cacheName, dictionaryName, stringBytesMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -482,8 +461,7 @@ public class DictionaryTest extends BaseTestClass {
             });
 
     // Set byte array key, String value
-    assertThat(
-            target.dictionarySetFieldsBytesString(cacheName, dictionaryName, bytesStringPairList))
+    assertThat(target.dictionarySetFieldsBytesString(cacheName, dictionaryName, bytesStringMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -500,7 +478,7 @@ public class DictionaryTest extends BaseTestClass {
             });
 
     // Set byte array key, byte array value
-    assertThat(target.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, bytesBytesPairList))
+    assertThat(target.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, bytesBytesMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -519,10 +497,12 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionarySetFieldsReturnsErrorWithNullCacheName() {
+    populateTestMaps();
+
     // String Key and String value
     assertThat(
             target.dictionarySetFieldsStringString(
-                null, dictionaryName, stringStringPairList, CollectionTtl.fromCacheTtl()))
+                null, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -530,7 +510,7 @@ public class DictionaryTest extends BaseTestClass {
     // String Key and Byte value
     assertThat(
             target.dictionarySetFieldsStringBytes(
-                null, dictionaryName, stringBytesPairList, CollectionTtl.fromCacheTtl()))
+                null, dictionaryName, stringBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -538,7 +518,7 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and String value
     assertThat(
             target.dictionarySetFieldsBytesString(
-                null, dictionaryName, bytesStringPairList, CollectionTtl.fromCacheTtl()))
+                null, dictionaryName, bytesStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -546,7 +526,7 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and Byte value
     assertThat(
             target.dictionarySetFieldsBytesBytes(
-                null, dictionaryName, bytesBytesPairList, CollectionTtl.fromCacheTtl()))
+                null, dictionaryName, bytesBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -554,10 +534,12 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionarySetFieldsReturnsErrorWithNullDictionaryName() {
+    populateTestMaps();
+
     // String Key and String value
     assertThat(
             target.dictionarySetFieldsStringString(
-                cacheName, null, stringStringPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, null, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -565,7 +547,7 @@ public class DictionaryTest extends BaseTestClass {
     // String Key and Byte value
     assertThat(
             target.dictionarySetFieldsStringBytes(
-                cacheName, null, stringBytesPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, null, stringBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -573,7 +555,7 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and String value
     assertThat(
             target.dictionarySetFieldsBytesString(
-                cacheName, null, bytesStringPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, null, bytesStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -581,7 +563,7 @@ public class DictionaryTest extends BaseTestClass {
     // Byte key and Byte value
     assertThat(
             target.dictionarySetFieldsBytesBytes(
-                cacheName, null, bytesBytesPairList, CollectionTtl.fromCacheTtl()))
+                cacheName, null, bytesBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -620,5 +602,19 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  private void populateTestMaps() {
+    stringStringMap.put("a", "b");
+    stringStringMap.put("aa", "bb");
+
+    stringBytesMap.put("c", "d".getBytes());
+    stringBytesMap.put("cc", "dd".getBytes());
+
+    bytesStringMap.put("e".getBytes(), "f");
+    bytesStringMap.put("ee".getBytes(), "ff");
+
+    bytesBytesMap.put("g".getBytes(), "h".getBytes());
+    bytesBytesMap.put("gg".getBytes(), "hh".getBytes());
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -3,8 +3,8 @@ package momento.sdk;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
@@ -1213,10 +1213,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<String, String>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<String, String> items, CollectionTtl ttl) {
     return scsDataClient.dictionarySetFieldsStringString(cacheName, dictionaryName, items, ttl);
   }
 
@@ -1232,9 +1229,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<String, String>> items) {
+      String cacheName, String dictionaryName, Map<String, String> items) {
     return scsDataClient.dictionarySetFieldsStringString(cacheName, dictionaryName, items, null);
   }
 
@@ -1250,10 +1245,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<String, byte[]>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<String, byte[]> items, CollectionTtl ttl) {
     return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, items, ttl);
   }
 
@@ -1269,9 +1261,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<String, byte[]>> items) {
+      String cacheName, String dictionaryName, Map<String, byte[]> items) {
     return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, items, null);
   }
 
@@ -1287,10 +1277,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<byte[], String>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<byte[], String> items, CollectionTtl ttl) {
     return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, items, ttl);
   }
 
@@ -1306,9 +1293,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<byte[], String>> items) {
+      String cacheName, String dictionaryName, Map<byte[], String> items) {
     return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, items, null);
   }
 
@@ -1324,10 +1309,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<byte[], byte[]>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<byte[], byte[]> items, CollectionTtl ttl) {
     return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, items, ttl);
   }
 
@@ -1343,9 +1325,7 @@ public final class CacheClient implements Closeable {
    * @return Future containing the result of the dictionary fetch back operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<byte[], byte[]>> items) {
+      String cacheName, String dictionaryName, Map<byte[], byte[]> items) {
     return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, items, null);
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -3,6 +3,7 @@ package momento.sdk;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -13,6 +14,7 @@ import momento.sdk.config.Configuration;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheDictionaryFetchResponse;
 import momento.sdk.messages.CacheDictionarySetFieldResponse;
+import momento.sdk.messages.CacheDictionarySetFieldsResponse;
 import momento.sdk.messages.CacheGetResponse;
 import momento.sdk.messages.CacheIncrementResponse;
 import momento.sdk.messages.CacheListConcatenateBackResponse;
@@ -1197,6 +1199,154 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, byte[] field, byte[] value) {
     return scsDataClient.dictionarySetField(cacheName, dictionaryName, field, value, null);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * @param cacheName - The cache containing the list.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
+   *     Duration)}
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<String, String>> items,
+      CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsStringString(cacheName, dictionaryName, items, ttl);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
+   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<String, String>> items) {
+    return scsDataClient.dictionarySetFieldsStringString(cacheName, dictionaryName, items, null);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
+   *     Duration)}
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<String, byte[]>> items,
+      CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, items, ttl);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
+   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<String, byte[]>> items) {
+    return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, items, null);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
+   *     Duration)}
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<byte[], String>> items,
+      CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, items, ttl);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
+   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<byte[], String>> items) {
+    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, items, null);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
+   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
+   *     Duration)}
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<byte[], byte[]>> items,
+      CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, items, ttl);
+  }
+
+  /**
+   * Sets all the fields in the given dictionary.
+   *
+   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
+   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to set the field in.
+   * @param items - The fields to set.
+   * @return Future containing the result of the dictionary fetch back operation.
+   */
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
+      String cacheName,
+      String dictionaryName,
+      List<AbstractMap.SimpleEntry<byte[], byte[]>> items) {
+    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, items, null);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -64,9 +64,9 @@ import io.grpc.stub.MetadataUtils;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -777,10 +777,7 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<String, String>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<String, String> items, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
@@ -799,10 +796,7 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<String, byte[]>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<String, byte[]> items, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
@@ -821,10 +815,7 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<byte[], String>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<byte[], String> items, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
@@ -843,10 +834,7 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName,
-      String dictionaryName,
-      List<AbstractMap.SimpleEntry<byte[], byte[]>> items,
-      CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<byte[], byte[]> items, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
@@ -892,44 +880,28 @@ final class ScsDataClient implements Closeable {
     return byteArrays.stream().map(this::convert).collect(Collectors.toList());
   }
 
-  private List<AbstractMap.SimpleEntry<ByteString, ByteString>> convertStringStringEntryList(
-      List<AbstractMap.SimpleEntry<String, String>> items) {
-    return items.stream()
-        .map(
-            item ->
-                new AbstractMap.SimpleEntry<ByteString, ByteString>(
-                    convert(item.getKey()), convert(item.getValue())))
-        .collect(Collectors.toList());
+  private Map<ByteString, ByteString> convertStringStringEntryList(Map<String, String> items) {
+    return items.entrySet().stream()
+        .collect(
+            Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
-  private List<AbstractMap.SimpleEntry<ByteString, ByteString>> convertStringBytesEntryList(
-      List<AbstractMap.SimpleEntry<String, byte[]>> items) {
-    return items.stream()
-        .map(
-            item ->
-                new AbstractMap.SimpleEntry<ByteString, ByteString>(
-                    convert(item.getKey()), convert(item.getValue())))
-        .collect(Collectors.toList());
+  private Map<ByteString, ByteString> convertStringBytesEntryList(Map<String, byte[]> items) {
+    return items.entrySet().stream()
+        .collect(
+            Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
-  private List<AbstractMap.SimpleEntry<ByteString, ByteString>> convertBytesStringEntryList(
-      List<AbstractMap.SimpleEntry<byte[], String>> items) {
-    return items.stream()
-        .map(
-            item ->
-                new AbstractMap.SimpleEntry<ByteString, ByteString>(
-                    convert(item.getKey()), convert(item.getValue())))
-        .collect(Collectors.toList());
+  private Map<ByteString, ByteString> convertBytesStringEntryList(Map<byte[], String> items) {
+    return items.entrySet().stream()
+        .collect(
+            Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
-  private List<AbstractMap.SimpleEntry<ByteString, ByteString>> convertBytesBytesEntryList(
-      List<AbstractMap.SimpleEntry<byte[], byte[]>> items) {
-    return items.stream()
-        .map(
-            item ->
-                new AbstractMap.SimpleEntry<ByteString, ByteString>(
-                    convert(item.getKey()), convert(item.getValue())))
-        .collect(Collectors.toList());
+  private Map<ByteString, ByteString> convertBytesBytesEntryList(Map<byte[], byte[]> items) {
+    return items.entrySet().stream()
+        .collect(
+            Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
   private CompletableFuture<CacheGetResponse> sendGet(String cacheName, ByteString key) {
@@ -1950,7 +1922,7 @@ final class ScsDataClient implements Closeable {
   private CompletableFuture<CacheDictionarySetFieldsResponse> sendDictionarySetFields(
       String cacheName,
       ByteString dictionaryName,
-      List<AbstractMap.SimpleEntry<ByteString, ByteString>> items,
+      Map<ByteString, ByteString> items,
       CollectionTtl ttl) {
 
     // Submit request to non-blocking stub
@@ -2234,9 +2206,7 @@ final class ScsDataClient implements Closeable {
   }
 
   private _DictionarySetRequest buildDictionarySetFieldsRequest(
-      ByteString dictionaryName,
-      List<AbstractMap.SimpleEntry<ByteString, ByteString>> items,
-      CollectionTtl ttl) {
+      ByteString dictionaryName, Map<ByteString, ByteString> items, CollectionTtl ttl) {
     return _DictionarySetRequest.newBuilder()
         .setDictionaryName(dictionaryName)
         .addAllItems(toDictionaryFieldValuePairs(items))
@@ -2246,8 +2216,8 @@ final class ScsDataClient implements Closeable {
   }
 
   private List<_DictionaryFieldValuePair> toDictionaryFieldValuePairs(
-      List<AbstractMap.SimpleEntry<ByteString, ByteString>> fieldValuepairs) {
-    return fieldValuepairs.stream()
+      Map<ByteString, ByteString> fieldValuepairs) {
+    return fieldValuepairs.entrySet().stream()
         .map(
             fieldValuePair ->
                 _DictionaryFieldValuePair.newBuilder()

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionarySetFieldsResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionarySetFieldsResponse.java
@@ -1,0 +1,26 @@
+package momento.sdk.messages;
+
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a dictionary set fields operation */
+public interface CacheDictionarySetFieldsResponse {
+  /** A successful dictionary set fields operation. */
+  class Success implements CacheDictionarySetFieldsResponse {}
+
+  /**
+   * A failed dictionary set fields operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements CacheDictionarySetFieldsResponse {
+
+    /**
+     * Constructs a dictionary set fields error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
### Commit 1
- Add dictionarySetFields API
- Had to use different names for methods to avoid "same erasure" problem
- Add corresponding integ tests

### Commit 2
- Change implementation from AbstractMap to Map
- Refactor integ tests based on the above change

## Build
`./gradlew :momento-sdk:spotlessApply && ./gradlew clean build`

## Issue
#171 