### PR TITLE
chore: Remove memoization from fetch APIs

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryFetchResponse.java
@@ -1,12 +1,10 @@
 package momento.sdk.messages;
 
-import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 import grpc.cache_client._DictionaryFieldValuePair;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
@@ -17,44 +15,6 @@ public interface CacheDictionaryFetchResponse {
   /** A successful dictionary fetch operation that found elements. */
   class Hit implements CacheDictionaryFetchResponse {
     private Map<ByteString, ByteString> byteStringKeysValues;
-    private final Supplier<Map<byte[], byte[]>> bytesBytesElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toByteArray(),
-                                entry -> entry.getValue().toByteArray())))
-            ::get;
-    private final Supplier<Map<String, String>> stringStringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toStringUtf8(),
-                                entry -> entry.getValue().toStringUtf8())))
-            ::get;
-
-    private final Supplier<Map<byte[], String>> bytesStringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toByteArray(),
-                                entry -> entry.getValue().toStringUtf8())))
-            ::get;
-
-    private final Supplier<Map<String, byte[]>> stringBytesElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toStringUtf8(),
-                                entry -> entry.getValue().toByteArray())))
-            ::get;
 
     /**
      * Constructs a dictionary fetch hit with a list of encoded keys and values.
@@ -75,7 +35,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<byte[], byte[]> valueDictionaryBytesBytes() {
-      return bytesBytesElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toByteArray(), entry -> entry.getValue().toByteArray()));
     }
 
     /**
@@ -84,7 +47,11 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<String, String> valueDictionaryStringString() {
-      return stringStringElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toStringUtf8(),
+                  entry -> entry.getValue().toStringUtf8()));
     }
 
     /**
@@ -93,7 +60,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<String, byte[]> valueDictionaryStringBytes() {
-      return stringBytesElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toStringUtf8(), entry -> entry.getValue().toByteArray()));
     }
 
     /**
@@ -102,7 +72,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<byte[], String> valueDictionaryBytesString() {
-      return bytesStringElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toByteArray(), entry -> entry.getValue().toStringUtf8()));
     }
 
     /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheListFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheListFetchResponse.java
@@ -1,10 +1,8 @@
 package momento.sdk.messages;
 
-import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 import java.util.Base64;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
@@ -15,20 +13,6 @@ public interface CacheListFetchResponse {
   /** A successful list fetch operation that found elements. */
   class Hit implements CacheListFetchResponse {
     private List<ByteString> byteStringValues;
-    private final Supplier<List<byte[]>> byteArrayElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toByteArray)
-                        .collect(Collectors.toList()))
-            ::get;
-    private final Supplier<List<String>> stringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toStringUtf8)
-                        .collect(Collectors.toList()))
-            ::get;
 
     /**
      * Constructs a list fetch hit with a list of encoded values.
@@ -45,7 +29,7 @@ public interface CacheListFetchResponse {
      * @return the values.
      */
     public List<byte[]> valueListByteArray() {
-      return byteArrayElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toByteArray).collect(Collectors.toList());
     }
 
     /**
@@ -54,7 +38,7 @@ public interface CacheListFetchResponse {
      * @return the values.
      */
     public List<String> valueListString() {
-      return stringElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toStringUtf8).collect(Collectors.toList());
     }
 
     /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetFetchResponse.java
@@ -1,11 +1,9 @@
 package momento.sdk.messages;
 
-import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
@@ -16,20 +14,6 @@ public interface CacheSetFetchResponse {
   /** A successful set fetch operation that found elements. */
   class Hit implements CacheSetFetchResponse {
     private List<ByteString> byteStringValues;
-    private final Supplier<Set<byte[]>> byteArrayElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toByteArray)
-                        .collect(Collectors.toSet()))
-            ::get;
-    private final Supplier<Set<String>> stringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toStringUtf8)
-                        .collect(Collectors.toSet()))
-            ::get;
 
     /**
      * Constructs a set fetch hit with a list of encoded values.
@@ -46,7 +30,7 @@ public interface CacheSetFetchResponse {
      * @return the values.
      */
     public Set<byte[]> valueSetByteArray() {
-      return byteArrayElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toByteArray).collect(Collectors.toSet());
     }
 
     /**
@@ -55,7 +39,7 @@ public interface CacheSetFetchResponse {
      * @return the values.
      */
     public Set<String> valueSetString() {
-      return stringElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toStringUtf8).collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
## PR Description
- Remove memoization from fetch apis in collections

## Build
`./gradlew :momento-sdk:spotlessApply && ./gradlew clean build`

## Issue
#171 