### PR TITLE
fix: remove string suffix, memoization, refactor java docs

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -355,7 +355,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // Set String key, String value
     assertThat(
-            target.dictionarySetFieldsStringString(
+            target.dictionarySetFields(
                 cacheName, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
@@ -431,7 +431,7 @@ public class DictionaryTest extends BaseTestClass {
     populateTestMaps();
 
     // Set String key, String value
-    assertThat(target.dictionarySetFieldsStringString(cacheName, dictionaryName, stringStringMap))
+    assertThat(target.dictionarySetFields(cacheName, dictionaryName, stringStringMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
 
@@ -501,7 +501,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and String value
     assertThat(
-            target.dictionarySetFieldsStringString(
+            target.dictionarySetFields(
                 null, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
@@ -538,7 +538,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and String value
     assertThat(
-            target.dictionarySetFieldsStringString(
+            target.dictionarySetFields(
                 cacheName, null, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
@@ -573,7 +573,7 @@ public class DictionaryTest extends BaseTestClass {
   public void dictionarySetFieldsReturnsErrorWithNullItem() {
     // String Key and String value
     assertThat(
-            target.dictionarySetFieldsStringString(
+            target.dictionarySetFields(
                 cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))

--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -64,7 +64,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBackString(
+            target.listConcatenateBack(
                 cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
@@ -76,7 +76,7 @@ public class ListTest extends BaseTestClass {
 
     // Add same list
     assertThat(
-            target.listConcatenateBackString(
+            target.listConcatenateBack(
                 cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
@@ -88,7 +88,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
     // Add a new values list without specifying ttl
-    assertThat(target.listConcatenateBackString(cacheName, listName, newValues, 0))
+    assertThat(target.listConcatenateBack(cacheName, listName, newValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -173,14 +173,14 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBackString(
+            target.listConcatenateBack(
                 null, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackString(null, listName, stringValues, 0))
+    assertThat(target.listConcatenateBack(null, listName, stringValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -208,14 +208,14 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBackString(
+            target.listConcatenateBack(
                 cacheName, null, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackString(cacheName, null, stringValues, 0))
+    assertThat(target.listConcatenateBack(cacheName, null, stringValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -239,14 +239,13 @@ public class ListTest extends BaseTestClass {
   public void shouldFailListConcatenateBackWhenNullElement() {
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBackString(
-                cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
+            target.listConcatenateBack(cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackString(cacheName, listName, null, 0))
+    assertThat(target.listConcatenateBack(cacheName, listName, null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -270,8 +269,7 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithPositiveStartEndIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBackString(
-            cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     CacheListFetchResponse cacheListFetchResponse =
@@ -288,8 +286,7 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNegativeStartEndIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBackString(
-            cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     CacheListFetchResponse cacheListFetchResponse =
@@ -306,8 +303,7 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNullStartIndex() {
     final String listName = "listName";
     target
-        .listConcatenateBackString(
-            cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // valid case for null startIndex and positive endIndex
@@ -334,8 +330,7 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNullEndIndex() {
     final String listName = "listName";
     target
-        .listConcatenateBackString(
-            cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // valid case for positive startIndex and null endIndex
@@ -362,8 +357,7 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithInvalidIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBackString(
-            cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // the positive startIndex is larger than the positive endIndex
@@ -393,7 +387,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -405,7 +399,7 @@ public class ListTest extends BaseTestClass {
 
     // Add same list
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -417,7 +411,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
     // Add a new values list without specifying ttl
-    assertThat(target.listConcatenateFrontString(cacheName, listName, newValues, 0))
+    assertThat(target.listConcatenateFront(cacheName, listName, newValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -502,14 +496,14 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 null, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFrontString(null, listName, stringValues, 0))
+    assertThat(target.listConcatenateFront(null, listName, stringValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -539,14 +533,14 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, null, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFrontString(cacheName, null, stringValues, 0))
+    assertThat(target.listConcatenateFront(cacheName, null, stringValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -570,14 +564,13 @@ public class ListTest extends BaseTestClass {
   public void shouldFailListConcatenateFrontWhenNullElement() {
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFrontString(
-                cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
+            target.listConcatenateFront(cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFrontString(cacheName, listName, null, 0))
+    assertThat(target.listConcatenateFront(cacheName, listName, null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -609,7 +602,7 @@ public class ListTest extends BaseTestClass {
 
     // add string values to list
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -660,7 +653,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBackString(
+            target.listConcatenateBack(
                 cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
@@ -703,7 +696,7 @@ public class ListTest extends BaseTestClass {
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBackString(
+            target.listConcatenateBack(
                 cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
@@ -1099,7 +1092,7 @@ public class ListTest extends BaseTestClass {
     List<String> values = Arrays.asList("val1", "val1", "val2", "val3", "val4");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -1199,7 +1192,7 @@ public class ListTest extends BaseTestClass {
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3", "val4");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -1226,7 +1219,7 @@ public class ListTest extends BaseTestClass {
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3", "val4");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -1254,7 +1247,7 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -1296,7 +1289,7 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -1337,7 +1330,7 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
@@ -1365,7 +1358,7 @@ public class ListTest extends BaseTestClass {
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFrontString(
+            target.listConcatenateFront(
                 cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);

--- a/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
@@ -175,7 +175,7 @@ public class SetTest {
     final Set<String> firstSet = Sets.newHashSet("one", "two");
     final Set<String> secondSet = Sets.newHashSet("two", "three");
 
-    assertThat(client.setAddElementsString(cacheName, setName, firstSet))
+    assertThat(client.setAddElements(cacheName, setName, firstSet))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetAddElementsResponse.Success.class);
 
@@ -185,8 +185,7 @@ public class SetTest {
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(2).containsAll(firstSet));
 
     // Try to add the same elements again
-    assertThat(
-            client.setAddElementsString(cacheName, setName, firstSet, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(cacheName, setName, firstSet, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetAddElementsResponse.Success.class);
 
@@ -196,9 +195,7 @@ public class SetTest {
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(2).containsAll(firstSet));
 
     // Add a set with one new and one overlapping element
-    assertThat(
-            client.setAddElementsString(
-                cacheName, setName, secondSet, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(cacheName, setName, secondSet, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetAddElementsResponse.Success.class);
 
@@ -262,9 +259,7 @@ public class SetTest {
     final Set<String> stringElements = Collections.singleton("element");
     final Set<byte[]> bytesElements = Collections.singleton("bytes-element".getBytes());
 
-    assertThat(
-            client.setAddElementsString(
-                null, setName, stringElements, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(null, setName, stringElements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -282,9 +277,7 @@ public class SetTest {
     final Set<String> stringElements = Collections.singleton("element");
     final Set<byte[]> bytesElements = Collections.singleton("bytes-element".getBytes());
 
-    assertThat(
-            client.setAddElementsString(
-                cacheName, null, stringElements, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(cacheName, null, stringElements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -299,8 +292,7 @@ public class SetTest {
 
   @Test
   public void setAddElementsReturnsErrorWithNullElements() {
-    assertThat(
-            client.setAddElementsString(cacheName, cacheName, null, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(cacheName, cacheName, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSetAddElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -320,8 +312,7 @@ public class SetTest {
     final Set<String> elements = Sets.newHashSet(element1, element2);
 
     // Add some elements to a set
-    assertThat(
-            client.setAddElementsString(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetAddElementsResponse.Success.class);
 
@@ -482,8 +473,7 @@ public class SetTest {
     final Set<String> elements = Sets.newHashSet(element1, element2, element3);
 
     // Add some elements to a set
-    assertThat(
-            client.setAddElementsString(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
+    assertThat(client.setAddElements(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetAddElementsResponse.Success.class);
 
@@ -498,7 +488,7 @@ public class SetTest {
 
     // Remove some elements that are in the set and one that isn't
     assertThat(
-            client.setRemoveElementsString(
+            client.setRemoveElements(
                 cacheName, setName, Sets.newHashSet(element2, element3, element4)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetRemoveElementsResponse.Success.class);
@@ -509,7 +499,7 @@ public class SetTest {
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
 
     // Try to remove an element that has already been removed
-    assertThat(client.setRemoveElementsString(cacheName, setName, Collections.singleton(element3)))
+    assertThat(client.setRemoveElements(cacheName, setName, Collections.singleton(element3)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetRemoveElementsResponse.Success.class);
 
@@ -519,7 +509,7 @@ public class SetTest {
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
 
     // Remove everything
-    assertThat(client.setRemoveElementsString(cacheName, setName, elements))
+    assertThat(client.setRemoveElements(cacheName, setName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetRemoveElementsResponse.Success.class);
 
@@ -529,7 +519,7 @@ public class SetTest {
 
     // Remove elements from the now non-existent set
     assertThat(
-            client.setRemoveElementsString(
+            client.setRemoveElements(
                 cacheName, setName, Sets.newHashSet(element1, element2, element3, element4)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSetRemoveElementsResponse.Success.class);
@@ -612,7 +602,7 @@ public class SetTest {
     final Set<String> stringElements = Sets.newHashSet("element");
     final Set<byte[]> bytesElements = Sets.newHashSet("bytes-element".getBytes());
 
-    assertThat(client.setRemoveElementsString(null, setName, stringElements))
+    assertThat(client.setRemoveElements(null, setName, stringElements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -628,7 +618,7 @@ public class SetTest {
     final Set<String> stringElements = Sets.newHashSet("element");
     final Set<byte[]> bytesElements = Sets.newHashSet("bytes-element".getBytes());
 
-    assertThat(client.setRemoveElementsString(cacheName, null, stringElements))
+    assertThat(client.setRemoveElements(cacheName, null, stringElements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -641,7 +631,7 @@ public class SetTest {
 
   @Test
   public void setRemoveElementsReturnsErrorWithNullElements() {
-    assertThat(client.setRemoveElementsString(cacheName, cacheName, null))
+    assertThat(client.setRemoveElements(cacheName, cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -554,9 +554,9 @@ public final class CacheClient implements Closeable {
    *     initializing a cache client. Defaults to client TTL.
    * @return Future containing the result of the add elements operation.
    */
-  public CompletableFuture<CacheSetAddElementsResponse> setAddElementsString(
+  public CompletableFuture<CacheSetAddElementsResponse> setAddElements(
       String cacheName, String setName, Set<String> elements, @Nullable CollectionTtl ttl) {
-    return scsDataClient.setAddElementsString(cacheName, setName, elements, ttl);
+    return scsDataClient.setAddElements(cacheName, setName, elements, ttl);
   }
 
   /**
@@ -570,9 +570,9 @@ public final class CacheClient implements Closeable {
    * @param elements The data to add to the set.
    * @return Future containing the result of the add elements operation.
    */
-  public CompletableFuture<CacheSetAddElementsResponse> setAddElementsString(
+  public CompletableFuture<CacheSetAddElementsResponse> setAddElements(
       String cacheName, String setName, Set<String> elements) {
-    return scsDataClient.setAddElementsString(cacheName, setName, elements, null);
+    return scsDataClient.setAddElements(cacheName, setName, elements, null);
   }
 
   /**
@@ -643,9 +643,9 @@ public final class CacheClient implements Closeable {
    * @param elements The values to remove from the set.
    * @return Future containing the result of the remove elements operation.
    */
-  public CompletableFuture<CacheSetRemoveElementsResponse> setRemoveElementsString(
+  public CompletableFuture<CacheSetRemoveElementsResponse> setRemoveElements(
       String cacheName, String setName, Set<String> elements) {
-    return scsDataClient.setRemoveElementsString(cacheName, setName, elements);
+    return scsDataClient.setRemoveElements(cacheName, setName, elements);
   }
 
   /**
@@ -685,14 +685,13 @@ public final class CacheClient implements Closeable {
    *     Duration)}
    * @return Future containing the result of the list concatenate back operation.
    */
-  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
+  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
       String cacheName,
       String listName,
       List<String> values,
       int truncateFrontToSize,
       @Nullable CollectionTtl ttl) {
-    return scsDataClient.listConcatenateBackString(
-        cacheName, listName, values, truncateFrontToSize, ttl);
+    return scsDataClient.listConcatenateBack(cacheName, listName, values, truncateFrontToSize, ttl);
   }
 
   /**
@@ -705,9 +704,9 @@ public final class CacheClient implements Closeable {
    *     list. Must be positive.
    * @return Future containing the result of the list concatenate back operation.
    */
-  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
+  public CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
       String cacheName, String listName, List<String> values, int truncateFrontToSize) {
-    return scsDataClient.listConcatenateBackString(
+    return scsDataClient.listConcatenateBack(
         cacheName, listName, values, truncateFrontToSize, null);
   }
 
@@ -763,14 +762,13 @@ public final class CacheClient implements Closeable {
    *     Duration)}
    * @return Future containing the result of the list concatenate front operation.
    */
-  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
       String cacheName,
       String listName,
       List<String> values,
       int truncateBackToSize,
       @Nullable CollectionTtl ttl) {
-    return scsDataClient.listConcatenateFrontString(
-        cacheName, listName, values, truncateBackToSize, ttl);
+    return scsDataClient.listConcatenateFront(cacheName, listName, values, truncateBackToSize, ttl);
   }
 
   /**
@@ -783,9 +781,9 @@ public final class CacheClient implements Closeable {
    *     list. Must be positive.
    * @return Future containing the result of the list concatenate front operation.
    */
-  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
+  public CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
       String cacheName, String listName, List<String> values, int truncateBackToSize) {
-    return scsDataClient.listConcatenateFrontString(
+    return scsDataClient.listConcatenateFront(
         cacheName, listName, values, truncateBackToSize, null);
   }
 
@@ -1070,7 +1068,7 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to fetch.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary fetch operation.
    */
   public CompletableFuture<CacheDictionaryFetchResponse> dictionaryFetch(
       String cacheName, String dictionaryName) {
@@ -1087,7 +1085,7 @@ public final class CacheClient implements Closeable {
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, String field, String value, CollectionTtl ttl) {
@@ -1101,7 +1099,7 @@ public final class CacheClient implements Closeable {
    * @param dictionaryName - The dictionary to set the field in.
    * @param field - The field to set.
    * @param value - The value to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, String field, String value) {
@@ -1118,7 +1116,7 @@ public final class CacheClient implements Closeable {
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, String field, byte[] value, CollectionTtl ttl) {
@@ -1132,7 +1130,7 @@ public final class CacheClient implements Closeable {
    * @param dictionaryName - The dictionary to set the field in.
    * @param field - The field to set.
    * @param value - The value to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, String field, byte[] value) {
@@ -1149,7 +1147,7 @@ public final class CacheClient implements Closeable {
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, byte[] field, String value, CollectionTtl ttl) {
@@ -1163,7 +1161,7 @@ public final class CacheClient implements Closeable {
    * @param dictionaryName - The dictionary to set the field in.
    * @param field - The field to set.
    * @param value - The value to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, byte[] field, String value) {
@@ -1180,7 +1178,7 @@ public final class CacheClient implements Closeable {
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, byte[] field, byte[] value, CollectionTtl ttl) {
@@ -1194,7 +1192,7 @@ public final class CacheClient implements Closeable {
    * @param dictionaryName - The dictionary to set the field in.
    * @param field - The field to set.
    * @param value - The value to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set field operation.
    */
   public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
       String cacheName, String dictionaryName, byte[] field, byte[] value) {
@@ -1206,15 +1204,15 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the list.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
+   * @param elements - The fields to set.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set fields operation.
    */
-  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
-      String cacheName, String dictionaryName, Map<String, String> items, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetFieldsStringString(cacheName, dictionaryName, items, ttl);
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFields(
+      String cacheName, String dictionaryName, Map<String, String> elements, CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFields(cacheName, dictionaryName, elements, ttl);
   }
 
   /**
@@ -1225,12 +1223,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @param elements - The fields to set.
+   * @return Future containing the result of the dictionary set fields operation.
    */
-  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
-      String cacheName, String dictionaryName, Map<String, String> items) {
-    return scsDataClient.dictionarySetFieldsStringString(cacheName, dictionaryName, items, null);
+  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFields(
+      String cacheName, String dictionaryName, Map<String, String> elements) {
+    return scsDataClient.dictionarySetFields(cacheName, dictionaryName, elements, null);
   }
 
   /**
@@ -1238,15 +1236,15 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
+   * @param elements - The fields to set.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set fields operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
-      String cacheName, String dictionaryName, Map<String, byte[]> items, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, items, ttl);
+      String cacheName, String dictionaryName, Map<String, byte[]> elements, CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, elements, ttl);
   }
 
   /**
@@ -1257,12 +1255,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @param elements - The fields to set.
+   * @return Future containing the result of the dictionary set fields operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
-      String cacheName, String dictionaryName, Map<String, byte[]> items) {
-    return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, items, null);
+      String cacheName, String dictionaryName, Map<String, byte[]> elements) {
+    return scsDataClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, elements, null);
   }
 
   /**
@@ -1270,15 +1268,15 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
+   * @param elements - The fields to set.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set fields operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName, String dictionaryName, Map<byte[], String> items, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, items, ttl);
+      String cacheName, String dictionaryName, Map<byte[], String> elements, CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, elements, ttl);
   }
 
   /**
@@ -1289,12 +1287,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @param elements - The fields to set.
+   * @return Future containing the result of the dictionary set fields operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName, String dictionaryName, Map<byte[], String> items) {
-    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, items, null);
+      String cacheName, String dictionaryName, Map<byte[], String> elements) {
+    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, elements, null);
   }
 
   /**
@@ -1302,15 +1300,15 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
+   * @param elements - The fields to set.
    * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
    *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
    *     Duration)}
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @return Future containing the result of the dictionary set fields operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName, String dictionaryName, Map<byte[], byte[]> items, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, items, ttl);
+      String cacheName, String dictionaryName, Map<byte[], byte[]> elements, CollectionTtl ttl) {
+    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, elements, ttl);
   }
 
   /**
@@ -1321,12 +1319,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the dictionary.
    * @param dictionaryName - The dictionary to set the field in.
-   * @param items - The fields to set.
-   * @return Future containing the result of the dictionary fetch back operation.
+   * @param elements - The fields to set.
+   * @return Future containing the result of the dictionary set fields operation.
    */
   public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName, String dictionaryName, Map<byte[], byte[]> items) {
-    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, items, null);
+      String cacheName, String dictionaryName, Map<byte[], byte[]> elements) {
+    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, elements, null);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -316,7 +316,7 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheSetAddElementsResponse> setAddElementsString(
+  CompletableFuture<CacheSetAddElementsResponse> setAddElements(
       String cacheName, String setName, Set<String> elements, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
@@ -374,7 +374,7 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheSetRemoveElementsResponse> setRemoveElementsString(
+  CompletableFuture<CacheSetRemoveElementsResponse> setRemoveElements(
       String cacheName, String setName, Set<String> elements) {
     try {
       checkCacheNameValid(cacheName);
@@ -411,7 +411,7 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackString(
+  CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
       String cacheName,
       String listName,
       List<String> values,
@@ -457,7 +457,7 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontString(
+  CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
       String cacheName,
       String listName,
       List<String> values,
@@ -776,19 +776,19 @@ final class ScsDataClient implements Closeable {
     }
   }
 
-  CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringString(
-      String cacheName, String dictionaryName, Map<String, String> items, CollectionTtl ttl) {
+  CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFields(
+      String cacheName, String dictionaryName, Map<String, String> elements, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
-      ensureValidValue(items);
+      ensureValidValue(elements);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendDictionarySetFields(
-          cacheName, convert(dictionaryName), convertStringStringEntryList(items), ttl);
+          cacheName, convert(dictionaryName), convertStringStringEntryList(elements), ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheDictionarySetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -796,18 +796,18 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsStringBytes(
-      String cacheName, String dictionaryName, Map<String, byte[]> items, CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<String, byte[]> elements, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
-      ensureValidValue(items);
+      ensureValidValue(elements);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendDictionarySetFields(
-          cacheName, convert(dictionaryName), convertStringBytesEntryList(items), ttl);
+          cacheName, convert(dictionaryName), convertStringBytesEntryList(elements), ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheDictionarySetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -815,18 +815,18 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName, String dictionaryName, Map<byte[], String> items, CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<byte[], String> elements, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
-      ensureValidValue(items);
+      ensureValidValue(elements);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendDictionarySetFields(
-          cacheName, convert(dictionaryName), convertBytesStringEntryList(items), ttl);
+          cacheName, convert(dictionaryName), convertBytesStringEntryList(elements), ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheDictionarySetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -834,18 +834,18 @@ final class ScsDataClient implements Closeable {
   }
 
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName, String dictionaryName, Map<byte[], byte[]> items, CollectionTtl ttl) {
+      String cacheName, String dictionaryName, Map<byte[], byte[]> elements, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
-      ensureValidValue(items);
+      ensureValidValue(elements);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendDictionarySetFields(
-          cacheName, convert(dictionaryName), convertBytesBytesEntryList(items), ttl);
+          cacheName, convert(dictionaryName), convertBytesBytesEntryList(elements), ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheDictionarySetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -880,26 +880,26 @@ final class ScsDataClient implements Closeable {
     return byteArrays.stream().map(this::convert).collect(Collectors.toList());
   }
 
-  private Map<ByteString, ByteString> convertStringStringEntryList(Map<String, String> items) {
-    return items.entrySet().stream()
+  private Map<ByteString, ByteString> convertStringStringEntryList(Map<String, String> elements) {
+    return elements.entrySet().stream()
         .collect(
             Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
-  private Map<ByteString, ByteString> convertStringBytesEntryList(Map<String, byte[]> items) {
-    return items.entrySet().stream()
+  private Map<ByteString, ByteString> convertStringBytesEntryList(Map<String, byte[]> elements) {
+    return elements.entrySet().stream()
         .collect(
             Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
-  private Map<ByteString, ByteString> convertBytesStringEntryList(Map<byte[], String> items) {
-    return items.entrySet().stream()
+  private Map<ByteString, ByteString> convertBytesStringEntryList(Map<byte[], String> elements) {
+    return elements.entrySet().stream()
         .collect(
             Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
 
-  private Map<ByteString, ByteString> convertBytesBytesEntryList(Map<byte[], byte[]> items) {
-    return items.entrySet().stream()
+  private Map<ByteString, ByteString> convertBytesBytesEntryList(Map<byte[], byte[]> elements) {
+    return elements.entrySet().stream()
         .collect(
             Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
   }
@@ -1922,14 +1922,14 @@ final class ScsDataClient implements Closeable {
   private CompletableFuture<CacheDictionarySetFieldsResponse> sendDictionarySetFields(
       String cacheName,
       ByteString dictionaryName,
-      Map<ByteString, ByteString> items,
+      Map<ByteString, ByteString> elements,
       CollectionTtl ttl) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
     final ListenableFuture<_DictionarySetResponse> rspFuture =
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-            .dictionarySet(buildDictionarySetFieldsRequest(dictionaryName, items, ttl));
+            .dictionarySet(buildDictionarySetFieldsRequest(dictionaryName, elements, ttl));
 
     // Build a CompletableFuture to return to caller
     final CompletableFuture<CacheDictionarySetFieldsResponse> returnFuture =
@@ -2206,10 +2206,10 @@ final class ScsDataClient implements Closeable {
   }
 
   private _DictionarySetRequest buildDictionarySetFieldsRequest(
-      ByteString dictionaryName, Map<ByteString, ByteString> items, CollectionTtl ttl) {
+      ByteString dictionaryName, Map<ByteString, ByteString> elements, CollectionTtl ttl) {
     return _DictionarySetRequest.newBuilder()
         .setDictionaryName(dictionaryName)
-        .addAllItems(toDictionaryFieldValuePairs(items))
+        .addAllItems(toDictionaryFieldValuePairs(elements))
         .setTtlMilliseconds(ttl.toMilliseconds().orElse(itemDefaultTtl.toMillis()))
         .setRefreshTtl(ttl.refreshTtl())
         .build();

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryFetchResponse.java
@@ -1,12 +1,10 @@
 package momento.sdk.messages;
 
-import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 import grpc.cache_client._DictionaryFieldValuePair;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
@@ -16,45 +14,7 @@ public interface CacheDictionaryFetchResponse {
 
   /** A successful dictionary fetch operation that found elements. */
   class Hit implements CacheDictionaryFetchResponse {
-    private Map<ByteString, ByteString> byteStringKeysValues;
-    private final Supplier<Map<byte[], byte[]>> bytesBytesElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toByteArray(),
-                                entry -> entry.getValue().toByteArray())))
-            ::get;
-    private final Supplier<Map<String, String>> stringStringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toStringUtf8(),
-                                entry -> entry.getValue().toStringUtf8())))
-            ::get;
-
-    private final Supplier<Map<byte[], String>> bytesStringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toByteArray(),
-                                entry -> entry.getValue().toStringUtf8())))
-            ::get;
-
-    private final Supplier<Map<String, byte[]>> stringBytesElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringKeysValues.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                entry -> entry.getKey().toStringUtf8(),
-                                entry -> entry.getValue().toByteArray())))
-            ::get;
+    private final Map<ByteString, ByteString> byteStringKeysValues;
 
     /**
      * Constructs a dictionary fetch hit with a list of encoded keys and values.
@@ -75,7 +35,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<byte[], byte[]> valueDictionaryBytesBytes() {
-      return bytesBytesElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toByteArray(), entry -> entry.getValue().toByteArray()));
     }
 
     /**
@@ -84,7 +47,11 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<String, String> valueDictionaryStringString() {
-      return stringStringElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toStringUtf8(),
+                  entry -> entry.getValue().toStringUtf8()));
     }
 
     /**
@@ -93,7 +60,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<String, byte[]> valueDictionaryStringBytes() {
-      return stringBytesElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toStringUtf8(), entry -> entry.getValue().toByteArray()));
     }
 
     /**
@@ -102,7 +72,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<byte[], String> valueDictionaryBytesString() {
-      return bytesStringElementsSupplier.get();
+      return byteStringKeysValues.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  entry -> entry.getKey().toByteArray(), entry -> entry.getValue().toStringUtf8()));
     }
 
     /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheListFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheListFetchResponse.java
@@ -1,10 +1,8 @@
 package momento.sdk.messages;
 
-import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 import java.util.Base64;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
@@ -14,21 +12,7 @@ public interface CacheListFetchResponse {
 
   /** A successful list fetch operation that found elements. */
   class Hit implements CacheListFetchResponse {
-    private List<ByteString> byteStringValues;
-    private final Supplier<List<byte[]>> byteArrayElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toByteArray)
-                        .collect(Collectors.toList()))
-            ::get;
-    private final Supplier<List<String>> stringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toStringUtf8)
-                        .collect(Collectors.toList()))
-            ::get;
+    private final List<ByteString> byteStringValues;
 
     /**
      * Constructs a list fetch hit with a list of encoded values.
@@ -45,7 +29,7 @@ public interface CacheListFetchResponse {
      * @return the values.
      */
     public List<byte[]> valueListByteArray() {
-      return byteArrayElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toByteArray).collect(Collectors.toList());
     }
 
     /**
@@ -54,7 +38,7 @@ public interface CacheListFetchResponse {
      * @return the values.
      */
     public List<String> valueListString() {
-      return stringElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toStringUtf8).collect(Collectors.toList());
     }
 
     /**

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheSetFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheSetFetchResponse.java
@@ -1,11 +1,9 @@
 package momento.sdk.messages;
 
-import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
@@ -15,21 +13,7 @@ public interface CacheSetFetchResponse {
 
   /** A successful set fetch operation that found elements. */
   class Hit implements CacheSetFetchResponse {
-    private List<ByteString> byteStringValues;
-    private final Supplier<Set<byte[]>> byteArrayElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toByteArray)
-                        .collect(Collectors.toSet()))
-            ::get;
-    private final Supplier<Set<String>> stringElementsSupplier =
-        Suppliers.memoize(
-                () ->
-                    byteStringValues.stream()
-                        .map(ByteString::toStringUtf8)
-                        .collect(Collectors.toSet()))
-            ::get;
+    private final List<ByteString> byteStringValues;
 
     /**
      * Constructs a set fetch hit with a list of encoded values.
@@ -46,7 +30,7 @@ public interface CacheSetFetchResponse {
      * @return the values.
      */
     public Set<byte[]> valueSetByteArray() {
-      return byteArrayElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toByteArray).collect(Collectors.toSet());
     }
 
     /**
@@ -55,7 +39,7 @@ public interface CacheSetFetchResponse {
      * @return the values.
      */
     public Set<String> valueSetString() {
-      return stringElementsSupplier.get();
+      return byteStringValues.stream().map(ByteString::toStringUtf8).collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
## PR Description:
- remove string suffix
- remove memoization 
- refactor java docs
- rename items to elements to match the method signature in other sdks like .NET