### PR TITLE
feat: Add didctionaryGetFields API

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -14,6 +14,7 @@ import momento.sdk.config.Configuration;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheDictionaryFetchResponse;
 import momento.sdk.messages.CacheDictionaryGetFieldResponse;
+import momento.sdk.messages.CacheDictionaryGetFieldsResponse;
 import momento.sdk.messages.CacheDictionarySetFieldResponse;
 import momento.sdk.messages.CacheDictionarySetFieldsResponse;
 import momento.sdk.messages.CacheGetResponse;
@@ -1352,6 +1353,32 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheDictionaryGetFieldResponse> dictionaryGetField(
       String cacheName, String dictionaryName, byte[] field) {
     return scsDataClient.dictionaryGetField(cacheName, dictionaryName, field);
+  }
+
+  /**
+   * Gets the fields and values from the given dictionary.
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to get the fields and values from.
+   * @param fields - The fields to get.
+   * @return Future containing the result of the dictionary get fields operation.
+   */
+  public CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFields(
+      String cacheName, String dictionaryName, List<String> fields) {
+    return scsDataClient.dictionaryGetFields(cacheName, dictionaryName, fields);
+  }
+
+  /**
+   * Gets the fields and values from the given dictionary.
+   *
+   * @param cacheName - The cache containing the dictionary.
+   * @param dictionaryName - The dictionary to get the fields and values from.
+   * @param fields - The fields to get.
+   * @return Future containing the result of the dictionary get fields operation.
+   */
+  public CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFieldsByteArray(
+      String cacheName, String dictionaryName, List<byte[]> fields) {
+    return scsDataClient.dictionaryGetFieldsByteArray(cacheName, dictionaryName, fields);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -923,14 +923,14 @@ final class ScsDataClient implements Closeable {
 
   private ByteString convert(String stringToEncode) {
     if (stringToEncode == null) {
-      return ByteString.copyFromUtf8("null");
+      return ByteString.EMPTY;
     }
     return ByteString.copyFromUtf8(stringToEncode);
   }
 
   private ByteString convert(byte[] bytes) {
     if (bytes == null) {
-      return ByteString.copyFromUtf8("null");
+      return ByteString.EMPTY;
     }
     return ByteString.copyFrom(bytes);
   }

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -81,6 +81,7 @@ import momento.sdk.exceptions.InternalServerException;
 import momento.sdk.messages.CacheDeleteResponse;
 import momento.sdk.messages.CacheDictionaryFetchResponse;
 import momento.sdk.messages.CacheDictionaryGetFieldResponse;
+import momento.sdk.messages.CacheDictionaryGetFieldsResponse;
 import momento.sdk.messages.CacheDictionarySetFieldResponse;
 import momento.sdk.messages.CacheDictionarySetFieldsResponse;
 import momento.sdk.messages.CacheGetResponse;
@@ -865,7 +866,8 @@ final class ScsDataClient implements Closeable {
       return sendDictionaryGetField(cacheName, convert(dictionaryName), convert(field));
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
-          new CacheDictionaryGetFieldResponse.Error(CacheServiceExceptionMapper.convert(e)));
+          new CacheDictionaryGetFieldResponse.Error(
+              CacheServiceExceptionMapper.convert(e), convert(field)));
     }
   }
 
@@ -879,15 +881,57 @@ final class ScsDataClient implements Closeable {
       return sendDictionaryGetField(cacheName, convert(dictionaryName), convert(field));
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
-          new CacheDictionaryGetFieldResponse.Error(CacheServiceExceptionMapper.convert(e)));
+          new CacheDictionaryGetFieldResponse.Error(
+              CacheServiceExceptionMapper.convert(e), convert(field)));
+    }
+  }
+
+  CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFields(
+      String cacheName, String dictionaryName, List<String> fields) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkDictionaryNameValid(dictionaryName);
+      ensureValidKey(fields);
+      for (String field : fields) {
+        ensureValidKey(field);
+      }
+
+      return sendDictionaryGetFields(cacheName, convert(dictionaryName), convertStringList(fields));
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheDictionaryGetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFieldsByteArray(
+      String cacheName, String dictionaryName, List<byte[]> fields) {
+    try {
+      checkCacheNameValid(cacheName);
+      checkDictionaryNameValid(dictionaryName);
+      ensureValidKey(fields);
+      for (byte[] field : fields) {
+        ensureValidKey(field);
+      }
+
+      return sendDictionaryGetFields(
+          cacheName, convert(dictionaryName), convertByteArrayList(fields));
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new CacheDictionaryGetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
     }
   }
 
   private ByteString convert(String stringToEncode) {
+    if (stringToEncode == null) {
+      return ByteString.copyFromUtf8("null");
+    }
     return ByteString.copyFromUtf8(stringToEncode);
   }
 
   private ByteString convert(byte[] bytes) {
+    if (bytes == null) {
+      return ByteString.copyFromUtf8("null");
+    }
     return ByteString.copyFrom(bytes);
   }
 
@@ -2033,7 +2077,8 @@ final class ScsDataClient implements Closeable {
                         CacheServiceExceptionMapper.convert(
                             new Exception(
                                 "_DictionaryGetResponseResponse contained no data but was found"),
-                            metadata)));
+                            metadata),
+                        field));
               } else if (rsp.getFound().getItemsList().get(0).getResult() == ECacheResult.Miss) {
                 returnFuture.complete(new CacheDictionaryGetFieldResponse.Miss(field));
               } else {
@@ -2048,6 +2093,55 @@ final class ScsDataClient implements Closeable {
           public void onFailure(@Nonnull Throwable e) {
             returnFuture.complete(
                 new CacheDictionaryGetFieldResponse.Error(
+                    CacheServiceExceptionMapper.convert(e, metadata), field));
+          }
+        },
+        MoreExecutors
+            .directExecutor()); // Execute on same thread that called execute on CompletionStage
+    // returned
+
+    return returnFuture;
+  }
+
+  private CompletableFuture<CacheDictionaryGetFieldsResponse> sendDictionaryGetFields(
+      String cacheName, ByteString dictionaryName, List<ByteString> fields) {
+
+    // Submit request to non-blocking stub
+    final Metadata metadata = metadataWithCache(cacheName);
+    final ListenableFuture<_DictionaryGetResponse> rspFuture =
+        attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
+            .dictionaryGet(buildDictionaryGetFieldsRequest(dictionaryName, fields));
+
+    // Build a CompletableFuture to return to caller
+    final CompletableFuture<CacheDictionaryGetFieldsResponse> returnFuture =
+        new CompletableFuture<CacheDictionaryGetFieldsResponse>() {
+          @Override
+          public boolean cancel(boolean mayInterruptIfRunning) {
+            // propagate cancel to the listenable future if called on returned completable future
+            final boolean result = rspFuture.cancel(mayInterruptIfRunning);
+            super.cancel(mayInterruptIfRunning);
+            return result;
+          }
+        };
+
+    // Convert returned ListenableFuture to CompletableFuture
+    Futures.addCallback(
+        rspFuture,
+        new FutureCallback<_DictionaryGetResponse>() {
+          @Override
+          public void onSuccess(_DictionaryGetResponse rsp) {
+            if (rsp.hasFound()) {
+              returnFuture.complete(
+                  new CacheDictionaryGetFieldsResponse.Hit(fields, rsp.getFound().getItemsList()));
+            } else if (rsp.hasMissing()) {
+              returnFuture.complete(new CacheDictionaryGetFieldsResponse.Miss());
+            }
+          }
+
+          @Override
+          public void onFailure(@Nonnull Throwable e) {
+            returnFuture.complete(
+                new CacheDictionaryGetFieldsResponse.Error(
                     CacheServiceExceptionMapper.convert(e, metadata)));
           }
         },
@@ -2324,6 +2418,14 @@ final class ScsDataClient implements Closeable {
     return _DictionaryGetRequest.newBuilder()
         .setDictionaryName(dictionaryName)
         .addFields(field)
+        .build();
+  }
+
+  private _DictionaryGetRequest buildDictionaryGetFieldsRequest(
+      ByteString dictionaryName, List<ByteString> fields) {
+    return _DictionaryGetRequest.newBuilder()
+        .setDictionaryName(dictionaryName)
+        .addAllFields(fields)
         .build();
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldResponse.java
@@ -132,14 +132,50 @@ public interface CacheDictionaryGetFieldResponse {
    * message is a copy of the message of the cause.
    */
   class Error extends SdkException implements CacheDictionaryGetFieldResponse {
+    private final ByteString field;
 
     /**
      * Constructs a cache dictionary get field error with a cause.
      *
      * @param cause the cause.
+     * @param field
      */
-    public Error(SdkException cause) {
+    public Error(SdkException cause, ByteString field) {
       super(cause);
+      this.field = field;
+    }
+
+    /**
+     * Gets the field as a byte array.
+     *
+     * @return the field.
+     */
+    public byte[] fieldByteArray() {
+      return field.toByteArray();
+    }
+
+    /**
+     * Gets the field as a UTF-8 {@link String}.
+     *
+     * @return the field.
+     */
+    public String fieldString() {
+      return field.toStringUtf8();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Truncates the internal fields to 20 characters to bound the size of the string.
+     */
+    @Override
+    public String toString() {
+      return super.toString()
+          + ": fieldString: \""
+          + StringHelpers.truncate(fieldString())
+          + "\" fieldByteArray: \""
+          + StringHelpers.truncate(Base64.getEncoder().encodeToString(fieldByteArray()))
+          + "\"";
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldsResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldsResponse.java
@@ -5,7 +5,6 @@ import grpc.cache_client.ECacheResult;
 import grpc.cache_client._DictionaryGetResponse;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,24 +18,19 @@ public interface CacheDictionaryGetFieldsResponse {
    * A successful dictionary get fields operation that found the keys with values in the dictionary.
    */
   class Hit implements CacheDictionaryGetFieldsResponse {
-    private final List<ByteString> fields;
-    private final List<_DictionaryGetResponse._DictionaryGetResponsePart> elements;
-
     public final List<CacheDictionaryGetFieldResponse> responsesList = new ArrayList<>();
 
     /**
      * Constructs a dictionary get fields hit with a list of encoded keys and values.
      *
-     * @param responses the retrieved resdictionary.
+     * @param responses the retrieved dictionary.
      */
     public Hit(
         List<ByteString> fields,
         List<_DictionaryGetResponse._DictionaryGetResponsePart> responses) {
-      this.fields = fields;
-      this.elements = responses;
 
       int counter = 0;
-      for (_DictionaryGetResponse._DictionaryGetResponsePart element : elements) {
+      for (_DictionaryGetResponse._DictionaryGetResponsePart element : responses) {
         if (element.getResult() == ECacheResult.Hit) {
           responsesList.add(
               new CacheDictionaryGetFieldResponse.Hit(fields.get(counter), element.getCacheBody()));
@@ -59,15 +53,12 @@ public interface CacheDictionaryGetFieldsResponse {
      * @return the dictionary.
      */
     public Map<String, String> valueDictionaryStringString() {
-      Map<String, String> map = new HashMap<>();
-      for (int i = 0; i < this.elements.size(); i++) {
-        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
-          map.put(
-              this.fields.get(i).toStringUtf8(),
-              this.elements.get(i).getCacheBody().toStringUtf8());
-        }
-      }
-      return map;
+      return responsesList.stream()
+          .filter(r -> r instanceof CacheDictionaryGetFieldResponse.Hit)
+          .collect(
+              Collectors.toMap(
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).fieldString(),
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).valueString()));
     }
 
     /**
@@ -76,14 +67,12 @@ public interface CacheDictionaryGetFieldsResponse {
      * @return the dictionary.
      */
     public Map<String, byte[]> valueDictionaryStringBytes() {
-      Map<String, byte[]> map = new HashMap<>();
-      for (int i = 0; i < this.elements.size(); i++) {
-        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
-          map.put(
-              this.fields.get(i).toStringUtf8(), this.elements.get(i).getCacheBody().toByteArray());
-        }
-      }
-      return map;
+      return responsesList.stream()
+          .filter(r -> r instanceof CacheDictionaryGetFieldResponse.Hit)
+          .collect(
+              Collectors.toMap(
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).fieldString(),
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).valueByteArray()));
     }
 
     /**
@@ -92,14 +81,12 @@ public interface CacheDictionaryGetFieldsResponse {
      * @return the dictionary.
      */
     public Map<byte[], String> valueDictionaryBytesString() {
-      Map<byte[], String> map = new HashMap<>();
-      for (int i = 0; i < this.elements.size(); i++) {
-        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
-          map.put(
-              this.fields.get(i).toByteArray(), this.elements.get(i).getCacheBody().toStringUtf8());
-        }
-      }
-      return map;
+      return responsesList.stream()
+          .filter(r -> r instanceof CacheDictionaryGetFieldResponse.Hit)
+          .collect(
+              Collectors.toMap(
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).fieldByteArray(),
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).valueString()));
     }
 
     /**
@@ -108,14 +95,12 @@ public interface CacheDictionaryGetFieldsResponse {
      * @return the dictionary.
      */
     public Map<byte[], byte[]> valueDictionaryBytesBytes() {
-      Map<byte[], byte[]> map = new HashMap<>();
-      for (int i = 0; i < this.elements.size(); i++) {
-        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
-          map.put(
-              this.fields.get(i).toByteArray(), this.elements.get(i).getCacheBody().toByteArray());
-        }
-      }
-      return map;
+      return responsesList.stream()
+          .filter(r -> r instanceof CacheDictionaryGetFieldResponse.Hit)
+          .collect(
+              Collectors.toMap(
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).fieldByteArray(),
+                  r -> ((CacheDictionaryGetFieldResponse.Hit) r).valueByteArray()));
     }
 
     @Override

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldsResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldsResponse.java
@@ -1,0 +1,189 @@
+package momento.sdk.messages;
+
+import com.google.protobuf.ByteString;
+import grpc.cache_client.ECacheResult;
+import grpc.cache_client._DictionaryGetResponse;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import momento.sdk.exceptions.CacheServiceExceptionMapper;
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/** Response for a dictionary get fields operation */
+public interface CacheDictionaryGetFieldsResponse {
+  /**
+   * A successful dictionary get fields operation that found the keys with values in the dictionary.
+   */
+  class Hit implements CacheDictionaryGetFieldsResponse {
+    private final List<ByteString> fields;
+    private final List<_DictionaryGetResponse._DictionaryGetResponsePart> elements;
+
+    public final List<CacheDictionaryGetFieldResponse> responsesList = new ArrayList<>();
+
+    /**
+     * Constructs a dictionary get fields hit with a list of encoded keys and values.
+     *
+     * @param responses the retrieved resdictionary.
+     */
+    public Hit(
+        List<ByteString> fields,
+        List<_DictionaryGetResponse._DictionaryGetResponsePart> responses) {
+      this.fields = fields;
+      this.elements = responses;
+
+      int counter = 0;
+      for (_DictionaryGetResponse._DictionaryGetResponsePart element : elements) {
+        if (element.getResult() == ECacheResult.Hit) {
+          responsesList.add(
+              new CacheDictionaryGetFieldResponse.Hit(fields.get(counter), element.getCacheBody()));
+        } else if (element.getResult() == ECacheResult.Miss) {
+          responsesList.add(new CacheDictionaryGetFieldResponse.Miss(fields.get(counter)));
+        } else {
+          responsesList.add(
+              new CacheDictionaryGetFieldResponse.Error(
+                  CacheServiceExceptionMapper.convert(
+                      new Exception(element.getResult().toString())),
+                  fields.get(counter)));
+        }
+        counter++;
+      }
+    }
+
+    /**
+     * Gets the retrieved dictionary of string keys and string values.
+     *
+     * @return the dictionary.
+     */
+    public Map<String, String> valueDictionaryStringString() {
+      Map<String, String> map = new HashMap<>();
+      for (int i = 0; i < this.elements.size(); i++) {
+        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
+          map.put(
+              this.fields.get(i).toStringUtf8(),
+              this.elements.get(i).getCacheBody().toStringUtf8());
+        }
+      }
+      return map;
+    }
+
+    /**
+     * Gets the retrieved dictionary of string keys and byte array values.
+     *
+     * @return the dictionary.
+     */
+    public Map<String, byte[]> valueDictionaryStringBytes() {
+      Map<String, byte[]> map = new HashMap<>();
+      for (int i = 0; i < this.elements.size(); i++) {
+        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
+          map.put(
+              this.fields.get(i).toStringUtf8(), this.elements.get(i).getCacheBody().toByteArray());
+        }
+      }
+      return map;
+    }
+
+    /**
+     * Gets the retrieved dictionary of byte array keys and string values.
+     *
+     * @return the dictionary.
+     */
+    public Map<byte[], String> valueDictionaryBytesString() {
+      Map<byte[], String> map = new HashMap<>();
+      for (int i = 0; i < this.elements.size(); i++) {
+        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
+          map.put(
+              this.fields.get(i).toByteArray(), this.elements.get(i).getCacheBody().toStringUtf8());
+        }
+      }
+      return map;
+    }
+
+    /**
+     * Gets the retrieved dictionary of byte array keys and byte array values.
+     *
+     * @return the dictionary.
+     */
+    public Map<byte[], byte[]> valueDictionaryBytesBytes() {
+      Map<byte[], byte[]> map = new HashMap<>();
+      for (int i = 0; i < this.elements.size(); i++) {
+        if (this.elements.get(i).getResult() == ECacheResult.Hit) {
+          map.put(
+              this.fields.get(i).toByteArray(), this.elements.get(i).getCacheBody().toByteArray());
+        }
+      }
+      return map;
+    }
+
+    @Override
+    public String toString() {
+      final String stringStringRepresentation =
+          valueDictionaryStringString().entrySet().stream()
+              .map(e -> e.getKey() + ":" + e.getValue())
+              .limit(5)
+              .map(StringHelpers::truncate)
+              .collect(Collectors.joining(", ", "\"", "\"..."));
+
+      final String bytesBytesRepresentation =
+          valueDictionaryBytesBytes().entrySet().stream()
+              .map(
+                  e ->
+                      Base64.getEncoder().encodeToString(e.getKey())
+                          + ":"
+                          + Base64.getEncoder().encodeToString(e.getValue()))
+              .limit(5)
+              .map(StringHelpers::truncate)
+              .collect(Collectors.joining(", ", "\"", "\"..."));
+
+      final String stringBytesRepresentation =
+          valueDictionaryStringBytes().entrySet().stream()
+              .map(e -> e.getKey() + ":" + Base64.getEncoder().encodeToString(e.getValue()))
+              .limit(5)
+              .map(StringHelpers::truncate)
+              .collect(Collectors.joining(", ", "\"", "\"..."));
+
+      final String bytesStringRepresentation =
+          valueDictionaryBytesString().entrySet().stream()
+              .map(e -> Base64.getEncoder().encodeToString(e.getKey()) + ":" + e.getValue())
+              .limit(5)
+              .map(StringHelpers::truncate)
+              .collect(Collectors.joining(", ", "\"", "\"..."));
+
+      return super.toString()
+          + ": valueStringString: "
+          + stringStringRepresentation
+          + " valueByteBytes: "
+          + bytesBytesRepresentation
+          + " valueStringBytes: "
+          + stringBytesRepresentation
+          + " valueBytesString: "
+          + bytesStringRepresentation;
+    }
+  }
+
+  /**
+   * A successful cache dictionary get fields operation for a key that does not exist in the
+   * dictionary.
+   */
+  class Miss implements CacheDictionaryGetFieldsResponse {}
+
+  /**
+   * A failed cache dictionary get fields operation. The response itself is an exception, so it can
+   * be directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements CacheDictionaryGetFieldsResponse {
+
+    /**
+     * Constructs a cache dictionary get fields error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}


### PR DESCRIPTION
## PR Description:
### Commit 1
- Add dictionaryGetFields API
- Add field parameter to CacheDictionaryGetFieldResponse.Error constructor (required for implementing the plural case)
- Add integ tests

### Commit 2
- Remove elements and fields internal representation from response class
- Use the responseList to get the map for desired data types
- fix minor bugs/ addressed comments on commit 1

## Issue
#171 