### PR TITLE
chore: add fromString and fromEnvVar methods to CredentialProvider

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/BaseTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/BaseTestClass.java
@@ -2,7 +2,6 @@ package momento.sdk;
 
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AlreadyExistsException;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,7 +22,7 @@ class BaseTestClass {
   }
 
   private static void ensureTestCacheExists() {
-    final CredentialProvider credentialProvider = new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+    final CredentialProvider credentialProvider = CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
     try (CacheClient client =
         CacheClient.builder(
                 credentialProvider, Configurations.Laptop.Latest(), Duration.ofSeconds(10))

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.auth.StringCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AuthenticationException;
@@ -30,7 +29,7 @@ final class CacheClientTest extends BaseTestClass {
   private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
 
   private CacheClient target;
 

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -6,8 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
-import momento.sdk.auth.StringCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.exceptions.AuthenticationException;
@@ -29,7 +27,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
   private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private CacheClient target;
 
   @BeforeEach
@@ -144,7 +142,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiIsImNwIjoiY29udHJvbC5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b"
             + "2hxLmNvbSIsImMiOiJjYWNoZS5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSJ9.gdghdjjfjyehhdkkkskskmml"
             + "s76573jnajhjjjhjdhnndy";
-    final CredentialProvider badTokenProvider = new StringCredentialProvider(badToken);
+    final CredentialProvider badTokenProvider = CredentialProvider.fromString(badToken);
 
     try (final CacheClient client =
         CacheClient.builder(

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.messages.CacheDeleteResponse;
@@ -21,7 +20,7 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
   private static final Duration DEFAULT_ITEM_TTL_SECONDS = Duration.ofSeconds(60);
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
   private CacheClient client;
 

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.auth.StringCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AuthenticationException;
@@ -24,7 +23,7 @@ final class CacheDataPlaneTest extends BaseTestClass {
   private static final Duration DEFAULT_ITEM_TTL_SECONDS = Duration.ofSeconds(60);
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
 
   private CacheClient client;

--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.BadRequestException;
 import momento.sdk.exceptions.InvalidArgumentException;
@@ -34,7 +33,7 @@ public class DictionaryTest extends BaseTestClass {
   private CacheClient target;
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
   private final String dictionaryName = "test-dictionary";
 

--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.messages.CacheListConcatenateBackResponse;
@@ -33,7 +32,7 @@ public class ListTest extends BaseTestClass {
   private CacheClient target;
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
 
   private final List<String> values = Arrays.asList("val1", "val2", "val3", "val4");

--- a/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
@@ -8,7 +8,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.messages.CacheSetAddElementResponse;
@@ -27,7 +26,7 @@ public class SetTest {
   private static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
   private CacheClient client;
 

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.EnvVarCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.exceptions.NotFoundException;
@@ -39,7 +38,7 @@ public class SortedSetTest {
   private static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
 
   private final CredentialProvider credentialProvider =
-      new EnvVarCredentialProvider("TEST_AUTH_TOKEN");
+      CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
   private final String cacheName = System.getenv("TEST_CACHE_NAME");
   private CacheClient client;
 

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -1,29 +1,51 @@
 package momento.sdk.auth;
 
+import javax.annotation.Nonnull;
+
 /**
  * Specifies the fields that are required for a Momento client to connect to and authenticate with
  * the Momento service.
  */
-public interface CredentialProvider {
+public abstract class CredentialProvider {
 
   /**
-   * The JWT used to authenticate to Momento.
+   * Creates a CredentialProvider using the provided auth token.
    *
-   * @return the JWT
+   * @param authToken A Momento auth token.
+   * @return The provider.
    */
-  String getAuthToken();
+  public static CredentialProvider fromString(@Nonnull String authToken) {
+    return new StringCredentialProvider(authToken);
+  }
 
   /**
-   * The endpoint with which the Momento client will connect to the Momento control plane.
+   * Creates a CredentialProvider by loading an auth token from the provided environment variable.
    *
-   * @return the endpoint
+   * @param envVar An environment variable containing a Momento auth token.
+   * @return The provider.
    */
-  String getControlEndpoint();
+  public static CredentialProvider fromEnvVar(@Nonnull String envVar) {
+    return new EnvVarCredentialProvider(envVar);
+  }
 
   /**
-   * The endpoint with which the Momento client will connect to the Momento data plane.
+   * Gets the token used to authenticate to Momento.
    *
-   * @return the endpoint
+   * @return The token.
    */
-  String getCacheEndpoint();
+  public abstract String getAuthToken();
+
+  /**
+   * Gets the endpoint with which the Momento client will connect to the Momento control plane.
+   *
+   * @return The endpoint.
+   */
+  public abstract String getControlEndpoint();
+
+  /**
+   * Gets the endpoint with which the Momento client will connect to the Momento data plane.
+   *
+   * @return The endpoint.
+   */
+  public abstract String getCacheEndpoint();
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 import momento.sdk.exceptions.InvalidArgumentException;
 
 /** Parses connection and authentication information from a JWT provided as a string. */
-public class StringCredentialProvider implements CredentialProvider {
+public class StringCredentialProvider extends CredentialProvider {
 
   private static class TokenAndEndpoints {
     public final String controlEndpoint;


### PR DESCRIPTION
Add fromString and fromEnvVar methods to CredentialProvider.

Change most instances of CredentialProvider in tests to use the new methods.