### PR TITLE
chore: Remove ByteBuffer methods and fix warnings

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
@@ -2,7 +2,6 @@ package momento.sdk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.auth.EnvVarCredentialProvider;
@@ -72,12 +71,6 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
     assertThat((CacheSetResponse.Error) stringSetResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    final CacheSetResponse byteBufferSetResponse =
-        client.set(cacheName, null, ByteBuffer.allocate(1), Duration.ofSeconds(10)).join();
-    assertThat(byteBufferSetResponse).isInstanceOf(CacheSetResponse.Error.class);
-    assertThat((CacheSetResponse.Error) byteBufferSetResponse)
-        .hasCauseInstanceOf(InvalidArgumentException.class);
-
     final CacheSetResponse byteKeySetResponse =
         client.set(cacheName, null, new byte[] {0x00}, Duration.ofSeconds(10)).join();
     assertThat(byteKeySetResponse).isInstanceOf(CacheSetResponse.Error.class);
@@ -88,15 +81,9 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
   @Test
   public void nullValueSetReturnsError() {
     final CacheSetResponse stringResponse =
-        client.set(cacheName, "hello", (String) null, Duration.ofSeconds(10)).join();
+        client.set(cacheName, "hello", null, Duration.ofSeconds(10)).join();
     assertThat(stringResponse).isInstanceOf(CacheSetResponse.Error.class);
     assertThat((CacheSetResponse.Error) stringResponse)
-        .hasCauseInstanceOf(InvalidArgumentException.class);
-
-    final CacheSetResponse byteBufferResponse =
-        client.set(cacheName, "hello", (ByteBuffer) null, Duration.ofSeconds(10)).join();
-    assertThat(byteBufferResponse).isInstanceOf(CacheSetResponse.Error.class);
-    assertThat((CacheSetResponse.Error) byteBufferResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
     final CacheSetResponse byteArrayResponse =
@@ -112,12 +99,6 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
         client.set(cacheName, "hello", "", Duration.ofSeconds(-1)).join();
     assertThat(stringSetResponse).isInstanceOf(CacheSetResponse.Error.class);
     assertThat((CacheSetResponse.Error) stringSetResponse)
-        .hasCauseInstanceOf(InvalidArgumentException.class);
-
-    final CacheSetResponse byteBufferSetResponse =
-        client.set(cacheName, "hello", ByteBuffer.allocate(1), Duration.ofSeconds(-1)).join();
-    assertThat(byteBufferSetResponse).isInstanceOf(CacheSetResponse.Error.class);
-    assertThat((CacheSetResponse.Error) byteBufferSetResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
     final CacheSetResponse byteArraySetResponse =

--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -1025,9 +1025,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryIncrementStringFieldHappyPath() {
     // Increment with ttl
-    assertThat(
-            target.dictionaryIncrement(
-                cacheName, dictionaryName, "a", 1, CollectionTtl.fromCacheTtl()))
+    assertThat(target.dictionaryIncrement(cacheName, dictionaryName, "a", 1))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Success.class))
@@ -1063,9 +1061,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryIncrementByteArrayFieldHappyPath() {
     // Increment with ttl
-    assertThat(
-            target.dictionaryIncrement(
-                cacheName, dictionaryName, "a".getBytes(), 1, CollectionTtl.fromCacheTtl()))
+    assertThat(target.dictionaryIncrement(cacheName, dictionaryName, "a".getBytes(), 1))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Success.class))

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -1,7 +1,6 @@
 package momento.sdk;
 
 import java.io.Closeable;
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -205,40 +204,6 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheDeleteResponse> delete(String cacheName, byte[] key) {
     return scsDataClient.delete(cacheName, key);
-  }
-
-  /**
-   * Sets the value in cache with a given Time To Live (TTL) seconds.
-   *
-   * <p>If a value for this key is already present it will be replaced by the new value.
-   *
-   * @param cacheName Name of the cache to store the item in
-   * @param key The key under which the value is to be added.
-   * @param value The value to be stored.
-   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
-   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
-   *     Duration)}
-   * @return Future containing the result of the set operation.
-   */
-  public CompletableFuture<CacheSetResponse> set(
-      String cacheName, String key, ByteBuffer value, @Nullable Duration ttl) {
-    return scsDataClient.set(cacheName, key, value, ttl);
-  }
-
-  /**
-   * Sets the value in the cache. If a value for this key is already present it will be replaced by
-   * the new value.
-   *
-   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
-   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
-   *
-   * @param cacheName Name of the cache to store the item in
-   * @param key The key under which the value is to be added.
-   * @param value The value to be stored.
-   * @return Future containing the result of the set operation.
-   */
-  public CompletableFuture<CacheSetResponse> set(String cacheName, String key, ByteBuffer value) {
-    return scsDataClient.set(cacheName, key, value, null);
   }
 
   /**


### PR DESCRIPTION
Remove client methods that take a ByteBuffer. They can be added later if desired.

Fix warnings in ScsDataClient.