### PR TITLE
chore: normalize sorted set api names

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -59,7 +59,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementStringHappyPath() {
-    final String element = "1";
+    final String value = "1";
     final double score = 1.0;
 
     assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
@@ -68,7 +68,7 @@ public class SortedSetTest extends BaseTestClass {
 
     assertThat(
             client.sortedSetPutElement(
-                cacheName, sortedSetName, element, score, CollectionTtl.fromCacheTtl()))
+                cacheName, sortedSetName, value, score, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSortedSetPutElementResponse.Success.class);
 
@@ -78,14 +78,14 @@ public class SortedSetTest extends BaseTestClass {
         .satisfies(
             hit -> {
               final List<ScoredElement> scoredElements = hit.elementsList();
-              assertThat(scoredElements).map(ScoredElement::getElement).containsOnly(element);
+              assertThat(scoredElements).map(ScoredElement::getElement).containsOnly(value);
               assertThat(scoredElements).map(ScoredElement::getScore).containsOnly(score);
             });
   }
 
   @Test
   public void sortedSetPutElementBytesHappyPath() {
-    final byte[] element = "1".getBytes();
+    final byte[] value = "1".getBytes();
     final double score = 1.0;
 
     assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
@@ -94,7 +94,7 @@ public class SortedSetTest extends BaseTestClass {
 
     assertThat(
             client.sortedSetPutElement(
-                cacheName, sortedSetName, element, score, CollectionTtl.fromCacheTtl()))
+                cacheName, sortedSetName, value, score, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSortedSetPutElementResponse.Success.class);
 
@@ -106,7 +106,7 @@ public class SortedSetTest extends BaseTestClass {
               final List<ScoredElement> scoredElements = hit.elementsList();
               assertThat(scoredElements)
                   .map(ScoredElement::getElementByteArray)
-                  .containsOnly(element);
+                  .containsOnly(value);
               assertThat(scoredElements).map(ScoredElement::getScore).containsOnly(score);
             });
   }

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -934,7 +934,7 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param value - The value  whose score we are retrieving.
+   * @param value - The value whose score we are retrieving.
    * @return Future containing the result of the get score operation.
    */
   public CompletableFuture<CacheSortedSetGetScoreResponse> sortedSetGetScore(

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -688,7 +688,7 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to add to.
-   * @param element - The element to add.
+   * @param value - The value of the element to add.
    * @param score - The score to assign to the element.
    * @param ttl TTL for the set in cache. This TTL takes precedence over the TTL used when
    *     initializing a cache client. Defaults to client TTL.
@@ -697,10 +697,10 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheSortedSetPutElementResponse> sortedSetPutElement(
       String cacheName,
       String sortedSetName,
-      String element,
+      String value,
       double score,
       @Nullable CollectionTtl ttl) {
-    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, element, score, ttl);
+    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, value, score, ttl);
   }
 
   /**
@@ -709,13 +709,13 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to add to.
-   * @param element - The element to add.
+   * @param value - The value of the element to add.
    * @param score - The score to assign to the element.
    * @return Future containing the result of the put element operation.
    */
   public CompletableFuture<CacheSortedSetPutElementResponse> sortedSetPutElement(
-      String cacheName, String sortedSetName, String element, double score) {
-    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, element, score, null);
+      String cacheName, String sortedSetName, String value, double score) {
+    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, value, score, null);
   }
 
   /**
@@ -724,7 +724,7 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to add to.
-   * @param element - The element to add.
+   * @param value - The value of the element to add.
    * @param score - The score to assign to the element.
    * @param ttl TTL for the set in cache. This TTL takes precedence over the TTL used when
    *     initializing a cache client. Defaults to client TTL.
@@ -733,10 +733,10 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheSortedSetPutElementResponse> sortedSetPutElement(
       String cacheName,
       String sortedSetName,
-      byte[] element,
+      byte[] value,
       double score,
       @Nullable CollectionTtl ttl) {
-    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, element, score, ttl);
+    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, value, score, ttl);
   }
 
   /**
@@ -745,13 +745,13 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to add to.
-   * @param element - The element to add.
+   * @param value - The value of the element to add.
    * @param score - The score to assign to the element.
    * @return Future containing the result of the put element operation.
    */
   public CompletableFuture<CacheSortedSetPutElementResponse> sortedSetPutElement(
-      String cacheName, String sortedSetName, byte[] element, double score) {
-    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, element, score, null);
+      String cacheName, String sortedSetName, byte[] value, double score) {
+    return scsDataClient.sortedSetPutElement(cacheName, sortedSetName, value, score, null);
   }
 
   /**
@@ -904,14 +904,14 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose rank we are retrieving.
+   * @param value - The value of element whose rank we are retrieving.
    * @param order - The order to read through the scores of the set. Affects the rank. Defaults to
    *     ascending, i.e. the rank of the element with the lowest score will be 0.
    * @return Future containing the result of the get rank operation.
    */
   public CompletableFuture<CacheSortedSetGetRankResponse> sortedSetGetRank(
-      String cacheName, String sortedSetName, String element, @Nullable SortOrder order) {
-    return scsDataClient.sortedSetGetRank(cacheName, sortedSetName, element, order);
+      String cacheName, String sortedSetName, String value, @Nullable SortOrder order) {
+    return scsDataClient.sortedSetGetRank(cacheName, sortedSetName, value, order);
   }
 
   /**
@@ -919,14 +919,14 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose rank we are retrieving.
+   * @param value - The value of element whose rank we are retrieving.
    * @param order - The order to read through the scores of the set. Affects the rank. Defaults to
    *     ascending, i.e. the rank of the element with the lowest score will be 0.
    * @return Future containing the result of the get rank operation.
    */
   public CompletableFuture<CacheSortedSetGetRankResponse> sortedSetGetRank(
-      String cacheName, String sortedSetName, byte[] element, @Nullable SortOrder order) {
-    return scsDataClient.sortedSetGetRank(cacheName, sortedSetName, element, order);
+      String cacheName, String sortedSetName, byte[] value, @Nullable SortOrder order) {
+    return scsDataClient.sortedSetGetRank(cacheName, sortedSetName, value, order);
   }
 
   /**
@@ -934,12 +934,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose score we are retrieving.
+   * @param value - The value  whose score we are retrieving.
    * @return Future containing the result of the get score operation.
    */
   public CompletableFuture<CacheSortedSetGetScoreResponse> sortedSetGetScore(
-      String cacheName, String sortedSetName, String element) {
-    return scsDataClient.sortedSetGetScore(cacheName, sortedSetName, element);
+      String cacheName, String sortedSetName, String value) {
+    return scsDataClient.sortedSetGetScore(cacheName, sortedSetName, value);
   }
 
   /**
@@ -947,12 +947,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose score we are retrieving.
+   * @param value - The value whose score we are retrieving.
    * @return Future containing the result of the get score operation.
    */
   public CompletableFuture<CacheSortedSetGetScoreResponse> sortedSetGetScore(
-      String cacheName, String sortedSetName, byte[] element) {
-    return scsDataClient.sortedSetGetScore(cacheName, sortedSetName, element);
+      String cacheName, String sortedSetName, byte[] value) {
+    return scsDataClient.sortedSetGetScore(cacheName, sortedSetName, value);
   }
 
   /**
@@ -960,12 +960,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param elements - The elements whose scores we are retrieving.
+   * @param values - The values whose scores we are retrieving.
    * @return Future containing the result of the get scores operation.
    */
   public CompletableFuture<CacheSortedSetGetScoresResponse> sortedSetGetScores(
-      String cacheName, String sortedSetName, Set<String> elements) {
-    return scsDataClient.sortedSetGetScores(cacheName, sortedSetName, elements);
+      String cacheName, String sortedSetName, Set<String> values) {
+    return scsDataClient.sortedSetGetScores(cacheName, sortedSetName, values);
   }
 
   /**
@@ -973,12 +973,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param elements - The elements whose scores we are retrieving.
+   * @param values - The values whose scores we are retrieving.
    * @return Future containing the result of the get scores operation.
    */
   public CompletableFuture<CacheSortedSetGetScoresResponse> sortedSetGetScoresByteArray(
-      String cacheName, String sortedSetName, Set<byte[]> elements) {
-    return scsDataClient.sortedSetGetScoresByteArray(cacheName, sortedSetName, elements);
+      String cacheName, String sortedSetName, Set<byte[]> values) {
+    return scsDataClient.sortedSetGetScoresByteArray(cacheName, sortedSetName, values);
   }
 
   /**
@@ -986,7 +986,7 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose score we are incrementing.
+   * @param value - The value whose score we are incrementing.
    * @param amount - The quantity to add to the score. May be positive, negative, or zero.
    * @param ttl TTL for the set in cache. This TTL takes precedence over the TTL used when
    *     initializing a cache client. Defaults to client TTL.
@@ -995,10 +995,10 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheSortedSetIncrementScoreResponse> sortedSetIncrementScore(
       String cacheName,
       String sortedSetName,
-      String element,
+      String value,
       double amount,
       @Nullable CollectionTtl ttl) {
-    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, element, amount, ttl);
+    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, value, amount, ttl);
   }
 
   /**
@@ -1006,13 +1006,13 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose score we are incrementing.
+   * @param value - The value whose score we are incrementing.
    * @param amount - The quantity to add to the score. May be positive, negative, or zero.
    * @return Future containing the result of the increment operation.
    */
   public CompletableFuture<CacheSortedSetIncrementScoreResponse> sortedSetIncrementScore(
-      String cacheName, String sortedSetName, String element, double amount) {
-    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, element, amount, null);
+      String cacheName, String sortedSetName, String value, double amount) {
+    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, value, amount, null);
   }
 
   /**
@@ -1020,7 +1020,7 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose score we are incrementing.
+   * @param value - The value whose score we are incrementing.
    * @param amount - The quantity to add to the score. May be positive, negative, or zero.
    * @param ttl TTL for the set in cache. This TTL takes precedence over the TTL used when
    *     initializing a cache client. Defaults to client TTL.
@@ -1029,10 +1029,10 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheSortedSetIncrementScoreResponse> sortedSetIncrementScore(
       String cacheName,
       String sortedSetName,
-      byte[] element,
+      byte[] value,
       double amount,
       @Nullable CollectionTtl ttl) {
-    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, element, amount, ttl);
+    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, value, amount, ttl);
   }
 
   /**
@@ -1040,13 +1040,13 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param element - The element whose score we are incrementing.
+   * @param value - The value whose score we are incrementing.
    * @param amount - The quantity to add to the score. May be positive, negative, or zero.
    * @return Future containing the result of the increment operation.
    */
   public CompletableFuture<CacheSortedSetIncrementScoreResponse> sortedSetIncrementScore(
-      String cacheName, String sortedSetName, byte[] element, double amount) {
-    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, element, amount, null);
+      String cacheName, String sortedSetName, byte[] value, double amount) {
+    return scsDataClient.sortedSetIncrementScore(cacheName, sortedSetName, value, amount, null);
   }
 
   /**
@@ -1054,12 +1054,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to remove from.
-   * @param element - The element to remove from the set.
+   * @param value - The value of the element to remove from the set.
    * @return Future containing the result of the remove operation.
    */
   public CompletableFuture<CacheSortedSetRemoveElementResponse> sortedSetRemoveElement(
-      String cacheName, String sortedSetName, String element) {
-    return scsDataClient.sortedSetRemoveElement(cacheName, sortedSetName, element);
+      String cacheName, String sortedSetName, String value) {
+    return scsDataClient.sortedSetRemoveElement(cacheName, sortedSetName, value);
   }
 
   /**
@@ -1067,12 +1067,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to remove from.
-   * @param element - The element to remove from the set.
+   * @param value - The value of the element to remove from the set.
    * @return Future containing the result of the remove operation.
    */
   public CompletableFuture<CacheSortedSetRemoveElementResponse> sortedSetRemoveElement(
-      String cacheName, String sortedSetName, byte[] element) {
-    return scsDataClient.sortedSetRemoveElement(cacheName, sortedSetName, element);
+      String cacheName, String sortedSetName, byte[] value) {
+    return scsDataClient.sortedSetRemoveElement(cacheName, sortedSetName, value);
   }
 
   /**
@@ -1080,12 +1080,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to remove from.
-   * @param elements - The elements to remove from the set.
+   * @param values - The values of elements to remove from the set.
    * @return Future containing the result of the remove operation.
    */
   public CompletableFuture<CacheSortedSetRemoveElementsResponse> sortedSetRemoveElements(
-      String cacheName, String sortedSetName, Set<String> elements) {
-    return scsDataClient.sortedSetRemoveElements(cacheName, sortedSetName, elements);
+      String cacheName, String sortedSetName, Set<String> values) {
+    return scsDataClient.sortedSetRemoveElements(cacheName, sortedSetName, values);
   }
 
   /**
@@ -1093,12 +1093,12 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to remove from.
-   * @param elements - The elements to remove from the set.
+   * @param values - The values of the elements to remove from the set.
    * @return Future containing the result of the remove operation.
    */
   public CompletableFuture<CacheSortedSetRemoveElementsResponse> sortedSetRemoveElementsByteArray(
-      String cacheName, String sortedSetName, Set<byte[]> elements) {
-    return scsDataClient.sortedSetRemoveElementsByteArray(cacheName, sortedSetName, elements);
+      String cacheName, String sortedSetName, Set<byte[]> values) {
+    return scsDataClient.sortedSetRemoveElementsByteArray(cacheName, sortedSetName, values);
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -2210,8 +2210,7 @@ final class ScsDataClient extends ScsClient {
     final Supplier<ListenableFuture<_SortedSetRemoveResponse>> stubSupplier =
         () ->
             attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-                .sortedSetRemove(
-                    buildSortedSetRemove(sortedSetName, Collections.singleton(value)));
+                .sortedSetRemove(buildSortedSetRemove(sortedSetName, Collections.singleton(value)));
 
     final Function<_SortedSetRemoveResponse, CacheSortedSetRemoveElementResponse> success =
         rsp -> new CacheSortedSetRemoveElementResponse.Success();

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -1857,7 +1857,7 @@ final class ScsDataClient extends ScsClient {
   private CompletableFuture<CacheSortedSetPutElementResponse> sendSortedSetPutElement(
       String cacheName,
       ByteString sortedSetName,
-      ByteString element,
+      ByteString value,
       double score,
       CollectionTtl collectionTtl) {
 
@@ -1867,7 +1867,7 @@ final class ScsDataClient extends ScsClient {
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
             .sortedSetPut(
                 buildSortedSetPutRequest(
-                    sortedSetName, Collections.singletonMap(element, score), collectionTtl));
+                    sortedSetName, Collections.singletonMap(value, score), collectionTtl));
 
     // Build a CompletableFuture to return to caller
     final CompletableFuture<CacheSortedSetPutElementResponse> returnFuture =
@@ -2061,13 +2061,13 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheSortedSetGetRankResponse> sendSortedSetGetRank(
-      String cacheName, ByteString sortedSetName, ByteString element, @Nullable SortOrder order) {
+      String cacheName, ByteString sortedSetName, ByteString value, @Nullable SortOrder order) {
     final Metadata metadata = metadataWithCache(cacheName);
 
     final Supplier<ListenableFuture<_SortedSetGetRankResponse>> stubSupplier =
         () ->
             attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-                .sortedSetGetRank(buildSortedSetGetRank(sortedSetName, element, order));
+                .sortedSetGetRank(buildSortedSetGetRank(sortedSetName, value, order));
 
     final Function<_SortedSetGetRankResponse, CacheSortedSetGetRankResponse> success =
         rsp -> {
@@ -2087,14 +2087,14 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheSortedSetGetScoreResponse> sendSortedSetGetScore(
-      String cacheName, ByteString sortedSetName, ByteString element) {
+      String cacheName, ByteString sortedSetName, ByteString value) {
     final Metadata metadata = metadataWithCache(cacheName);
 
     final Supplier<ListenableFuture<_SortedSetGetScoreResponse>> stubSupplier =
         () ->
             attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
                 .sortedSetGetScore(
-                    buildSortedSetGetScores(sortedSetName, Collections.singletonList(element)));
+                    buildSortedSetGetScores(sortedSetName, Collections.singletonList(value)));
 
     final Function<_SortedSetGetScoreResponse, CacheSortedSetGetScoreResponse> success =
         rsp -> {
@@ -2105,9 +2105,9 @@ final class ScsDataClient extends ScsClient {
               final _SortedSetGetScoreResponse._SortedSetGetScoreResponsePart part = partOpt.get();
 
               if (part.getResult().equals(ECacheResult.Hit)) {
-                return new CacheSortedSetGetScoreResponse.Hit(element, part.getScore());
+                return new CacheSortedSetGetScoreResponse.Hit(value, part.getScore());
               } else if (part.getResult().equals(ECacheResult.Miss)) {
-                return new CacheSortedSetGetScoreResponse.Miss(element);
+                return new CacheSortedSetGetScoreResponse.Miss(value);
               } else {
                 return new CacheSortedSetGetScoreResponse.Error(
                     new UnknownException("Unrecognized result: " + part.getResult()));
@@ -2118,7 +2118,7 @@ final class ScsDataClient extends ScsClient {
             }
 
           } else {
-            return new CacheSortedSetGetScoreResponse.Miss(element);
+            return new CacheSortedSetGetScoreResponse.Miss(value);
           }
         };
 
@@ -2131,11 +2131,11 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheSortedSetGetScoresResponse> sendSortedSetGetScores(
-      String cacheName, ByteString sortedSetName, Set<ByteString> elements) {
+      String cacheName, ByteString sortedSetName, Set<ByteString> values) {
 
     // We need to know the order of the elements so that we can
     // match them up with the values returned from the server.
-    final List<ByteString> orderedElements = new ArrayList<>(elements);
+    final List<ByteString> orderedElements = new ArrayList<>(values);
 
     final Metadata metadata = metadataWithCache(cacheName);
 
@@ -2182,7 +2182,7 @@ final class ScsDataClient extends ScsClient {
   private CompletableFuture<CacheSortedSetIncrementScoreResponse> sendSortedSetIncrementScore(
       String cacheName,
       ByteString sortedSetName,
-      ByteString element,
+      ByteString value,
       double amount,
       CollectionTtl ttl) {
     final Metadata metadata = metadataWithCache(cacheName);
@@ -2190,7 +2190,7 @@ final class ScsDataClient extends ScsClient {
     final Supplier<ListenableFuture<_SortedSetIncrementResponse>> stubSupplier =
         () ->
             attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-                .sortedSetIncrement(buildSortedSetIncrement(sortedSetName, element, amount, ttl));
+                .sortedSetIncrement(buildSortedSetIncrement(sortedSetName, value, amount, ttl));
 
     final Function<_SortedSetIncrementResponse, CacheSortedSetIncrementScoreResponse> success =
         rsp -> new CacheSortedSetIncrementScoreResponse.Success(rsp.getScore());
@@ -2204,14 +2204,14 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheSortedSetRemoveElementResponse> sendSortedSetRemoveElement(
-      String cacheName, ByteString sortedSetName, ByteString element) {
+      String cacheName, ByteString sortedSetName, ByteString value) {
     final Metadata metadata = metadataWithCache(cacheName);
 
     final Supplier<ListenableFuture<_SortedSetRemoveResponse>> stubSupplier =
         () ->
             attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
                 .sortedSetRemove(
-                    buildSortedSetRemove(sortedSetName, Collections.singleton(element)));
+                    buildSortedSetRemove(sortedSetName, Collections.singleton(value)));
 
     final Function<_SortedSetRemoveResponse, CacheSortedSetRemoveElementResponse> success =
         rsp -> new CacheSortedSetRemoveElementResponse.Success();
@@ -2225,13 +2225,13 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheSortedSetRemoveElementsResponse> sendSortedSetRemoveElements(
-      String cacheName, ByteString sortedSetName, Set<ByteString> elements) {
+      String cacheName, ByteString sortedSetName, Set<ByteString> values) {
     final Metadata metadata = metadataWithCache(cacheName);
 
     final Supplier<ListenableFuture<_SortedSetRemoveResponse>> stubSupplier =
         () ->
             attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-                .sortedSetRemove(buildSortedSetRemove(sortedSetName, elements));
+                .sortedSetRemove(buildSortedSetRemove(sortedSetName, values));
 
     final Function<_SortedSetRemoveResponse, CacheSortedSetRemoveElementsResponse> success =
         rsp -> new CacheSortedSetRemoveElementsResponse.Success();


### PR DESCRIPTION
Many sorted set APIs alter an element, as indexed by a
`value`. Consistent with other SDKs, we call the argument `value`, not
`element`, since `element` can be confused with the value+score
combination.

work towards https://github.com/momentohq/client-sdk-java/issues/248
