### PR TITLE
chore: Update list internal methods with nullable truncate*ToSize

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -60,7 +60,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateBack(
-                cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, oldValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -72,7 +72,7 @@ public class ListTest extends BaseTestClass {
     // Add same list
     assertThat(
             target.listConcatenateBack(
-                cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, oldValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -83,7 +83,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
     // Add a new values list without specifying ttl
-    assertThat(target.listConcatenateBack(cacheName, listName, newValues, 0))
+    assertThat(target.listConcatenateBack(cacheName, listName, newValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -107,7 +107,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateBackByteArray(
-                cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, oldValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -119,7 +119,7 @@ public class ListTest extends BaseTestClass {
     // Add same list
     assertThat(
             target.listConcatenateBackByteArray(
-                cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, oldValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -138,7 +138,7 @@ public class ListTest extends BaseTestClass {
             hit -> assertThat(hit.valueListByteArray()).hasSize(6).containsAll(expectedList));
 
     // Add a new values list without specifying ttl
-    assertThat(target.listConcatenateBackByteArray(cacheName, listName, newValues, 0))
+    assertThat(target.listConcatenateBackByteArray(cacheName, listName, newValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -169,13 +169,13 @@ public class ListTest extends BaseTestClass {
     // With ttl specified in method signature
     assertThat(
             target.listConcatenateBack(
-                null, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                null, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBack(null, listName, stringValues, 0))
+    assertThat(target.listConcatenateBack(null, listName, stringValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -183,13 +183,13 @@ public class ListTest extends BaseTestClass {
     // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackByteArray(
-                null, listName, byteArrayValues, 0, CollectionTtl.fromCacheTtl()))
+                null, listName, byteArrayValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackByteArray(null, listName, byteArrayValues, 0))
+    assertThat(target.listConcatenateBackByteArray(null, listName, byteArrayValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -204,13 +204,13 @@ public class ListTest extends BaseTestClass {
     // With ttl specified in method signature
     assertThat(
             target.listConcatenateBack(
-                cacheName, null, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, null, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBack(cacheName, null, stringValues, 0))
+    assertThat(target.listConcatenateBack(cacheName, null, stringValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -218,13 +218,13 @@ public class ListTest extends BaseTestClass {
     // With ttl specified in method signature
     assertThat(
             target.listConcatenateBackByteArray(
-                cacheName, null, byteArrayValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, null, byteArrayValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackByteArray(cacheName, null, byteArrayValues, 0))
+    assertThat(target.listConcatenateBackByteArray(cacheName, null, byteArrayValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -234,13 +234,14 @@ public class ListTest extends BaseTestClass {
   public void shouldFailListConcatenateBackWhenNullElement() {
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBack(cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
+            target.listConcatenateBack(
+                cacheName, listName, null, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBack(cacheName, listName, null, 0))
+    assertThat(target.listConcatenateBack(cacheName, listName, null, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -254,7 +255,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackByteArray(cacheName, listName, null, 0))
+    assertThat(target.listConcatenateBackByteArray(cacheName, listName, null, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -264,7 +265,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithPositiveStartEndIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(
+            cacheName, listName, values, 100, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     CacheListFetchResponse cacheListFetchResponse =
@@ -281,7 +283,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNegativeStartEndIndices() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(
+            cacheName, listName, values, 100, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     CacheListFetchResponse cacheListFetchResponse =
@@ -298,7 +301,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNullStartIndex() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(
+            cacheName, listName, values, 100, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // valid case for null startIndex and positive endIndex
@@ -325,7 +329,8 @@ public class ListTest extends BaseTestClass {
   public void shouldFetchAllValuesWhenListFetchWithNullEndIndex() {
     final String listName = "listName";
     target
-        .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
+        .listConcatenateBack(
+            cacheName, listName, values, 100, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // valid case for positive startIndex and null endIndex
@@ -383,7 +388,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, oldValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -395,7 +400,7 @@ public class ListTest extends BaseTestClass {
     // Add same list
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, oldValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, oldValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -406,7 +411,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
     // Add a new values list without specifying ttl
-    assertThat(target.listConcatenateFront(cacheName, listName, newValues, 0))
+    assertThat(target.listConcatenateFront(cacheName, listName, newValues, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -598,7 +603,7 @@ public class ListTest extends BaseTestClass {
     // add string values to list
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -610,7 +615,7 @@ public class ListTest extends BaseTestClass {
     // add byte array values to list
     assertThat(
             target.listConcatenateFrontByteArray(
-                cacheName, listName, byteArrayValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, byteArrayValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -649,7 +654,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateBack(
-                cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, values, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -692,7 +697,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateBack(
-                cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, values, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateBackResponse.Success.class);
 
@@ -734,7 +739,8 @@ public class ListTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
-    assertThat(target.listPushBack(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushBack(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -744,7 +750,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushBack(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushBack(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -755,7 +762,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(2).containsAll(expectedList));
 
     // Add a new value without specifying ttl
-    assertThat(target.listPushBack(cacheName, listName, newValue, 0))
+    assertThat(target.listPushBack(cacheName, listName, newValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -776,7 +783,8 @@ public class ListTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
-    assertThat(target.listPushBack(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushBack(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -786,7 +794,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListByteArray()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushBack(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushBack(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -798,7 +807,7 @@ public class ListTest extends BaseTestClass {
             hit -> assertThat(hit.valueListByteArray()).hasSize(2).containsAll(expectedList));
 
     // Add a new value without specifying ttl
-    assertThat(target.listPushBack(cacheName, listName, newValue, 0))
+    assertThat(target.listPushBack(cacheName, listName, newValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushBackResponse.Success.class);
 
@@ -912,7 +921,8 @@ public class ListTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
-    assertThat(target.listPushFront(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushFront(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -922,7 +932,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushFront(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushFront(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -933,7 +944,7 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(2).containsAll(expectedList));
 
     // Add a new value without specifying ttl
-    assertThat(target.listPushFront(cacheName, listName, newValue, 0))
+    assertThat(target.listPushFront(cacheName, listName, newValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -954,7 +965,8 @@ public class ListTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListFetchResponse.Miss.class);
 
-    assertThat(target.listPushFront(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushFront(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -964,7 +976,8 @@ public class ListTest extends BaseTestClass {
         .satisfies(hit -> assertThat(hit.valueListByteArray()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushFront(cacheName, listName, oldValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushFront(cacheName, listName, oldValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -976,7 +989,7 @@ public class ListTest extends BaseTestClass {
             hit -> assertThat(hit.valueListByteArray()).hasSize(2).containsAll(expectedList));
 
     // Add a new value without specifying ttl
-    assertThat(target.listPushFront(cacheName, listName, newValue, 0))
+    assertThat(target.listPushFront(cacheName, listName, newValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListPushFrontResponse.Success.class);
 
@@ -995,26 +1008,26 @@ public class ListTest extends BaseTestClass {
     final byte[] byteArrayValue = "val1".getBytes();
 
     // With ttl specified in method signature
-    assertThat(target.listPushFront(null, listName, stringValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(target.listPushFront(null, listName, stringValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(null, listName, stringValue, 0))
+    assertThat(target.listPushFront(null, listName, stringValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(null, listName, byteArrayValue, 0, CollectionTtl.fromCacheTtl()))
+            target.listPushFront(null, listName, byteArrayValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(null, listName, byteArrayValue, 0))
+    assertThat(target.listPushFront(null, listName, byteArrayValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1026,26 +1039,28 @@ public class ListTest extends BaseTestClass {
     final byte[] byteArrayValue = "val1".getBytes();
 
     // With ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, null, stringValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            target.listPushFront(cacheName, null, stringValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, null, stringValue, 0))
+    assertThat(target.listPushFront(cacheName, null, stringValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(cacheName, null, byteArrayValue, 0, CollectionTtl.fromCacheTtl()))
+            target.listPushFront(
+                cacheName, null, byteArrayValue, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, null, byteArrayValue, 0))
+    assertThat(target.listPushFront(cacheName, null, byteArrayValue, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1088,7 +1103,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, values, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -1188,7 +1203,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -1215,7 +1230,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -1243,7 +1258,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -1285,7 +1300,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -1326,7 +1341,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 
@@ -1354,7 +1369,7 @@ public class ListTest extends BaseTestClass {
 
     assertThat(
             target.listConcatenateFront(
-                cacheName, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
+                cacheName, listName, stringValues, 100, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheListConcatenateFrontResponse.Success.class);
 

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -10,6 +10,7 @@ import static momento.sdk.ValidationUtils.checkSortedSetCountValid;
 import static momento.sdk.ValidationUtils.checkSortedSetOffsetValid;
 import static momento.sdk.ValidationUtils.ensureValidCacheSet;
 import static momento.sdk.ValidationUtils.ensureValidKey;
+import static momento.sdk.ValidationUtils.ensureValidTruncateToSize;
 import static momento.sdk.ValidationUtils.ensureValidValue;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -754,22 +755,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBack(
-      String cacheName,
-      String listName,
-      List<String> values,
-      int truncateFrontToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull Iterable<String> values,
+      @Nullable Integer truncateFrontToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(values);
+      ensureValidTruncateToSize(truncateFrontToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListConcatenateBack(
-          cacheName, convert(listName), convertStringList(values), ttl, truncateFrontToSize);
+          cacheName, convert(listName), convertStringIterable(values), truncateFrontToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -777,22 +779,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListConcatenateBackResponse> listConcatenateBackByteArray(
-      String cacheName,
-      String listName,
-      List<byte[]> values,
-      int truncateFrontToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull Iterable<byte[]> values,
+      @Nullable Integer truncateFrontToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(values);
+      ensureValidTruncateToSize(truncateFrontToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListConcatenateBack(
-          cacheName, convert(listName), convertByteArrayList(values), ttl, truncateFrontToSize);
+          cacheName, convert(listName), convertByteArrayIterable(values), truncateFrontToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -800,22 +803,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFront(
-      String cacheName,
-      String listName,
-      List<String> values,
-      int truncateBackToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull Iterable<String> values,
+      @Nullable Integer truncateBackToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(values);
+      ensureValidTruncateToSize(truncateBackToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListConcatenateFront(
-          cacheName, convert(listName), convertStringList(values), ttl, truncateBackToSize);
+          cacheName, convert(listName), convertStringIterable(values), truncateBackToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -823,10 +827,10 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListConcatenateFrontResponse> listConcatenateFrontByteArray(
-      String cacheName,
-      String listName,
-      List<byte[]> values,
-      int truncateBackToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull Iterable<byte[]> values,
+      @Nullable Integer truncateBackToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
@@ -838,7 +842,7 @@ final class ScsDataClient extends ScsClient {
       }
 
       return sendListConcatenateFront(
-          cacheName, convert(listName), convertByteArrayList(values), ttl, truncateBackToSize);
+          cacheName, convert(listName), convertByteArrayIterable(values), truncateBackToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListConcatenateFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -846,7 +850,10 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListFetchResponse> listFetch(
-      String cacheName, String listName, Integer startIndex, Integer endIndex) {
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nullable Integer startIndex,
+      @Nullable Integer endIndex) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -858,7 +865,8 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheListLengthResponse> listLength(String cacheName, String listName) {
+  CompletableFuture<CacheListLengthResponse> listLength(
+      @Nonnull String cacheName, @Nonnull String listName) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -869,7 +877,8 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheListPopBackResponse> listPopBack(String cacheName, String listName) {
+  CompletableFuture<CacheListPopBackResponse> listPopBack(
+      @Nonnull String cacheName, @Nonnull String listName) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -880,7 +889,8 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheListPopFrontResponse> listPopFront(String cacheName, String listName) {
+  CompletableFuture<CacheListPopFrontResponse> listPopFront(
+      @Nonnull String cacheName, @Nonnull String listName) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -892,22 +902,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListPushBackResponse> listPushBack(
-      String cacheName,
-      String listName,
-      String value,
-      int truncateFrontToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull String value,
+      @Nullable Integer truncateFrontToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(value);
+      ensureValidTruncateToSize(truncateFrontToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListPushBack(
-          cacheName, convert(listName), convert(value), ttl, truncateFrontToSize);
+          cacheName, convert(listName), convert(value), truncateFrontToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -915,22 +926,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListPushBackResponse> listPushBack(
-      String cacheName,
-      String listName,
-      byte[] value,
-      int truncateFrontToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull byte[] value,
+      @Nullable Integer truncateFrontToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(value);
+      ensureValidTruncateToSize(truncateFrontToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListPushBack(
-          cacheName, convert(listName), convert(value), ttl, truncateFrontToSize);
+          cacheName, convert(listName), convert(value), truncateFrontToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushBackResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -938,22 +950,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListPushFrontResponse> listPushFront(
-      String cacheName,
-      String listName,
-      String value,
-      int truncateBackToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull String value,
+      @Nullable Integer truncateBackToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(value);
+      ensureValidTruncateToSize(truncateBackToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListPushFront(
-          cacheName, convert(listName), convert(value), ttl, truncateBackToSize);
+          cacheName, convert(listName), convert(value), truncateBackToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -961,22 +974,23 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListPushFrontResponse> listPushFront(
-      String cacheName,
-      String listName,
-      byte[] value,
-      int truncateBackToSize,
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nonnull byte[] value,
+      @Nullable Integer truncateBackToSize,
       @Nullable CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
       ensureValidValue(value);
+      ensureValidTruncateToSize(truncateBackToSize);
 
       if (ttl == null) {
         ttl = CollectionTtl.of(itemDefaultTtl);
       }
 
       return sendListPushFront(
-          cacheName, convert(listName), convert(value), ttl, truncateBackToSize);
+          cacheName, convert(listName), convert(value), truncateBackToSize, ttl);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheListPushFrontResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -984,7 +998,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListRemoveValueResponse> listRemoveValue(
-      String cacheName, String listName, String value) {
+      @Nonnull String cacheName, @Nonnull String listName, @Nonnull String value) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -998,7 +1012,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListRemoveValueResponse> listRemoveValue(
-      String cacheName, String listName, byte[] value) {
+      @Nonnull String cacheName, @Nonnull String listName, @Nonnull byte[] value) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -1012,7 +1026,10 @@ final class ScsDataClient extends ScsClient {
   }
 
   CompletableFuture<CacheListRetainResponse> listRetain(
-      String cacheName, String listName, Integer startIndex, Integer endIndex) {
+      @Nonnull String cacheName,
+      @Nonnull String listName,
+      @Nullable Integer startIndex,
+      @Nullable Integer endIndex) {
     try {
       checkCacheNameValid(cacheName);
       checkListNameValid(listName);
@@ -2253,18 +2270,18 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListConcatenateBackResponse> sendListConcatenateBack(
-      String cacheName,
-      ByteString listName,
-      List<ByteString> values,
-      CollectionTtl ttl,
-      int truncateFrontToSize) {
+      @Nonnull String cacheName,
+      @Nonnull ByteString listName,
+      @Nonnull List<ByteString> values,
+      @Nullable Integer truncateFrontToSize,
+      @Nonnull CollectionTtl ttl) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
     final ListenableFuture<_ListConcatenateBackResponse> rspFuture =
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
             .listConcatenateBack(
-                buildListConcatenateBackRequest(listName, values, ttl, truncateFrontToSize));
+                buildListConcatenateBackRequest(listName, values, truncateFrontToSize, ttl));
 
     // Build a CompletableFuture to return to caller
     final CompletableFuture<CacheListConcatenateBackResponse> returnFuture =
@@ -2303,18 +2320,18 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListConcatenateFrontResponse> sendListConcatenateFront(
-      String cacheName,
-      ByteString listName,
-      List<ByteString> values,
-      CollectionTtl ttl,
-      int truncateBackToSize) {
+      @Nonnull String cacheName,
+      @Nonnull ByteString listName,
+      @Nonnull List<ByteString> values,
+      @Nullable Integer truncateBackToSize,
+      @Nonnull CollectionTtl ttl) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
     final ListenableFuture<_ListConcatenateFrontResponse> rspFuture =
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
             .listConcatenateFront(
-                buildListConcatenateFrontRequest(listName, values, ttl, truncateBackToSize));
+                buildListConcatenateFrontRequest(listName, values, truncateBackToSize, ttl));
 
     // Build a CompletableFuture to return to caller
     final CompletableFuture<CacheListConcatenateFrontResponse> returnFuture =
@@ -2353,7 +2370,10 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListFetchResponse> sendListFetch(
-      String cacheName, ByteString listName, Integer startIndex, Integer endIndex) {
+      @Nonnull String cacheName,
+      @Nonnull ByteString listName,
+      @Nullable Integer startIndex,
+      @Nullable Integer endIndex) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
@@ -2399,7 +2419,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListLengthResponse> sendListLength(
-      String cacheName, ByteString listName) {
+      @Nonnull String cacheName, @Nonnull ByteString listName) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
@@ -2446,7 +2466,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListPopBackResponse> sendListPopBack(
-      String cacheName, ByteString listName) {
+      @Nonnull String cacheName, @Nonnull ByteString listName) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
@@ -2493,17 +2513,17 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListPushBackResponse> sendListPushBack(
-      String cacheName,
-      ByteString listName,
-      ByteString value,
-      CollectionTtl ttl,
-      int truncateFrontToSize) {
+      @Nonnull String cacheName,
+      @Nonnull ByteString listName,
+      @Nonnull ByteString value,
+      @Nullable Integer truncateFrontToSize,
+      @Nonnull CollectionTtl ttl) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
     final ListenableFuture<_ListPushBackResponse> rspFuture =
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-            .listPushBack(buildListPushBackRequest(listName, value, ttl, truncateFrontToSize));
+            .listPushBack(buildListPushBackRequest(listName, value, truncateFrontToSize, ttl));
 
     // Build a CompletableFuture to return to caller
     final CompletableFuture<CacheListPushBackResponse> returnFuture =
@@ -2541,7 +2561,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListPopFrontResponse> sendListPopFront(
-      String cacheName, ByteString listName) {
+      @Nonnull String cacheName, @Nonnull ByteString listName) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
@@ -2588,17 +2608,17 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListPushFrontResponse> sendListPushFront(
-      String cacheName,
-      ByteString listName,
-      ByteString value,
-      CollectionTtl ttl,
-      int truncateBackToSize) {
+      @Nonnull String cacheName,
+      @Nonnull ByteString listName,
+      @Nonnull ByteString value,
+      @Nullable Integer truncateBackToSize,
+      @Nonnull CollectionTtl ttl) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
     final ListenableFuture<_ListPushFrontResponse> rspFuture =
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
-            .listPushFront(buildListPushFrontRequest(listName, value, ttl, truncateBackToSize));
+            .listPushFront(buildListPushFrontRequest(listName, value, truncateBackToSize, ttl));
 
     // Build a CompletableFuture to return to caller
     final CompletableFuture<CacheListPushFrontResponse> returnFuture =
@@ -2636,7 +2656,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListRemoveValueResponse> sendListRemoveValue(
-      String cacheName, ByteString listName, ByteString value) {
+      @Nonnull String cacheName, @Nonnull ByteString listName, @Nonnull ByteString value) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
@@ -2680,7 +2700,10 @@ final class ScsDataClient extends ScsClient {
   }
 
   private CompletableFuture<CacheListRetainResponse> sendListRetain(
-      String cacheName, ByteString listName, Integer startIndex, Integer endIndex) {
+      @Nonnull String cacheName,
+      @Nonnull ByteString listName,
+      @Nullable Integer startIndex,
+      @Nullable Integer endIndex) {
 
     // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
@@ -3319,148 +3342,138 @@ final class ScsDataClient extends ScsClient {
   }
 
   private _ListConcatenateBackRequest buildListConcatenateBackRequest(
-      ByteString listName, List<ByteString> values, CollectionTtl ttl, int truncateFrontToSize) {
-    _ListConcatenateBackRequest request =
+      @Nonnull ByteString listName,
+      @Nonnull List<ByteString> values,
+      @Nullable Integer truncateFrontToSize,
+      @Nonnull CollectionTtl ttl) {
+    final _ListConcatenateBackRequest.Builder builder =
         _ListConcatenateBackRequest.newBuilder()
             .setListName(listName)
             .setTtlMilliseconds(ttl.toMilliseconds().orElse(itemDefaultTtl.toMillis()))
             .setRefreshTtl(ttl.refreshTtl())
-            .setTruncateFrontToSize(truncateFrontToSize)
-            .addAllValues(values)
-            .build();
-    return request;
+            .addAllValues(values);
+
+    if (truncateFrontToSize != null) {
+      builder.setTruncateFrontToSize(truncateFrontToSize);
+    }
+
+    return builder.build();
   }
 
   private _ListConcatenateFrontRequest buildListConcatenateFrontRequest(
-      ByteString listName, List<ByteString> values, CollectionTtl ttl, int truncateBackToSize) {
-    _ListConcatenateFrontRequest request =
+      @Nonnull ByteString listName,
+      @Nonnull List<ByteString> values,
+      @Nullable Integer truncateBackToSize,
+      @Nonnull CollectionTtl ttl) {
+    final _ListConcatenateFrontRequest.Builder builder =
         _ListConcatenateFrontRequest.newBuilder()
             .setListName(listName)
             .setTtlMilliseconds(ttl.toMilliseconds().orElse(itemDefaultTtl.toMillis()))
             .setRefreshTtl(ttl.refreshTtl())
-            .setTruncateBackToSize(truncateBackToSize)
-            .addAllValues(values)
-            .build();
-    return request;
+            .addAllValues(values);
+
+    if (truncateBackToSize != null) {
+      builder.setTruncateBackToSize(truncateBackToSize);
+    }
+
+    return builder.build();
   }
 
   private _ListFetchRequest buildListFetchRequest(
-      ByteString listName, Integer startIndex, Integer endIndex) {
-    _ListFetchRequest request;
-    if (startIndex != null && endIndex != null) {
-      request =
-          _ListFetchRequest.newBuilder()
-              .setListName(listName)
-              .setInclusiveStart(startIndex)
-              .setExclusiveEnd(endIndex)
-              .build();
-    } else if (startIndex != null && endIndex == null) {
-      request =
-          _ListFetchRequest.newBuilder()
-              .setListName(listName)
-              .setInclusiveStart(startIndex)
-              .setUnboundedEnd(_Unbounded.newBuilder().build())
-              .build();
-    } else if (startIndex == null && endIndex != null) {
-      request =
-          _ListFetchRequest.newBuilder()
-              .setListName(listName)
-              .setUnboundedStart(_Unbounded.newBuilder().build())
-              .setExclusiveEnd(endIndex)
-              .build();
+      @Nonnull ByteString listName, @Nullable Integer startIndex, @Nullable Integer endIndex) {
+    final _ListFetchRequest.Builder builder = _ListFetchRequest.newBuilder().setListName(listName);
+
+    if (startIndex != null) {
+      builder.setInclusiveStart(startIndex);
     } else {
-      request =
-          _ListFetchRequest.newBuilder()
-              .setListName(listName)
-              .setUnboundedStart(_Unbounded.newBuilder().build())
-              .setUnboundedEnd(_Unbounded.newBuilder().build())
-              .build();
+      builder.setUnboundedStart(_Unbounded.newBuilder().build());
     }
 
-    return request;
+    if (endIndex != null) {
+      builder.setExclusiveEnd(endIndex);
+    } else {
+      builder.setUnboundedEnd(_Unbounded.newBuilder().build());
+    }
+
+    return builder.build();
   }
 
-  private _ListLengthRequest buildListLengthRequest(ByteString listName) {
+  private _ListLengthRequest buildListLengthRequest(@Nonnull ByteString listName) {
     return _ListLengthRequest.newBuilder().setListName(listName).build();
   }
 
-  private _ListPopBackRequest buildListPopBackRequest(ByteString listName) {
+  private _ListPopBackRequest buildListPopBackRequest(@Nonnull ByteString listName) {
     return _ListPopBackRequest.newBuilder().setListName(listName).build();
   }
 
-  private _ListPopFrontRequest buildListPopFrontRequest(ByteString listName) {
+  private _ListPopFrontRequest buildListPopFrontRequest(@Nonnull ByteString listName) {
     return _ListPopFrontRequest.newBuilder().setListName(listName).build();
   }
 
   private _ListPushBackRequest buildListPushBackRequest(
-      ByteString listName, ByteString value, CollectionTtl ttl, int truncateFrontToSize) {
-    _ListPushBackRequest request =
+      @Nonnull ByteString listName,
+      @Nonnull ByteString value,
+      @Nullable Integer truncateFrontToSize,
+      @Nonnull CollectionTtl ttl) {
+    final _ListPushBackRequest.Builder builder =
         _ListPushBackRequest.newBuilder()
             .setListName(listName)
             .setTtlMilliseconds(ttl.toMilliseconds().orElse(itemDefaultTtl.toMillis()))
             .setRefreshTtl(ttl.refreshTtl())
-            .setTruncateFrontToSize(truncateFrontToSize)
-            .setValue(value)
-            .build();
-    return request;
+            .setValue(value);
+
+    if (truncateFrontToSize != null) {
+      builder.setTruncateFrontToSize(truncateFrontToSize);
+    }
+
+    return builder.build();
   }
 
   private _ListPushFrontRequest buildListPushFrontRequest(
-      ByteString listName, ByteString value, CollectionTtl ttl, int truncateBackToSize) {
-    _ListPushFrontRequest request =
+      @Nonnull ByteString listName,
+      @Nonnull ByteString value,
+      @Nullable Integer truncateBackToSize,
+      @Nonnull CollectionTtl ttl) {
+    final _ListPushFrontRequest.Builder builder =
         _ListPushFrontRequest.newBuilder()
             .setListName(listName)
             .setTtlMilliseconds(ttl.toMilliseconds().orElse(itemDefaultTtl.toMillis()))
             .setRefreshTtl(ttl.refreshTtl())
-            .setTruncateBackToSize(truncateBackToSize)
-            .setValue(value)
-            .build();
-    return request;
+            .setValue(value);
+
+    if (truncateBackToSize != null) {
+      builder.setTruncateBackToSize(truncateBackToSize);
+    }
+
+    return builder.build();
   }
 
-  private _ListRemoveRequest buildListRemoveValueRequest(ByteString listName, ByteString value) {
-    _ListRemoveRequest request =
-        _ListRemoveRequest.newBuilder()
-            .setListName(listName)
-            .setAllElementsWithValue(value)
-            .build();
-    return request;
+  private _ListRemoveRequest buildListRemoveValueRequest(
+      @Nonnull ByteString listName, @Nonnull ByteString value) {
+    return _ListRemoveRequest.newBuilder()
+        .setListName(listName)
+        .setAllElementsWithValue(value)
+        .build();
   }
 
   private _ListRetainRequest buildListRetainRequest(
-      ByteString listName, Integer startIndex, Integer endIndex) {
-    _ListRetainRequest request;
-    if (startIndex != null && endIndex != null) {
-      request =
-          _ListRetainRequest.newBuilder()
-              .setListName(listName)
-              .setInclusiveStart(startIndex)
-              .setExclusiveEnd(endIndex)
-              .build();
-    } else if (startIndex != null && endIndex == null) {
-      request =
-          _ListRetainRequest.newBuilder()
-              .setListName(listName)
-              .setInclusiveStart(startIndex)
-              .setUnboundedEnd(_Unbounded.newBuilder().build())
-              .build();
-    } else if (startIndex == null && endIndex != null) {
-      request =
-          _ListRetainRequest.newBuilder()
-              .setListName(listName)
-              .setUnboundedStart(_Unbounded.newBuilder().build())
-              .setExclusiveEnd(endIndex)
-              .build();
+      @Nonnull ByteString listName, @Nullable Integer startIndex, @Nullable Integer endIndex) {
+    final _ListRetainRequest.Builder builder =
+        _ListRetainRequest.newBuilder().setListName(listName);
+
+    if (startIndex != null) {
+      builder.setInclusiveStart(startIndex);
     } else {
-      request =
-          _ListRetainRequest.newBuilder()
-              .setListName(listName)
-              .setUnboundedStart(_Unbounded.newBuilder().build())
-              .setUnboundedEnd(_Unbounded.newBuilder().build())
-              .build();
+      builder.setUnboundedStart(_Unbounded.newBuilder().build());
     }
 
-    return request;
+    if (endIndex != null) {
+      builder.setExclusiveEnd(endIndex);
+    } else {
+      builder.setUnboundedEnd(_Unbounded.newBuilder().build());
+    }
+
+    return builder.build();
   }
 
   private _DictionaryFetchRequest buildDictionaryFetchRequest(ByteString dictionaryName) {
@@ -3478,10 +3491,7 @@ final class ScsDataClient extends ScsClient {
   }
 
   private _DictionaryFieldValuePair toSingletonFieldValuePair(ByteString field, ByteString value) {
-    _DictionaryFieldValuePair dictionaryFieldValuePair =
-        _DictionaryFieldValuePair.newBuilder().setField(field).setValue(value).build();
-
-    return dictionaryFieldValuePair;
+    return _DictionaryFieldValuePair.newBuilder().setField(field).setValue(value).build();
   }
 
   private _DictionarySetRequest buildDictionarySetFieldsRequest(

--- a/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
+++ b/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
@@ -23,6 +23,7 @@ public final class ValidationUtils {
   static final String SCORE_RANGE_INVALID =
       "maxScore (inclusive) must be greater than or equal to minScore (inclusive).";
   static final String SIGNING_KEY_TTL_CANNOT_BE_NEGATIVE = "Signing key TTL cannot be negative.";
+  static final String TRUNCATE_TO_SIZE_MUST_BE_POSITIVE = "Truncate-to-size must be positive";
 
   ValidationUtils() {}
 
@@ -116,6 +117,12 @@ public final class ValidationUtils {
   static void ensureValidTtlMinutes(Duration ttlMinutes) {
     if (ttlMinutes.toMinutes() < 0) {
       throw new InvalidArgumentException(SIGNING_KEY_TTL_CANNOT_BE_NEGATIVE);
+    }
+  }
+
+  static void ensureValidTruncateToSize(Integer truncateToSize) {
+    if (truncateToSize != null && truncateToSize <= 0) {
+      throw new InvalidArgumentException(TRUNCATE_TO_SIZE_MUST_BE_POSITIVE);
     }
   }
 }


### PR DESCRIPTION
Make the truncate*ToSize arguments in the internal client nullable.

Annotate all list method arguments Nullable/Nonnull in the internal
client.

Add validation to ensure the truncate*ToSize arguments are greater than
0. Fix the tests that were supplying 0.

Make the list methods that take a List<> take an Iterable<>.

Fix warnings in the list rpc request generation code.