### PR TITLE
feat: add sorted set fetch by score overload to fetch whole set

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -425,7 +425,7 @@ public class SortedSetTest extends BaseTestClass {
     elements.put(four, 2.0);
     elements.put(five, 1.5);
 
-    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName, null, null))
+    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheSortedSetFetchResponse.Miss.class);
 
@@ -447,6 +447,9 @@ public class SortedSetTest extends BaseTestClass {
               assertThat(scoredElements)
                   .map(ScoredElement::getElement)
                   .containsSequence(one, three, two, five, four);
+              assertThat(scoredElements)
+                    .map(ScoredElement::getScore)
+                    .containsSequence(0.0, 0.5, 1.0, 1.5, 2.0);
             });
 
     // Partial set descending
@@ -477,6 +480,20 @@ public class SortedSetTest extends BaseTestClass {
               assertThat(scoredElements)
                   .map(ScoredElement::getElement)
                   .containsSequence(three, two, five);
+            });
+
+    // Full set ascending
+    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Hit.class))
+        .satisfies(
+            hit -> {
+              final List<ScoredElement> scoredElements = hit.elementsList();
+              assertThat(scoredElements).hasSize(5);
+              // check ordering
+              assertThat(scoredElements)
+                  .map(ScoredElement::getElement)
+                  .containsSequence(one, three, two, five, four);
             });
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -448,8 +448,8 @@ public class SortedSetTest extends BaseTestClass {
                   .map(ScoredElement::getElement)
                   .containsSequence(one, three, two, five, four);
               assertThat(scoredElements)
-                    .map(ScoredElement::getScore)
-                    .containsSequence(0.0, 0.5, 1.0, 1.5, 2.0);
+                  .map(ScoredElement::getScore)
+                  .containsSequence(0.0, 0.5, 1.0, 1.5, 2.0);
             });
 
     // Partial set descending

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -900,6 +900,19 @@ public final class CacheClient implements Closeable {
   }
 
   /**
+   * Fetch all elements in the given sorted set by score in ascending order.
+   *
+   * @param cacheName - The cache containing the sorted set.
+   * @param sortedSetName - The sorted set to fetch from.
+   * @return Future containing the result of the fetch operation.
+   */
+  public CompletableFuture<CacheSortedSetFetchResponse> sortedSetFetchByScore(
+      String cacheName, String sortedSetName) {
+    return scsDataClient.sortedSetFetchByScore(
+        cacheName, sortedSetName, null, null, null, null, null);
+  }
+
+  /**
    * Look up the rank of an element in a sorted set.
    *
    * @param cacheName - The cache containing the sorted set.


### PR DESCRIPTION
Adds a `sortedSetFetchByScore` overload which fetches the whole sorted set in ascending order.

work towards: https://github.com/momentohq/client-sdk-java/issues/248