### PR TITLE
chore: pare down `sortedSetFetchByScore` overloads

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -435,8 +435,7 @@ public class SortedSetTest extends BaseTestClass {
 
     // Full set ascending, end index larger than set
     assertThat(
-            client.sortedSetFetchByScore(
-                cacheName, sortedSetName, 0.0, 9.9, SortOrder.ASCENDING))
+            client.sortedSetFetchByScore(cacheName, sortedSetName, 0.0, 9.9, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -517,7 +516,9 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetFetchByScore(randomString("cache"), sortedSetName, null, null, null, 0, 100))
+    assertThat(
+            client.sortedSetFetchByScore(
+                randomString("cache"), sortedSetName, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -436,7 +436,7 @@ public class SortedSetTest extends BaseTestClass {
     // Full set ascending, end index larger than set
     assertThat(
             client.sortedSetFetchByScore(
-                cacheName, sortedSetName, 0.0, 9.9, SortOrder.ASCENDING, null, null))
+                cacheName, sortedSetName, 0.0, 9.9, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -469,7 +469,7 @@ public class SortedSetTest extends BaseTestClass {
             });
 
     // Partial set limited by offset and count
-    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName, 1, 3))
+    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName, null, null, null, 1, 3))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -509,7 +509,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetFetchByScore(null, sortedSetName, 0, 100))
+    assertThat(client.sortedSetFetchByScore(null, sortedSetName, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -517,7 +517,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetFetchByScore(randomString("cache"), sortedSetName, 0, 100))
+    assertThat(client.sortedSetFetchByScore(randomString("cache"), sortedSetName, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
@@ -525,7 +525,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetFetchByScore(cacheName, null, 0, 100))
+    assertThat(client.sortedSetFetchByScore(cacheName, null, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheSortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -887,16 +887,21 @@ public final class CacheClient implements Closeable {
    *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
-   * @param offset - The number of elements to skip before returning the first element. Defaults to
-   *     0. Note: this is not the rank of the first element to return, but the number of elements of
-   *     the result set to skip before returning the first element.
-   * @param count - The maximum number of elements to return. Defaults to all elements.
+   * @param minScore - The minimum score (inclusive) of the elements to fetch. Defaults to negative
+   *     infinity.
+   * @param maxScore - The maximum score (inclusive) of the elements to fetch. Defaults to positive
+   *     infinity.
+   * @param order - The order to fetch the elements in. Defaults to ascending.
    * @return Future containing the result of the fetch operation.
    */
   public CompletableFuture<CacheSortedSetFetchResponse> sortedSetFetchByScore(
-      String cacheName, String sortedSetName, @Nullable Integer offset, @Nullable Integer count) {
+      String cacheName,
+      String sortedSetName,
+      @Nullable Double minScore,
+      @Nullable Double maxScore,
+      @Nullable SortOrder order) {
     return scsDataClient.sortedSetFetchByScore(
-        cacheName, sortedSetName, null, null, null, offset, count);
+        cacheName, sortedSetName, minScore, maxScore, order, null, null);
   }
 
   /**


### PR DESCRIPTION
Until a future ask comes in, we will suppose the following overloads
for `sortedSetFetchByScore`:

- (nothing) fetch the whole sorted set
- (common options) minScore, maxScore, sortOrtder
- (all options) minScore, maxScore, sortOrder, limit, offset

work towards: https://github.com/momentohq/client-sdk-java/issues/248
