### PR TITLE
feat: add `FetchByScoreOptions` builder

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -56,6 +56,7 @@ import momento.sdk.messages.ListSigningKeysResponse;
 import momento.sdk.messages.RevokeSigningKeyResponse;
 import momento.sdk.messages.SortOrder;
 import momento.sdk.requests.CollectionTtl;
+import momento.sdk.requests.sortedset.FetchByScoreOptions;
 
 /** Client to perform operations against the Momento Cache Service */
 public final class CacheClient implements Closeable {
@@ -911,6 +912,19 @@ public final class CacheClient implements Closeable {
     return scsDataClient.sortedSetFetchByScore(
         cacheName, sortedSetName, null, null, null, null, null);
   }
+
+  /**
+   * Fetch the elements in the given sorted set by score.
+   * @param cacheName - The cache containing the sorted set.
+   * @param sortedSetName - The sorted set to fetch from.
+   * @param options - The options to use for the fetch operation.
+   * @return Future containing the result of the fetch operation.
+   */
+  public CompletableFuture<CacheSortedSetFetchResponse> sortedSetFetchByScore(@Nonnull String cacheName, @Nonnull String sortedSetName, @Nonnull FetchByScoreOptions options) {
+    return scsDataClient.sortedSetFetchByScore(
+            cacheName, sortedSetName, options.getMinScore(), options.getMaxScore(), options.getSortOrder(),
+            options.getOffset(), options.getCount());
+    }
 
   /**
    * Look up the rank of an element in a sorted set.

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -915,16 +915,25 @@ public final class CacheClient implements Closeable {
 
   /**
    * Fetch the elements in the given sorted set by score.
+   *
    * @param cacheName - The cache containing the sorted set.
    * @param sortedSetName - The sorted set to fetch from.
    * @param options - The options to use for the fetch operation.
    * @return Future containing the result of the fetch operation.
    */
-  public CompletableFuture<CacheSortedSetFetchResponse> sortedSetFetchByScore(@Nonnull String cacheName, @Nonnull String sortedSetName, @Nonnull FetchByScoreOptions options) {
+  public CompletableFuture<CacheSortedSetFetchResponse> sortedSetFetchByScore(
+      @Nonnull String cacheName,
+      @Nonnull String sortedSetName,
+      @Nonnull FetchByScoreOptions options) {
     return scsDataClient.sortedSetFetchByScore(
-            cacheName, sortedSetName, options.getMinScore(), options.getMaxScore(), options.getSortOrder(),
-            options.getOffset(), options.getCount());
-    }
+        cacheName,
+        sortedSetName,
+        options.getMinScore(),
+        options.getMaxScore(),
+        options.getSortOrder(),
+        options.getOffset(),
+        options.getCount());
+  }
 
   /**
    * Look up the rank of an element in a sorted set.

--- a/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptions.java
@@ -1,0 +1,64 @@
+package momento.sdk.requests.sortedset;
+
+import momento.sdk.messages.SortOrder;
+
+import javax.annotation.Nullable;
+
+/**
+ * Options for fetching elements from a sorted set by score.
+ */
+public class FetchByScoreOptions {
+    @Nullable private Double minScore;
+    @Nullable private Double maxScore;
+    @Nullable private SortOrder sortOrder;
+    @Nullable private Integer offset;
+    @Nullable private Integer count;
+
+    public FetchByScoreOptions() {
+    }
+
+    @Nullable
+    public Double getMinScore() {
+        return minScore;
+    }
+
+    public void setMinScore(@Nullable Double minScore) {
+        this.minScore = minScore;
+    }
+
+    @Nullable
+    public Double getMaxScore() {
+        return maxScore;
+    }
+
+    public void setMaxScore(@Nullable Double maxScore) {
+        this.maxScore = maxScore;
+    }
+
+    @Nullable
+    public SortOrder getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(@Nullable SortOrder sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    @Nullable
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public void setOffset(@Nullable Integer offset) {
+        this.offset = offset;
+    }
+
+    @Nullable
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(@Nullable Integer count) {
+        this.count = count;
+    }
+}

--- a/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptions.java
@@ -1,64 +1,60 @@
 package momento.sdk.requests.sortedset;
 
+import javax.annotation.Nullable;
 import momento.sdk.messages.SortOrder;
 
-import javax.annotation.Nullable;
-
-/**
- * Options for fetching elements from a sorted set by score.
- */
+/** Options for fetching elements from a sorted set by score. */
 public class FetchByScoreOptions {
-    @Nullable private Double minScore;
-    @Nullable private Double maxScore;
-    @Nullable private SortOrder sortOrder;
-    @Nullable private Integer offset;
-    @Nullable private Integer count;
+  @Nullable private Double minScore;
+  @Nullable private Double maxScore;
+  @Nullable private SortOrder sortOrder;
+  @Nullable private Integer offset;
+  @Nullable private Integer count;
 
-    public FetchByScoreOptions() {
-    }
+  public FetchByScoreOptions() {}
 
-    @Nullable
-    public Double getMinScore() {
-        return minScore;
-    }
+  @Nullable
+  public Double getMinScore() {
+    return minScore;
+  }
 
-    public void setMinScore(@Nullable Double minScore) {
-        this.minScore = minScore;
-    }
+  public void setMinScore(@Nullable Double minScore) {
+    this.minScore = minScore;
+  }
 
-    @Nullable
-    public Double getMaxScore() {
-        return maxScore;
-    }
+  @Nullable
+  public Double getMaxScore() {
+    return maxScore;
+  }
 
-    public void setMaxScore(@Nullable Double maxScore) {
-        this.maxScore = maxScore;
-    }
+  public void setMaxScore(@Nullable Double maxScore) {
+    this.maxScore = maxScore;
+  }
 
-    @Nullable
-    public SortOrder getSortOrder() {
-        return sortOrder;
-    }
+  @Nullable
+  public SortOrder getSortOrder() {
+    return sortOrder;
+  }
 
-    public void setSortOrder(@Nullable SortOrder sortOrder) {
-        this.sortOrder = sortOrder;
-    }
+  public void setSortOrder(@Nullable SortOrder sortOrder) {
+    this.sortOrder = sortOrder;
+  }
 
-    @Nullable
-    public Integer getOffset() {
-        return offset;
-    }
+  @Nullable
+  public Integer getOffset() {
+    return offset;
+  }
 
-    public void setOffset(@Nullable Integer offset) {
-        this.offset = offset;
-    }
+  public void setOffset(@Nullable Integer offset) {
+    this.offset = offset;
+  }
 
-    @Nullable
-    public Integer getCount() {
-        return count;
-    }
+  @Nullable
+  public Integer getCount() {
+    return count;
+  }
 
-    public void setCount(@Nullable Integer count) {
-        this.count = count;
-    }
+  public void setCount(@Nullable Integer count) {
+    this.count = count;
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptionsBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptionsBuilder.java
@@ -1,0 +1,34 @@
+package momento.sdk.requests.sortedset;
+
+import momento.sdk.messages.SortOrder;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A builder for {@link FetchByScoreOptions}.
+ */
+public class FetchByScoreOptionsBuilder {
+    private FetchByScoreOptions options = new FetchByScoreOptions();
+
+    public FetchByScoreOptionsBuilder() {
+    }
+
+    public FetchByScoreOptionsBuilder minScore(double minScore) {
+        options.setMinScore(minScore);
+        return this;
+    }
+
+    public FetchByScoreOptionsBuilder maxScore(double maxScore) {
+        options.setMaxScore(maxScore);
+        return this;
+    }
+
+    public FetchByScoreOptionsBuilder sortOrder(@Nonnull SortOrder sortOrder) {
+        options.setSortOrder(sortOrder);
+        return this;
+    }
+
+    public FetchByScoreOptions build() {
+        return options;
+    }
+}

--- a/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptionsBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/requests/sortedset/FetchByScoreOptionsBuilder.java
@@ -1,34 +1,30 @@
 package momento.sdk.requests.sortedset;
 
+import javax.annotation.Nonnull;
 import momento.sdk.messages.SortOrder;
 
-import javax.annotation.Nonnull;
-
-/**
- * A builder for {@link FetchByScoreOptions}.
- */
+/** A builder for {@link FetchByScoreOptions}. */
 public class FetchByScoreOptionsBuilder {
-    private FetchByScoreOptions options = new FetchByScoreOptions();
+  private FetchByScoreOptions options = new FetchByScoreOptions();
 
-    public FetchByScoreOptionsBuilder() {
-    }
+  public FetchByScoreOptionsBuilder() {}
 
-    public FetchByScoreOptionsBuilder minScore(double minScore) {
-        options.setMinScore(minScore);
-        return this;
-    }
+  public FetchByScoreOptionsBuilder minScore(double minScore) {
+    options.setMinScore(minScore);
+    return this;
+  }
 
-    public FetchByScoreOptionsBuilder maxScore(double maxScore) {
-        options.setMaxScore(maxScore);
-        return this;
-    }
+  public FetchByScoreOptionsBuilder maxScore(double maxScore) {
+    options.setMaxScore(maxScore);
+    return this;
+  }
 
-    public FetchByScoreOptionsBuilder sortOrder(@Nonnull SortOrder sortOrder) {
-        options.setSortOrder(sortOrder);
-        return this;
-    }
+  public FetchByScoreOptionsBuilder sortOrder(@Nonnull SortOrder sortOrder) {
+    options.setSortOrder(sortOrder);
+    return this;
+  }
 
-    public FetchByScoreOptions build() {
-        return options;
-    }
+  public FetchByScoreOptions build() {
+    return options;
+  }
 }


### PR DESCRIPTION
To allow more flexible invocations of `sortedSetFetchByScore`, we
introduce an options class and builder class. That way a user can
selectively set any subset of the options.

Note: we can merge this upon a customer request.