### PR TITLE
chore: Remove dictionary methods that take byte[] fields

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -83,44 +83,6 @@ public class DictionaryTest extends BaseTestClass {
                 assertThat(hit.valueDictionaryStringBytes())
                     .hasSize(2)
                     .containsEntry("c", "d".getBytes()));
-
-    // Set ByteArray key, String Value
-    assertThat(
-            target.dictionarySetField(
-                cacheName, dictionaryName, "e".getBytes(), "f", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], String> bytesStringMap = hit.valueDictionaryBytesString();
-              assertThat(bytesStringMap.keySet()).hasSize(3).contains("e".getBytes());
-              assertThat(bytesStringMap.values()).contains("f");
-            });
-
-    //     Set ByteArray key, ByteArray Value
-    assertThat(
-            target.dictionarySetField(
-                cacheName,
-                dictionaryName,
-                "g".getBytes(),
-                "h".getBytes(),
-                CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], byte[]> byetByteMap = hit.valueDictionaryBytesBytes();
-              assertThat(byetByteMap.keySet()).hasSize(4).contains("g".getBytes());
-              assertThat(byetByteMap.values()).contains("h".getBytes());
-            });
   }
 
   @Test
@@ -150,36 +112,6 @@ public class DictionaryTest extends BaseTestClass {
                 assertThat(hit.valueDictionaryStringBytes())
                     .hasSize(2)
                     .containsEntry("c", "d".getBytes()));
-
-    // Set ByteArray key, String Value
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "e".getBytes(), "f"))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], String> bytesStringMap = hit.valueDictionaryBytesString();
-              assertThat(bytesStringMap.keySet()).hasSize(3).contains("e".getBytes());
-              assertThat(bytesStringMap.values()).contains("f");
-            });
-
-    //     Set ByteArray key, ByteArray Value
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "g".getBytes(), "h".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], byte[]> byetByteMap = hit.valueDictionaryBytesBytes();
-              assertThat(byetByteMap.keySet()).hasSize(4).contains("g".getBytes());
-              assertThat(byetByteMap.values()).contains("h".getBytes());
-            });
   }
 
   @Test
@@ -195,22 +127,6 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(
             target.dictionarySetField(
                 null, dictionaryName, "a", "b".getBytes(), CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetField(
-                null, dictionaryName, "a".getBytes(), "b", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetField(
-                null, dictionaryName, "a".getBytes(), "b".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -231,22 +147,6 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetField(
-                cacheName, null, "a".getBytes(), "b", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetField(
-                cacheName, null, "a".getBytes(), "b".getBytes(), CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
@@ -254,7 +154,7 @@ public class DictionaryTest extends BaseTestClass {
     // String Key and String value
     assertThat(
             target.dictionarySetField(
-                cacheName, dictionaryName, (String) null, "b", CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, null, "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -262,31 +162,7 @@ public class DictionaryTest extends BaseTestClass {
     // String Key and Byte value
     assertThat(
             target.dictionarySetField(
-                cacheName,
-                dictionaryName,
-                (String) null,
-                "b".getBytes(),
-                CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetField(
-                cacheName, dictionaryName, (byte[]) null, "b", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetField(
-                cacheName,
-                dictionaryName,
-                (byte[]) null,
-                "b".getBytes(),
-                CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, null, "b".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -306,26 +182,6 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(
             target.dictionarySetField(
                 cacheName, dictionaryName, "a", (byte[]) null, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetField(
-                cacheName, null, "a".getBytes(), (String) null, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetField(
-                cacheName,
-                dictionaryName,
-                "a".getBytes(),
-                (byte[]) null,
-                CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -391,44 +247,6 @@ public class DictionaryTest extends BaseTestClass {
               assertThat(stringBytesMap.keySet()).hasSize(4).contains("c", "cc");
               assertThat(stringBytesMap.values()).contains("d".getBytes(), "dd".getBytes());
             });
-
-    // Set byte array key, String value
-    assertThat(
-            target.dictionarySetFieldsBytesString(
-                cacheName, dictionaryName, bytesStringMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], String> bytesStringMap = hit.valueDictionaryBytesString();
-              assertThat(bytesStringMap.keySet())
-                  .hasSize(6)
-                  .contains("e".getBytes(), "ee".getBytes());
-              assertThat(bytesStringMap.values()).contains("f", "ff");
-            });
-
-    // Set byte array key, byte array value
-    assertThat(
-            target.dictionarySetFieldsBytesBytes(
-                cacheName, dictionaryName, bytesBytesMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], byte[]> bytesStringMap = hit.valueDictionaryBytesBytes();
-              assertThat(bytesStringMap.keySet())
-                  .hasSize(8)
-                  .contains("g".getBytes(), "gg".getBytes());
-              assertThat(bytesStringMap.values()).contains("h".getBytes(), "hh".getBytes());
-            });
   }
 
   @Test
@@ -464,40 +282,6 @@ public class DictionaryTest extends BaseTestClass {
               assertThat(stringBytesMap.keySet()).hasSize(4).contains("c", "cc");
               assertThat(stringBytesMap.values()).contains("d".getBytes(), "dd".getBytes());
             });
-
-    // Set byte array key, String value
-    assertThat(target.dictionarySetFieldsBytesString(cacheName, dictionaryName, bytesStringMap))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], String> bytesStringMap = hit.valueDictionaryBytesString();
-              assertThat(bytesStringMap.keySet())
-                  .hasSize(6)
-                  .contains("e".getBytes(), "ee".getBytes());
-              assertThat(bytesStringMap.values()).contains("f", "ff");
-            });
-
-    // Set byte array key, byte array value
-    assertThat(target.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, bytesBytesMap))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
-
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryFetchResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], byte[]> bytesStringMap = hit.valueDictionaryBytesBytes();
-              assertThat(bytesStringMap.keySet())
-                  .hasSize(8)
-                  .contains("g".getBytes(), "gg".getBytes());
-              assertThat(bytesStringMap.values()).contains("h".getBytes(), "hh".getBytes());
-            });
   }
 
   @Test
@@ -516,22 +300,6 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(
             target.dictionarySetFieldsStringBytes(
                 null, dictionaryName, stringBytesMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetFieldsBytesString(
-                null, dictionaryName, bytesStringMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetFieldsBytesBytes(
-                null, dictionaryName, bytesBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -556,22 +324,6 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetFieldsBytesString(
-                cacheName, null, bytesStringMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetFieldsBytesBytes(
-                cacheName, null, bytesBytesMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
@@ -591,27 +343,11 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and String value
-    assertThat(
-            target.dictionarySetFieldsBytesString(
-                cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte key and Byte value
-    assertThat(
-            target.dictionarySetFieldsBytesBytes(
-                cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionarySetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
   public void dictionaryGetFieldHappyPath() {
-    // Get field/value as string
+    // Get the value as a string
     assertThat(
             target.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
@@ -627,19 +363,19 @@ public class DictionaryTest extends BaseTestClass {
               assertThat(hit.valueString()).isEqualTo("b");
             });
 
-    // Get field/value as byte array
+    // Get the value as a byte array
     assertThat(
             target.dictionarySetField(
-                cacheName, dictionaryName, "c", "d", CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, "c", "d".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "c".getBytes()))
+    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "c"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Hit.class))
         .satisfies(
             hit -> {
-              assertThat(hit.fieldByteArray()).isEqualTo("c".getBytes());
+              assertThat(hit.field()).isEqualTo("c");
               assertThat(hit.valueByteArray()).isEqualTo("d".getBytes());
             });
   }
@@ -648,12 +384,6 @@ public class DictionaryTest extends BaseTestClass {
   public void dictionaryGetFieldReturnsErrorWithNullCacheName() {
     // String field
     assertThat(target.dictionaryGetField(null, dictionaryName, "a"))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryGetField(null, dictionaryName, "a".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -666,24 +396,12 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryGetField(cacheName, null, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
   public void dictionaryGetFieldReturnsErrorWithNullField() {
     // String field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, (String) null))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, (byte[]) null))
+    assertThat(target.dictionaryGetField(cacheName, dictionaryName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -701,22 +419,12 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(target.dictionaryGetField(cacheName, dictionaryName, "c"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionaryGetFieldResponse.Miss.class);
-
-    // ByteArray field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "c".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldResponse.Miss.class);
   }
 
   @Test
   public void dictionaryGetFieldReturnsMissWhenDictionaryNotExists() {
     // String field
     assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldResponse.Miss.class);
-
-    // ByteArray field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionaryGetFieldResponse.Miss.class);
   }
@@ -763,120 +471,6 @@ public class DictionaryTest extends BaseTestClass {
               assertThat(stringStringMap.values())
                   .contains("b".getBytes(), "d".getBytes(), "f".getBytes());
             });
-
-    // Gets a map of byte keys and string values
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "c", "e")))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], String> stringStringMap = hit.valueDictionaryBytesString();
-              assertThat(stringStringMap.keySet())
-                  .hasSize(3)
-                  .contains("a".getBytes(), "c".getBytes(), "e".getBytes());
-              assertThat(stringStringMap.values()).contains("b", "d", "f");
-            });
-
-    // Gets a map of byte array keys and byte array values
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "c", "e")))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], byte[]> stringStringMap = hit.valueDictionaryBytesBytes();
-              assertThat(stringStringMap.keySet())
-                  .hasSize(3)
-                  .contains("a".getBytes(), "c".getBytes(), "e".getBytes());
-              assertThat(stringStringMap.values())
-                  .contains("b".getBytes(), "d".getBytes(), "f".getBytes());
-            });
-  }
-
-  @Test
-  public void dictionaryGetFieldsByteArrayHappyPath() {
-    assertThat(
-            target.dictionarySetField(
-                cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(
-            target.dictionarySetField(
-                cacheName, dictionaryName, "c", "d", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(
-            target.dictionarySetField(
-                cacheName, dictionaryName, "e", "f", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    // Gets a map of string keys and string values
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName,
-                dictionaryName,
-                Arrays.asList("a".getBytes(), "c".getBytes(), "e".getBytes())))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<String, String> stringStringMap = hit.valueDictionaryStringString();
-              assertThat(stringStringMap.keySet()).hasSize(3).contains("a", "c", "e");
-              assertThat(stringStringMap.values()).contains("b", "d", "f");
-            });
-
-    // Gets a map of string keys and byte array values
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName,
-                dictionaryName,
-                Arrays.asList("a".getBytes(), "c".getBytes(), "e".getBytes())))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<String, byte[]> stringStringMap = hit.valueDictionaryStringBytes();
-              assertThat(stringStringMap.keySet()).hasSize(3).contains("a", "c", "e");
-              assertThat(stringStringMap.values())
-                  .contains("b".getBytes(), "d".getBytes(), "f".getBytes());
-            });
-
-    // Gets a map of byte keys and string values
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName,
-                dictionaryName,
-                Arrays.asList("a".getBytes(), "c".getBytes(), "e".getBytes())))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], String> stringStringMap = hit.valueDictionaryBytesString();
-              assertThat(stringStringMap.keySet())
-                  .hasSize(3)
-                  .contains("a".getBytes(), "c".getBytes(), "e".getBytes());
-              assertThat(stringStringMap.values()).contains("b", "d", "f");
-            });
-
-    // Gets a map of byte array keys and byte array values
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName,
-                dictionaryName,
-                Arrays.asList("a".getBytes(), "c".getBytes(), "e".getBytes())))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<byte[], byte[]> stringStringMap = hit.valueDictionaryBytesBytes();
-              assertThat(stringStringMap.keySet())
-                  .hasSize(3)
-                  .contains("a".getBytes(), "c".getBytes(), "e".getBytes());
-              assertThat(stringStringMap.values())
-                  .contains("b".getBytes(), "d".getBytes(), "f".getBytes());
-            });
   }
 
   @Test
@@ -886,30 +480,12 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array fields
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                null,
-                dictionaryName,
-                Arrays.asList("a".getBytes(), "c".getBytes(), "e".getBytes())))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
   public void dictionaryGetFieldsReturnsErrorWithNullDictionaryName() {
     // String fields
     assertThat(target.dictionaryGetFields(cacheName, null, Arrays.asList("a", "c", "e")))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array fields
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName, null, Arrays.asList("a".getBytes(), "c".getBytes(), "e".getBytes())))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -928,21 +504,6 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(
             target.dictionaryGetFields(
                 cacheName, dictionaryName, stringListWithAtleastOneNullField))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array fields
-    assertThat(target.dictionaryGetFieldsByteArray(cacheName, dictionaryName, null))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    List<byte[]> bytesListWithAtleastOneNullField = Arrays.asList("a".getBytes(), null);
-
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName, dictionaryName, bytesListWithAtleastOneNullField))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -975,8 +536,6 @@ public class DictionaryTest extends BaseTestClass {
     assertThat(responseList.get(0)).isInstanceOf(CacheDictionaryGetFieldResponse.Hit.class);
     assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(0)).fieldString())
         .isEqualTo("a");
-    assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(0)).fieldByteArray())
-        .isEqualTo("a".getBytes());
     assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(0)).valueString())
         .isEqualTo("b");
     assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(0)).valueByteArray())
@@ -986,8 +545,6 @@ public class DictionaryTest extends BaseTestClass {
         .isInstanceOf(CacheDictionaryGetFieldResponse.Hit.class);
     assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(1)).fieldString())
         .isEqualTo("c");
-    assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(1)).fieldByteArray())
-        .isEqualTo("c".getBytes());
     assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(1)).valueString())
         .isEqualTo("d");
     assertThat(((CacheDictionaryGetFieldResponse.Hit) responseList.get(1)).valueByteArray())
@@ -1006,13 +563,6 @@ public class DictionaryTest extends BaseTestClass {
     // String field
     assertThat(
             target.dictionaryGetFields(cacheName, dictionaryName, Collections.singletonList("a")))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldsResponse.Miss.class);
-
-    // ByteArray field
-    assertThat(
-            target.dictionaryGetFieldsByteArray(
-                cacheName, dictionaryName, Collections.singletonList("a".getBytes())))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDictionaryGetFieldsResponse.Miss.class);
   }
@@ -1050,42 +600,6 @@ public class DictionaryTest extends BaseTestClass {
             hit -> {
               assertThat(hit.fieldString()).isEqualTo("a");
               assertThat(hit.valueString()).isEqualTo("-1000");
-            });
-  }
-
-  @Test
-  public void dictionaryIncrementByteArrayFieldHappyPath() {
-    // Increment with ttl
-    assertThat(target.dictionaryIncrement(cacheName, dictionaryName, "a".getBytes(), 1))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Success.class))
-        .satisfies(success -> assertThat(success.valueNumber()).isEqualTo(1));
-
-    assertThat(
-            target.dictionaryIncrement(
-                cacheName, dictionaryName, "a".getBytes(), 41, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Success.class))
-        .satisfies(success -> assertThat(success.valueNumber()).isEqualTo(42));
-
-    // Increment without ttl
-    assertThat(
-            target.dictionaryIncrement(
-                cacheName, dictionaryName, "a".getBytes(), -1042, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Success.class))
-        .satisfies(success -> assertThat(success.valueNumber()).isEqualTo(-1000));
-
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              assertThat(hit.fieldByteArray()).isEqualTo("a".getBytes());
-              assertThat(hit.valueByteArray()).isEqualTo("-1000".getBytes());
             });
   }
 
@@ -1134,28 +648,12 @@ public class DictionaryTest extends BaseTestClass {
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(
-            target.dictionaryIncrement(
-                null, dictionaryName, "a".getBytes(), 1, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
   public void dictionaryIncrementReturnsErrorWithNullDictionaryName() {
     // String field
     assertThat(target.dictionaryIncrement(cacheName, null, "a", 1, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(
-            target.dictionaryIncrement(
-                cacheName, null, "a".getBytes(), 1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1166,15 +664,7 @@ public class DictionaryTest extends BaseTestClass {
     // String field
     assertThat(
             target.dictionaryIncrement(
-                cacheName, dictionaryName, (String) null, 1, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(
-            target.dictionaryIncrement(
-                cacheName, dictionaryName, (byte[]) null, 1, CollectionTtl.fromCacheTtl()))
+                cacheName, dictionaryName, null, 1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryIncrementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1229,46 +719,9 @@ public class DictionaryTest extends BaseTestClass {
   }
 
   @Test
-  public void dictionaryRemoveFieldByteArrayHappyPath() {
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldResponse.Miss.class);
-
-    assertThat(
-            target.dictionarySetField(
-                cacheName, dictionaryName, "a".getBytes(), "b", CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldResponse.Success.class);
-
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              assertThat(hit.fieldByteArray()).isEqualTo("a".getBytes());
-              assertThat(hit.valueString()).isEqualTo("b");
-            });
-
-    assertThat(target.dictionaryRemoveField(cacheName, dictionaryName, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryRemoveFieldResponse.Success.class);
-
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldResponse.Miss.class);
-  }
-
-  @Test
   public void dictionaryRemoveFieldReturnsErrorWithNullCacheName() {
     // String field
     assertThat(target.dictionaryRemoveField(null, dictionaryName, "a"))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryRemoveField(null, dictionaryName, "a".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldResponse.Error.class))
@@ -1283,26 +736,12 @@ public class DictionaryTest extends BaseTestClass {
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryRemoveField(cacheName, null, "a".getBytes()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
   }
 
   @Test
   public void dictionaryRemoveFieldReturnsErrorWithNullField() {
     // String field
-    assertThat(target.dictionaryRemoveField(cacheName, dictionaryName, (String) null))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryRemoveField(cacheName, dictionaryName, (byte[]) null))
+    assertThat(target.dictionaryRemoveField(cacheName, dictionaryName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldResponse.Error.class))
@@ -1342,52 +781,9 @@ public class DictionaryTest extends BaseTestClass {
   }
 
   @Test
-  public void dictionaryRemoveFieldsByteArrayHappyPath() {
-    populateTestMaps();
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldsResponse.Miss.class);
-
-    assertThat(
-            target.dictionarySetFields(
-                cacheName, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionarySetFieldsResponse.Success.class);
-
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheDictionaryGetFieldsResponse.Hit.class))
-        .satisfies(
-            hit -> {
-              final Map<String, String> stringStringMap = hit.valueDictionaryStringString();
-              assertThat(stringStringMap.keySet()).hasSize(2).contains("a", "aa");
-              assertThat(stringStringMap.values()).contains("b", "bb");
-            });
-
-    assertThat(
-            target.dictionaryRemoveFieldsByteArray(
-                cacheName, dictionaryName, Arrays.asList("a".getBytes(), "aa".getBytes())))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryRemoveFieldsResponse.Success.class);
-
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
-        .succeedsWithin(FIVE_SECONDS)
-        .isInstanceOf(CacheDictionaryGetFieldsResponse.Miss.class);
-  }
-
-  @Test
   public void dictionaryRemoveFieldsReturnsErrorWithNullCacheName() {
     // String field
-    assertThat(target.dictionaryRemoveFields(null, dictionaryName, Arrays.asList("a")))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(
-            target.dictionaryRemoveFieldsByteArray(
-                null, dictionaryName, Arrays.asList("a".getBytes())))
+    assertThat(target.dictionaryRemoveFields(null, dictionaryName, Collections.singletonList("a")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))
@@ -1397,15 +793,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryRemoveFieldsReturnsErrorWithNullDictionaryName() {
     // String field
-    assertThat(target.dictionaryRemoveFields(cacheName, null, Arrays.asList("a")))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(
-            target.dictionaryRemoveFieldsByteArray(cacheName, null, Arrays.asList("a".getBytes())))
+    assertThat(target.dictionaryRemoveFields(cacheName, null, Collections.singletonList("a")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))
@@ -1422,21 +810,6 @@ public class DictionaryTest extends BaseTestClass {
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(target.dictionaryRemoveFields(cacheName, dictionaryName, Arrays.asList("a", null)))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Byte Array field
-    assertThat(target.dictionaryRemoveFields(cacheName, dictionaryName, null))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(
-            InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    assertThat(
-            target.dictionaryRemoveFieldsByteArray(
-                cacheName, dictionaryName, Arrays.asList("a".getBytes(), null)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(
             InstanceOfAssertFactories.type(CacheDictionaryRemoveFieldsResponse.Error.class))

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -1809,68 +1809,6 @@ public final class CacheClient implements Closeable {
   }
 
   /**
-   * Sets a field in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param field - The field to set.
-   * @param value - The value to set.
-   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
-   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
-   *     Duration)}
-   * @return Future containing the result of the dictionary set field operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
-      String cacheName, String dictionaryName, byte[] field, String value, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetField(cacheName, dictionaryName, field, value, ttl);
-  }
-
-  /**
-   * Sets a field in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param field - The field to set.
-   * @param value - The value to set.
-   * @return Future containing the result of the dictionary set field operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
-      String cacheName, String dictionaryName, byte[] field, String value) {
-    return scsDataClient.dictionarySetField(cacheName, dictionaryName, field, value, null);
-  }
-
-  /**
-   * Sets a field in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param field - The field to set.
-   * @param value - The value to set.
-   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
-   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
-   *     Duration)}
-   * @return Future containing the result of the dictionary set field operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
-      String cacheName, String dictionaryName, byte[] field, byte[] value, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetField(cacheName, dictionaryName, field, value, ttl);
-  }
-
-  /**
-   * Sets a field in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param field - The field to set.
-   * @param value - The value to set.
-   * @return Future containing the result of the dictionary set field operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
-      String cacheName, String dictionaryName, byte[] field, byte[] value) {
-    return scsDataClient.dictionarySetField(cacheName, dictionaryName, field, value, null);
-  }
-
-  /**
    * Sets all the fields in the given dictionary.
    *
    * @param cacheName - The cache containing the list.
@@ -1935,70 +1873,6 @@ public final class CacheClient implements Closeable {
   }
 
   /**
-   * Sets all the fields in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param elements - The fields to set.
-   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
-   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
-   *     Duration)}
-   * @return Future containing the result of the dictionary set fields operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName, String dictionaryName, Map<byte[], String> elements, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, elements, ttl);
-  }
-
-  /**
-   * Sets all the fields in the given dictionary.
-   *
-   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
-   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param elements - The fields to set.
-   * @return Future containing the result of the dictionary set fields operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName, String dictionaryName, Map<byte[], String> elements) {
-    return scsDataClient.dictionarySetFieldsBytesString(cacheName, dictionaryName, elements, null);
-  }
-
-  /**
-   * Sets all the fields in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param elements - The fields to set.
-   * @param ttl Time to Live for the item in Cache. This ttl takes precedence over the TTL used when
-   *     building a cache client {@link CacheClient#builder(CredentialProvider, Configuration,
-   *     Duration)}
-   * @return Future containing the result of the dictionary set fields operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName, String dictionaryName, Map<byte[], byte[]> elements, CollectionTtl ttl) {
-    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, elements, ttl);
-  }
-
-  /**
-   * Sets all the fields in the given dictionary.
-   *
-   * <p>The Time to Live (TTL) seconds defaults to the parameter used when building this Cache
-   * client - {@link CacheClient#builder(CredentialProvider, Configuration, Duration)}
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to set the field in.
-   * @param elements - The fields to set.
-   * @return Future containing the result of the dictionary set fields operation.
-   */
-  public CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName, String dictionaryName, Map<byte[], byte[]> elements) {
-    return scsDataClient.dictionarySetFieldsBytesBytes(cacheName, dictionaryName, elements, null);
-  }
-
-  /**
    * Gets the field and value from the given dictionary.
    *
    * @param cacheName - The cache containing the dictionary.
@@ -2008,19 +1882,6 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheDictionaryGetFieldResponse> dictionaryGetField(
       String cacheName, String dictionaryName, String field) {
-    return scsDataClient.dictionaryGetField(cacheName, dictionaryName, field);
-  }
-
-  /**
-   * Gets the field and value from the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to get the field from.
-   * @param field - The field to get.
-   * @return Future containing the result of the dictionary get field operation.
-   */
-  public CompletableFuture<CacheDictionaryGetFieldResponse> dictionaryGetField(
-      String cacheName, String dictionaryName, byte[] field) {
     return scsDataClient.dictionaryGetField(cacheName, dictionaryName, field);
   }
 
@@ -2035,19 +1896,6 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFields(
       String cacheName, String dictionaryName, List<String> fields) {
     return scsDataClient.dictionaryGetFields(cacheName, dictionaryName, fields);
-  }
-
-  /**
-   * Gets the fields and values from the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to get the fields and values from.
-   * @param fields - The fields to get.
-   * @return Future containing the result of the dictionary get fields operation.
-   */
-  public CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFieldsByteArray(
-      String cacheName, String dictionaryName, List<byte[]> fields) {
-    return scsDataClient.dictionaryGetFieldsByteArray(cacheName, dictionaryName, fields);
   }
 
   /**
@@ -2081,36 +1929,6 @@ public final class CacheClient implements Closeable {
   }
 
   /**
-   * Increments the field's value in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to increment the value in.
-   * @param field - The field for which the value is to be incremented.
-   * @param amount The amount to increment.
-   * @param ttl The time to live for the item in Cache. If null, the client's default TTL will be
-   *     used.
-   * @return Future containing the result of the dictionary increment operation.
-   */
-  public CompletableFuture<CacheDictionaryIncrementResponse> dictionaryIncrement(
-      String cacheName, String dictionaryName, byte[] field, long amount, CollectionTtl ttl) {
-    return scsDataClient.dictionaryIncrement(cacheName, dictionaryName, field, amount, ttl);
-  }
-
-  /**
-   * Increments the field's value in the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to increment the value in.
-   * @param field - The field for which the value is to be incremented.
-   * @param amount The amount to increment.
-   * @return Future containing the result of the dictionary increment operation.
-   */
-  public CompletableFuture<CacheDictionaryIncrementResponse> dictionaryIncrement(
-      String cacheName, String dictionaryName, byte[] field, long amount) {
-    return scsDataClient.dictionaryIncrement(cacheName, dictionaryName, field, amount, null);
-  }
-
-  /**
    * Remove the field from the given dictionary.
    *
    * @param cacheName - The cache containing the dictionary.
@@ -2120,19 +1938,6 @@ public final class CacheClient implements Closeable {
    */
   public CompletableFuture<CacheDictionaryRemoveFieldResponse> dictionaryRemoveField(
       String cacheName, String dictionaryName, String field) {
-    return scsDataClient.dictionaryRemoveField(cacheName, dictionaryName, field);
-  }
-
-  /**
-   * Remove the field from the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to remove the field from.
-   * @param field - The field to remove.
-   * @return Future containing the result of the dictionary remove field operation.
-   */
-  public CompletableFuture<CacheDictionaryRemoveFieldResponse> dictionaryRemoveField(
-      String cacheName, String dictionaryName, byte[] field) {
     return scsDataClient.dictionaryRemoveField(cacheName, dictionaryName, field);
   }
 
@@ -2147,19 +1952,6 @@ public final class CacheClient implements Closeable {
   public CompletableFuture<CacheDictionaryRemoveFieldsResponse> dictionaryRemoveFields(
       String cacheName, String dictionaryName, List<String> fields) {
     return scsDataClient.dictionaryRemoveFields(cacheName, dictionaryName, fields);
-  }
-
-  /**
-   * Removes the fields from the given dictionary.
-   *
-   * @param cacheName - The cache containing the dictionary.
-   * @param dictionaryName - The dictionary to remove the fields from.
-   * @param fields - The fields to remove.
-   * @return Future containing the result of the dictionary remove fields operation.
-   */
-  public CompletableFuture<CacheDictionaryRemoveFieldsResponse> dictionaryRemoveFieldsByteArray(
-      String cacheName, String dictionaryName, List<byte[]> fields) {
-    return scsDataClient.dictionaryRemoveFieldsByteArray(cacheName, dictionaryName, fields);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -1080,46 +1080,6 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
-      String cacheName, String dictionaryName, byte[] field, String value, CollectionTtl ttl) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(field);
-      ensureValidValue(value);
-
-      if (ttl == null) {
-        ttl = CollectionTtl.of(itemDefaultTtl);
-      }
-
-      return sendDictionarySetField(
-          cacheName, convert(dictionaryName), convert(field), convert(value), ttl);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionarySetFieldResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheDictionarySetFieldResponse> dictionarySetField(
-      String cacheName, String dictionaryName, byte[] field, byte[] value, CollectionTtl ttl) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(field);
-      ensureValidValue(value);
-
-      if (ttl == null) {
-        ttl = CollectionTtl.of(itemDefaultTtl);
-      }
-
-      return sendDictionarySetField(
-          cacheName, convert(dictionaryName), convert(field), convert(value), ttl);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionarySetFieldResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
   CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFields(
       String cacheName, String dictionaryName, Map<String, String> elements, CollectionTtl ttl) {
     try {
@@ -1158,61 +1118,8 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesString(
-      String cacheName, String dictionaryName, Map<byte[], String> elements, CollectionTtl ttl) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidValue(elements);
-
-      if (ttl == null) {
-        ttl = CollectionTtl.of(itemDefaultTtl);
-      }
-
-      return sendDictionarySetFields(
-          cacheName, convert(dictionaryName), convertBytesStringEntryList(elements), ttl);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionarySetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheDictionarySetFieldsResponse> dictionarySetFieldsBytesBytes(
-      String cacheName, String dictionaryName, Map<byte[], byte[]> elements, CollectionTtl ttl) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidValue(elements);
-
-      if (ttl == null) {
-        ttl = CollectionTtl.of(itemDefaultTtl);
-      }
-
-      return sendDictionarySetFields(
-          cacheName, convert(dictionaryName), convertBytesBytesEntryList(elements), ttl);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionarySetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
   CompletableFuture<CacheDictionaryGetFieldResponse> dictionaryGetField(
       String cacheName, String dictionaryName, String field) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(field);
-
-      return sendDictionaryGetField(cacheName, convert(dictionaryName), convert(field));
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionaryGetFieldResponse.Error(
-              CacheServiceExceptionMapper.convert(e), convert(field)));
-    }
-  }
-
-  CompletableFuture<CacheDictionaryGetFieldResponse> dictionaryGetField(
-      String cacheName, String dictionaryName, byte[] field) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
@@ -1243,46 +1150,8 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheDictionaryGetFieldsResponse> dictionaryGetFieldsByteArray(
-      String cacheName, String dictionaryName, List<byte[]> fields) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(fields);
-      for (byte[] field : fields) {
-        ensureValidKey(field);
-      }
-
-      return sendDictionaryGetFields(
-          cacheName, convert(dictionaryName), convertByteArrayList(fields));
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionaryGetFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
   CompletableFuture<CacheDictionaryIncrementResponse> dictionaryIncrement(
       String cacheName, String dictionaryName, String field, long amount, CollectionTtl ttl) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(field);
-      ensureValidValue(amount);
-
-      if (ttl == null) {
-        ttl = CollectionTtl.of(itemDefaultTtl);
-      }
-
-      return sendDictionaryIncrement(
-          cacheName, convert(dictionaryName), convert(field), amount, ttl);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionaryIncrementResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheDictionaryIncrementResponse> dictionaryIncrement(
-      String cacheName, String dictionaryName, byte[] field, long amount, CollectionTtl ttl) {
     try {
       checkCacheNameValid(cacheName);
       checkDictionaryNameValid(dictionaryName);
@@ -1315,20 +1184,6 @@ final class ScsDataClient extends ScsClient {
     }
   }
 
-  CompletableFuture<CacheDictionaryRemoveFieldResponse> dictionaryRemoveField(
-      String cacheName, String dictionaryName, byte[] field) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(field);
-
-      return sendDictionaryRemoveField(cacheName, convert(dictionaryName), convert(field));
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionaryRemoveFieldResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
   CompletableFuture<CacheDictionaryRemoveFieldsResponse> dictionaryRemoveFields(
       String cacheName, String dictionaryName, List<String> fields) {
     try {
@@ -1341,24 +1196,6 @@ final class ScsDataClient extends ScsClient {
 
       return sendDictionaryRemoveFields(
           cacheName, convert(dictionaryName), convertStringList(fields));
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(
-          new CacheDictionaryRemoveFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
-    }
-  }
-
-  CompletableFuture<CacheDictionaryRemoveFieldsResponse> dictionaryRemoveFieldsByteArray(
-      String cacheName, String dictionaryName, List<byte[]> fields) {
-    try {
-      checkCacheNameValid(cacheName);
-      checkDictionaryNameValid(dictionaryName);
-      ensureValidKey(fields);
-      for (byte[] field : fields) {
-        ensureValidKey(field);
-      }
-
-      return sendDictionaryRemoveFields(
-          cacheName, convert(dictionaryName), convertByteArrayList(fields));
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new CacheDictionaryRemoveFieldsResponse.Error(CacheServiceExceptionMapper.convert(e)));
@@ -1403,10 +1240,6 @@ final class ScsDataClient extends ScsClient {
     return strings.stream().map(this::convert).collect(Collectors.toList());
   }
 
-  private List<ByteString> convertByteArrayList(List<byte[]> byteArrays) {
-    return byteArrays.stream().map(this::convert).collect(Collectors.toList());
-  }
-
   private Map<ByteString, ByteString> convertStringStringEntryList(Map<String, String> elements) {
     return elements.entrySet().stream()
         .collect(
@@ -1414,18 +1247,6 @@ final class ScsDataClient extends ScsClient {
   }
 
   private Map<ByteString, ByteString> convertStringBytesEntryList(Map<String, byte[]> elements) {
-    return elements.entrySet().stream()
-        .collect(
-            Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
-  }
-
-  private Map<ByteString, ByteString> convertBytesStringEntryList(Map<byte[], String> elements) {
-    return elements.entrySet().stream()
-        .collect(
-            Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
-  }
-
-  private Map<ByteString, ByteString> convertBytesBytesEntryList(Map<byte[], byte[]> elements) {
     return elements.entrySet().stream()
         .collect(
             Collectors.toMap(entry -> convert(entry.getKey()), entry -> convert(entry.getValue())));
@@ -2763,8 +2584,13 @@ final class ScsDataClient extends ScsClient {
           @Override
           public void onSuccess(_DictionaryFetchResponse rsp) {
             if (rsp.hasFound()) {
-              returnFuture.complete(
-                  new CacheDictionaryFetchResponse.Hit(rsp.getFound().getItemsList()));
+              final Map<ByteString, ByteString> fieldsToValues =
+                  rsp.getFound().getItemsList().stream()
+                      .collect(
+                          Collectors.toMap(
+                              _DictionaryFieldValuePair::getField,
+                              _DictionaryFieldValuePair::getValue));
+              returnFuture.complete(new CacheDictionaryFetchResponse.Hit(fieldsToValues));
             } else if (rsp.hasMissing()) {
               returnFuture.complete(new CacheDictionaryFetchResponse.Miss());
             }
@@ -2944,7 +2770,6 @@ final class ScsDataClient extends ScsClient {
   private CompletableFuture<CacheDictionaryGetFieldsResponse> sendDictionaryGetFields(
       String cacheName, ByteString dictionaryName, List<ByteString> fields) {
 
-    // Submit request to non-blocking stub
     final Metadata metadata = metadataWithCache(cacheName);
     final ListenableFuture<_DictionaryGetResponse> rspFuture =
         attachMetadata(scsDataGrpcStubsManager.getStub(), metadata)
@@ -2969,9 +2794,26 @@ final class ScsDataClient extends ScsClient {
           @Override
           public void onSuccess(_DictionaryGetResponse rsp) {
             if (rsp.hasFound()) {
-              returnFuture.complete(
-                  new CacheDictionaryGetFieldsResponse.Hit(fields, rsp.getFound().getItemsList()));
-            } else if (rsp.hasMissing()) {
+              final List<_DictionaryGetResponse._DictionaryGetResponsePart> elements =
+                  rsp.getFound().getItemsList();
+
+              final List<CacheDictionaryGetFieldResponse> responses = new ArrayList<>();
+              for (int i = 0; i < elements.size(); ++i) {
+                final _DictionaryGetResponse._DictionaryGetResponsePart part = elements.get(i);
+                if (part.getResult().equals(ECacheResult.Hit)) {
+                  responses.add(
+                      new CacheDictionaryGetFieldResponse.Hit(fields.get(i), part.getCacheBody()));
+                } else if (part.getResult().equals(ECacheResult.Miss)) {
+                  responses.add(new CacheDictionaryGetFieldResponse.Miss(fields.get(i)));
+                } else {
+                  responses.add(
+                      new CacheDictionaryGetFieldResponse.Error(
+                          new UnknownException("Unrecognized result: " + part.getResult()),
+                          fields.get(i)));
+                }
+              }
+              returnFuture.complete(new CacheDictionaryGetFieldsResponse.Hit(responses));
+            } else {
               returnFuture.complete(new CacheDictionaryGetFieldsResponse.Miss());
             }
           }
@@ -3494,8 +3336,8 @@ final class ScsDataClient extends ScsClient {
   }
 
   private List<_DictionaryFieldValuePair> toDictionaryFieldValuePairs(
-      Map<ByteString, ByteString> fieldValuepairs) {
-    return fieldValuepairs.entrySet().stream()
+      Map<ByteString, ByteString> fieldValuePairs) {
+    return fieldValuePairs.entrySet().stream()
         .map(
             fieldValuePair ->
                 _DictionaryFieldValuePair.newBuilder()

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryFetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryFetchResponse.java
@@ -1,9 +1,7 @@
 package momento.sdk.messages;
 
 import com.google.protobuf.ByteString;
-import grpc.cache_client._DictionaryFieldValuePair;
 import java.util.Base64;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import momento.sdk.exceptions.SdkException;
@@ -14,31 +12,15 @@ public interface CacheDictionaryFetchResponse {
 
   /** A successful dictionary fetch operation that found elements. */
   class Hit implements CacheDictionaryFetchResponse {
-    private final Map<ByteString, ByteString> byteStringKeysValues;
+    private final Map<ByteString, ByteString> fieldsToValues;
 
     /**
      * Constructs a dictionary fetch hit with a list of encoded keys and values.
      *
-     * @param byteStringKeysValues the retrieved dictionary.
+     * @param fieldsToValues the retrieved dictionary.
      */
-    public Hit(List<_DictionaryFieldValuePair> byteStringKeysValues) {
-      this.byteStringKeysValues =
-          byteStringKeysValues.stream()
-              .collect(
-                  Collectors.toMap(
-                      _DictionaryFieldValuePair::getField, _DictionaryFieldValuePair::getValue));
-    }
-
-    /**
-     * Gets the retrieved values as a dictionary of byte array keys and values.
-     *
-     * @return the dictionary.
-     */
-    public Map<byte[], byte[]> valueDictionaryBytesBytes() {
-      return byteStringKeysValues.entrySet().stream()
-          .collect(
-              Collectors.toMap(
-                  entry -> entry.getKey().toByteArray(), entry -> entry.getValue().toByteArray()));
+    public Hit(Map<ByteString, ByteString> fieldsToValues) {
+      this.fieldsToValues = fieldsToValues;
     }
 
     /**
@@ -47,7 +29,7 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<String, String> valueDictionaryStringString() {
-      return byteStringKeysValues.entrySet().stream()
+      return fieldsToValues.entrySet().stream()
           .collect(
               Collectors.toMap(
                   entry -> entry.getKey().toStringUtf8(),
@@ -69,22 +51,10 @@ public interface CacheDictionaryFetchResponse {
      * @return the dictionary.
      */
     public Map<String, byte[]> valueDictionaryStringBytes() {
-      return byteStringKeysValues.entrySet().stream()
+      return fieldsToValues.entrySet().stream()
           .collect(
               Collectors.toMap(
                   entry -> entry.getKey().toStringUtf8(), entry -> entry.getValue().toByteArray()));
-    }
-
-    /**
-     * Gets the retrieved value as a dictionary of byte array keys and UTF-8 String values
-     *
-     * @return the dictionary.
-     */
-    public Map<byte[], String> valueDictionaryBytesString() {
-      return byteStringKeysValues.entrySet().stream()
-          .collect(
-              Collectors.toMap(
-                  entry -> entry.getKey().toByteArray(), entry -> entry.getValue().toStringUtf8()));
     }
 
     /**
@@ -101,17 +71,6 @@ public interface CacheDictionaryFetchResponse {
               .map(StringHelpers::truncate)
               .collect(Collectors.joining(", ", "\"", "\"..."));
 
-      final String bytesBytesRepresentation =
-          valueDictionaryBytesBytes().entrySet().stream()
-              .map(
-                  e ->
-                      Base64.getEncoder().encodeToString(e.getKey())
-                          + ":"
-                          + Base64.getEncoder().encodeToString(e.getValue()))
-              .limit(5)
-              .map(StringHelpers::truncate)
-              .collect(Collectors.joining(", ", "\"", "\"..."));
-
       final String stringBytesRepresentation =
           valueDictionaryStringBytes().entrySet().stream()
               .map(e -> e.getKey() + ":" + Base64.getEncoder().encodeToString(e.getValue()))
@@ -119,22 +78,11 @@ public interface CacheDictionaryFetchResponse {
               .map(StringHelpers::truncate)
               .collect(Collectors.joining(", ", "\"", "\"..."));
 
-      final String bytesStringRepresentation =
-          valueDictionaryBytesString().entrySet().stream()
-              .map(e -> Base64.getEncoder().encodeToString(e.getKey()) + ":" + e.getValue())
-              .limit(5)
-              .map(StringHelpers::truncate)
-              .collect(Collectors.joining(", ", "\"", "\"..."));
-
       return super.toString()
           + ": valueStringString: "
           + stringStringRepresentation
-          + " valueByteBytes: "
-          + bytesBytesRepresentation
           + " valueStringBytes: "
-          + stringBytesRepresentation
-          + " valueBytesString: "
-          + bytesStringRepresentation;
+          + stringBytesRepresentation;
     }
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/messages/CacheDictionaryGetFieldResponse.java
@@ -26,15 +26,6 @@ public interface CacheDictionaryGetFieldResponse {
     }
 
     /**
-     * Gets the retrieved field as a byte array.
-     *
-     * @return the field.
-     */
-    public byte[] fieldByteArray() {
-      return field.toByteArray();
-    }
-
-    /**
      * Gets the retrieved field as a UTF-8 {@link String}.
      *
      * @return the field.
@@ -89,8 +80,6 @@ public interface CacheDictionaryGetFieldResponse {
       return super.toString()
           + ": fieldString: \""
           + StringHelpers.truncate(fieldString())
-          + "\" fieldByteArray: \""
-          + StringHelpers.truncate(Base64.getEncoder().encodeToString(fieldByteArray()))
           + ": valueString: \""
           + StringHelpers.truncate(valueString())
           + "\" valueByteArray: \""


### PR DESCRIPTION
Remove all dictionary methods that take byte[] as a field. byte[] does not behave well as a map key. We can add them back in later if desired.

Remove dictionary response getters that return byte[] fields.

Move grpc-specific logic from dictionary responses into the internal client.