### PR TITLE
fix: use unique prefix for CI test cache names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: dummy
+      TEST_CACHE_NAME: java-integration-test-ci-${{ github.sha }}
 
     steps:
     - name: Checkout project


### PR DESCRIPTION
Prevent collisions between concurrent CI workflows.
