### PR TITLE
chore: Prepare job for 1.0 release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,4 +1,4 @@
-name: CD
+name: 'Manual Release'
 
 on:
   workflow_dispatch:
@@ -28,7 +28,7 @@ jobs:
       uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
       with:
         project_status: official
-        project_stability: experimental
+        project_stability: stable
         project_type: sdk
         sdk_language: Java
         usage_example_path: ./examples/lib/src/main/java/momento/client/example/BasicExample.java
@@ -38,7 +38,6 @@ jobs:
       uses: go-semantic-release/action@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        allow-initial-development-versions: true
         force-bump-patch-version: true
 
     - name: Publish to sonatype


### PR DESCRIPTION
Rename CD job to Manual Release to reflect what it does.

Remove development versions flag from the version action to allow for a 1.0 release.