### PR TITLE
chore: remove README generator action from manual release task

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -24,15 +24,6 @@ jobs:
       with:
         arguments: clean build
 
-    - name: Generate README
-      uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
-      with:
-        project_status: official
-        project_stability: stable
-        project_type: sdk
-        sdk_language: Java
-        usage_example_path: ./examples/lib/src/main/java/momento/client/example/BasicExample.java
-
     - name: Set release
       id: semrel
       uses: go-semantic-release/action@v1


### PR DESCRIPTION
We are generating the README on push to main so we don't need
it on the release task anymore, and this version is outdated.
