### PR TITLE
feat: add retry interceptor for JAVA SDK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,13 @@ gson = "2.10.1"
 guava = "31.1-android"
 java-protos = "0.54.1"
 slf4j = "1.7.36"
+logback = "1.4.8"
 
 [libraries]
 grpc-api = { module = "io.grpc:grpc-api", version.ref = "grpc"}
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 grpc-nettyshaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
+grpc-context = { module = "io.grpc:grpc-context", version.ref = "grpc" }
 
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
@@ -28,4 +30,5 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback"}
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ guava = "31.1-android"
 java-protos = "0.54.1"
 slf4j = "1.7.36"
 logback = "1.4.8"
+mockito = "5.4.0"
 
 [libraries]
 grpc-api = { module = "io.grpc:grpc-api", version.ref = "grpc"}
@@ -31,4 +32,7 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback"}
+mockito = {module = "org.mockito:mockito-core", version.ref = "mockito"}
+mockito-jupiter = {module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito"}
+
 

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     api(libs.grpc.api) // Marked api because SdkException contains classes from this dependency
     implementation(libs.grpc.stub)
     implementation(libs.grpc.nettyshaded)
+    implementation(libs.grpc.context)
     implementation(libs.protobuf.java)
     implementation(libs.guava)
     implementation(libs.gson)
@@ -25,6 +26,9 @@ dependencies {
     // Test dependencies
     testImplementation(libs.junit)
     testImplementation(libs.assertj)
+    testImplementation(libs.slf4j.api)
+    testImplementation(libs.logback)
+
 }
 
 spotless {

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -26,9 +26,10 @@ dependencies {
     // Test dependencies
     testImplementation(libs.junit)
     testImplementation(libs.assertj)
+    testImplementation(libs.mockito)
+    testImplementation(libs.mockito.jupiter)
     testImplementation(libs.slf4j.api)
     testImplementation(libs.logback)
-
 }
 
 spotless {

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -189,8 +189,9 @@ final class CacheControlPlaneTest extends BaseTestClass {
         .isThrownBy(
             () ->
                 CacheClient.builder(
-                        credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-                    .setDeadline(Duration.ofMillis(0))
+                        credentialProvider,
+                        Configurations.Laptop.latest().withTimeout(Duration.ofMillis(0)),
+                        DEFAULT_TTL_SECONDS)
                     .build());
   }
 
@@ -201,8 +202,9 @@ final class CacheControlPlaneTest extends BaseTestClass {
         .isThrownBy(
             () ->
                 CacheClient.builder(
-                        credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-                    .setDeadline(Duration.ofMillis(-1))
+                        credentialProvider,
+                        Configurations.Laptop.latest().withTimeout(Duration.ofMillis(-1)),
+                        DEFAULT_TTL_SECONDS)
                     .build());
   }
 
@@ -213,8 +215,9 @@ final class CacheControlPlaneTest extends BaseTestClass {
         .isThrownBy(
             () ->
                 CacheClient.builder(
-                        credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-                    .setDeadline(null)
+                        credentialProvider,
+                        Configurations.Laptop.latest().withTimeout(null),
+                        DEFAULT_TTL_SECONDS)
                     .build());
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
@@ -112,8 +112,9 @@ final class CacheDataPlaneTest extends BaseTestClass {
   public void getWithShortTimeoutReturnsError() {
     try (final CacheClient client =
         CacheClient.builder(
-                credentialProvider, Configurations.Laptop.latest(), DEFAULT_ITEM_TTL_SECONDS)
-            .setDeadline(Duration.ofMillis(1))
+                credentialProvider,
+                Configurations.Laptop.latest().withTimeout(Duration.ofMillis(1)),
+                DEFAULT_ITEM_TTL_SECONDS)
             .build()) {
 
       final GetResponse response = client.get("cache", "key").join();
@@ -151,10 +152,11 @@ final class CacheDataPlaneTest extends BaseTestClass {
 
   @Test
   public void setWithShortTimeoutReturnsError() {
-    try (CacheClient client =
+    try (final CacheClient client =
         CacheClient.builder(
-                credentialProvider, Configurations.Laptop.latest(), DEFAULT_ITEM_TTL_SECONDS)
-            .setDeadline(Duration.ofMillis(1))
+                credentialProvider,
+                Configurations.Laptop.latest().withTimeout(Duration.ofMillis(1)),
+                DEFAULT_ITEM_TTL_SECONDS)
             .build()) {
 
       final SetResponse response = client.set("cache", "key", "value").join();

--- a/momento-sdk/src/intTest/resources/logback.xml
+++ b/momento-sdk/src/intTest/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/momento-sdk/src/main/java/momento/sdk/CacheClientBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClientBuilder.java
@@ -4,12 +4,6 @@ import java.time.Duration;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configuration;
-import momento.sdk.config.transport.GrpcConfiguration;
-import momento.sdk.config.transport.TransportStrategy;
-import momento.sdk.retry.DefaultRetryEligibilityStrategy;
-import momento.sdk.retry.FixedCountRetryStrategy;
-import momento.sdk.retry.RetryEligibilityStrategy;
-import momento.sdk.retry.RetryStrategy;
 
 /** Builder for {@link CacheClient} */
 public final class CacheClientBuilder {
@@ -33,40 +27,6 @@ public final class CacheClientBuilder {
     this.configuration = configuration;
     ValidationUtils.ensureValidTtl(itemDefaultTtl);
     this.itemDefaultTtl = itemDefaultTtl;
-  }
-
-  /**
-   * Sets the maximum duration of a client call.
-   *
-   * @param deadline The deadline duration.
-   * @return The updated builder.
-   */
-  public CacheClientBuilder setDeadline(@Nonnull Duration deadline) {
-    ValidationUtils.ensureRequestDeadlineValid(deadline);
-
-    final GrpcConfiguration newGrpcConfiguration =
-        configuration.getTransportStrategy().getGrpcConfiguration().withDeadline(deadline);
-    final TransportStrategy newTransportStrategy =
-        configuration.getTransportStrategy().withGrpcConfiguration(newGrpcConfiguration);
-    final RetryStrategy retryStrategy =
-        configuration.getRetryStrategy() == null
-            ?
-            // create default if the configuration didn't have a retry strategy otherwise don't
-            // override a customer provided strategy
-            new FixedCountRetryStrategy(Configuration.MAX_RETRIES)
-            : configuration.getRetryStrategy();
-    final RetryEligibilityStrategy retryEligibilityStrategy =
-        configuration.getRetryEligibilityStrategy() == null
-            ?
-            // create default if the configuration didn't have a retry eligbility strategy otherwise
-            // don't override a customer provided strategy
-            new DefaultRetryEligibilityStrategy()
-            : configuration.getRetryEligibilityStrategy();
-    configuration =
-        configuration.withTransportStrategy(
-            newTransportStrategy, retryStrategy, retryEligibilityStrategy);
-
-    return this;
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
@@ -11,7 +11,11 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 import momento.sdk.retry.RetryEligibilityStrategy;
 import momento.sdk.retry.RetryStrategy;

--- a/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
@@ -1,0 +1,189 @@
+package momento.sdk;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.Context;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import javax.annotation.Nullable;
+import momento.sdk.retry.RetryEligibilityStrategy;
+import momento.sdk.retry.RetryStrategy;
+import momento.sdk.retry.RetryingUnaryClientCall;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interceptor for retrying client calls with gRPC servers. This interceptor is responsible for
+ * handling retry logic when making unary (single request, single response) gRPC calls.
+ *
+ * <p>A {@link ClientCall} is essentially an instance of a gRPC invoker. Every gRPC interceptor
+ * expects us to return such client call(s) that it will execute in order. Each call has a "start"
+ * method, which is the entry point for the call.
+ *
+ * <p>This retry client interceptor returns an instance of a {@link RetryingUnaryClientCall}, which
+ * is a client call designed to handle retrying unary (single request, single response) operations.
+ * The interceptor uses a provided {@link RetryStrategy} and {@link RetryEligibilityStrategy} to
+ * determine when and how to retry failed calls.
+ *
+ * <p>The interceptor is constructed with a {@link RetryStrategy} and a {@link
+ * RetryEligibilityStrategy}, both of which can be customized based on specific requirements. The
+ * {@link RetryStrategy} is responsible for providing the delay between retry attempts, while the
+ * {@link RetryEligibilityStrategy} helps decide whether a request is eligible for retry based on
+ * the status and method details.
+ *
+ * <p>When a gRPC call is intercepted, the interceptor checks whether the method is unary (client
+ * sends one message), and if so, it wraps the original {@link ClientCall} with the {@link
+ * RetryingUnaryClientCall}. This custom call is responsible for handling the retry logic.
+ *
+ * <p>When the gRPC call is closed, the {@code onClose} method is called, which is the point where
+ * we can safely check the status of the initial request that was made and determine if we want to
+ * retry or not. If the request was successful or ineligible for retry (based on the {@link
+ * RetryEligibilityStrategy}), the interceptor returns the result to the original listener,
+ * effectively completing the call. Otherwise, it starts the retrying process by scheduling a new
+ * call attempt with a delay provided by the {@link RetryStrategy}.
+ *
+ * <p>If the retry attempts are exhausted or if the provided delay is not present (indicating that
+ * we should not retry anymore), the interceptor propagates the final result to the original
+ * listener, effectively completing the call with the last status received.
+ *
+ * <p>Note that the interceptor only supports unary operations for retrying.
+ *
+ * @see RetryStrategy
+ * @see RetryEligibilityStrategy
+ * @param <ReqT> The type of the request message.
+ * @param <RespT> The type of the response message.
+ */
+final class RetryClientInterceptor implements ClientInterceptor {
+
+  private final RetryStrategy retryStrategy;
+  private final RetryEligibilityStrategy retryEligibilityStrategy;
+  private final Logger logger = LoggerFactory.getLogger(RetryClientInterceptor.class);
+
+  public RetryClientInterceptor(
+      final RetryStrategy retryStrategy, final RetryEligibilityStrategy retryEligibilityStrategy) {
+    this.retryStrategy = retryStrategy;
+    this.retryEligibilityStrategy = retryEligibilityStrategy;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      final MethodDescriptor<ReqT, RespT> method,
+      final CallOptions callOptions,
+      final Channel channel) {
+    // currently the SDK only supports unary operations which we want to retry on
+    if (!method.getType().clientSendsOneMessage()) {
+      return channel.newCall(method, callOptions);
+    }
+
+    return new RetryingUnaryClientCall<ReqT, RespT>(channel.newCall(method, callOptions)) {
+      private int attemptNumber = 0;
+      @Nullable private Future<?> future = null;
+
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        super.start(
+            new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+                responseListener) {
+
+              /**
+               * At this point, the ClientCall has been closed. Any additional calls to the
+               * ClientCall will not be processed by the server. The server does not send any
+               * further messages, acknowledgements, or notifications. This is the point where we
+               * can safely check the status of the initial request that was made, and determine if
+               * we want to retry or not.
+               *
+               * @param status the result of the remote call.
+               * @param trailers metadata provided at call completion.
+               */
+              @Override
+              public void onClose(Status status, Metadata trailers) {
+                // we don't have any more business with the server, and since we either complete the
+                // call or retry
+                // later on, we try to cancel the current attempt. If the request was successful,
+                // this
+                // cancellation will be moot either way.
+                cancelAttempt();
+
+                // anything other than an OK status means it's an erroneous situation.
+                // OK indicates the gRPC call completed successfully and hence we return
+                if (status.isOk()) {
+                  super.onClose(status, trailers);
+                  return;
+                }
+
+                // isRequestIneligibleToRetry is an internal construct to determine if it's safe to
+                // retry and/or on which error codes. This has intentionally been decoupled from the
+                // RetryStrategy logic. Advanced clients who want to make a decision based on gRPC
+                // request can override
+                // {@link RetryEligibilityStrategy}
+                if (isRequestIneligibleToRetry(status)) {
+                  // since this was not a success, we will propagate the error and not retry
+                  logger.debug("Request was ineligible to retry; status code " + status.getCode());
+                  super.onClose(status, trailers);
+                  return;
+                }
+
+                // now we can safely start retrying
+
+                attemptNumber++;
+                final Optional<Long> retryDelay = retryStrategy.getDelay(attemptNumber);
+
+                // a delay not present indicates we have exhausted retries or exceeded
+                // delay or any variable the strategy author wishes to not retry anymore
+                if (!retryDelay.isPresent()) {
+                  super.onClose(status, trailers);
+                  return;
+                }
+
+                // Thread.sleep(0) also makes the OS prioritize it at some point
+                if (retryDelay.get() > 0L) {
+                  try {
+                    Thread.sleep(retryDelay.get());
+                  } catch (InterruptedException e) {
+                    // Restore the interrupted status
+                    Thread.currentThread().interrupt();
+                    // we continue even if we're interrupted
+                  }
+                }
+
+                final Runnable runnable =
+                    Context.current().wrap(() -> retry(channel.newCall(method, callOptions)));
+                // use the current thread to run the task
+                future = CompletableFuture.runAsync(runnable, MoreExecutors.directExecutor());
+              }
+
+              @Override
+              public void onMessage(RespT message) {
+                super.onMessage(message);
+              }
+
+              private boolean isRequestIneligibleToRetry(Status status) {
+                return !retryEligibilityStrategy.isEligibileForRetry(
+                    status, method.getFullMethodName());
+              }
+            },
+            headers);
+      }
+
+      @Override
+      public void cancel(@Nullable String message, @Nullable Throwable cause) {
+        cancelAttempt();
+        super.cancel(message, cause);
+      }
+
+      private void cancelAttempt() {
+        if (future != null) {
+          future.cancel(true);
+        }
+      }
+    };
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nullable;
 import momento.sdk.retry.RetryEligibilityStrategy;
 import momento.sdk.retry.RetryStrategy;

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -101,7 +101,8 @@ import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.exceptions.InternalServerException;
 import momento.sdk.exceptions.UnknownException;
 import momento.sdk.requests.CollectionTtl;
-import momento.sdk.responses.*;
+
+import momento.sdk.responses.SortOrder;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.IncrementResponse;

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -101,7 +101,6 @@ import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.exceptions.InternalServerException;
 import momento.sdk.exceptions.UnknownException;
 import momento.sdk.requests.CollectionTtl;
-
 import momento.sdk.responses.SortOrder;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetResponse;

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -14,7 +14,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configuration;

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -8,7 +8,13 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configuration;
@@ -29,8 +35,7 @@ final class ScsDataGrpcStubsManager implements Closeable {
   private final ExecutorService retryExecutor;
 
   // An arbitary selection of twice the number of available processors.
-  private static final int MAX_RETRY_THREAD_POOL_SIZE =
-      Runtime.getRuntime().availableProcessors() * 2;
+  private static final int MAX_RETRY_THREAD_POOL_SIZE = 64;
   // Timeout to keep threads idle/alive in the retry thread pool
   private static final long RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS = 60L;
 

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -8,7 +8,7 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configuration;
@@ -25,16 +25,55 @@ final class ScsDataGrpcStubsManager implements Closeable {
   private final ManagedChannel channel;
   private final ScsGrpc.ScsFutureStub futureStub;
   private final Duration deadline;
+  private final ScheduledExecutorService retryScheduler;
+  private final ExecutorService retryExecutor;
+
+  // An arbitary selection of twice the number of available processors.
+  private static final int MAX_RETRY_THREAD_POOL_SIZE =
+      Runtime.getRuntime().availableProcessors() * 2;
+  // Timeout to keep threads idle/alive in the retry thread pool
+  private static final long RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS = 60L;
 
   ScsDataGrpcStubsManager(
       @Nonnull CredentialProvider credentialProvider, @Nonnull Configuration configuration) {
     this.deadline = configuration.getTransportStrategy().getGrpcConfiguration().getDeadline();
 
+    /**
+     * These two executors are used by {@link RetryClientInterceptor} to schedule and execute
+     * retries on failed gRPC requests. One is a single threaded scheduling executor {@link
+     * ScheduledExecutorService} that's only responsible to schedule retries with a given delay. The
+     * other executor {@link ThreadPoolExecutor} is a dynamic executor that spawns threads as
+     * necessary and executes the retries (essentially doing the I/O work).
+     *
+     * <p>{@link ScheduledExecutorService} creates idle threads and hence the choice of using two
+     * executors. The small overhead of a single thread doing the scheduling negates the
+     * implications of creating potentially hundreds of idle threads with the
+     * ScheduledExecutorService. This executor is chosen to avoid a Thread.sleep() while doing
+     * retries. There are no available configurations to ScheduledExecutorService such that it grows
+     * dynamically.
+     *
+     * <p>The {@link ThreadPoolExecutor} has a size of 0 and grows onDemand. The maximumPoolSize is
+     * present to cap the number of threads we create for retries; where the {@link
+     * LinkedBlockingQueue} essentially stores any pending retries. Note that the keep alive time
+     * for each thread is 60 seconds, beyond which the JVM will destroy the thread. This is the
+     * default value of {@link Executors.newCachedThreadPool()} and also applies in our situation as
+     * even with backoffs, one retry should be below 60 seconds. We aren't directly using a cached
+     * thread pool because it grows unbounded.
+     */
+    this.retryScheduler = Executors.newSingleThreadScheduledExecutor();
+    this.retryExecutor =
+        new ThreadPoolExecutor(
+            0,
+            MAX_RETRY_THREAD_POOL_SIZE,
+            RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>());
+
     this.channel = setupChannel(credentialProvider, configuration);
     this.futureStub = ScsGrpc.newFutureStub(channel);
   }
 
-  private static ManagedChannel setupChannel(
+  private ManagedChannel setupChannel(
       CredentialProvider credentialProvider, Configuration configuration) {
     final NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
@@ -44,7 +83,7 @@ final class ScsDataGrpcStubsManager implements Closeable {
     clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken()));
     clientInterceptors.add(
         new RetryClientInterceptor(
-            configuration.getRetryStrategy(), configuration.getRetryEligibilityStrategy()));
+            configuration.getRetryStrategy(), retryScheduler, retryExecutor));
     channelBuilder.intercept(clientInterceptors);
     return channelBuilder.build();
   }
@@ -65,6 +104,8 @@ final class ScsDataGrpcStubsManager implements Closeable {
 
   @Override
   public void close() {
+    retryScheduler.shutdown();
+    retryExecutor.shutdown();
     channel.shutdown();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
@@ -1,9 +1,8 @@
 package momento.sdk.config;
 
+import java.time.Duration;
+import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.config.transport.TransportStrategy;
-import momento.sdk.retry.DefaultRetryEligibilityStrategy;
-import momento.sdk.retry.FixedCountRetryStrategy;
-import momento.sdk.retry.RetryEligibilityStrategy;
 import momento.sdk.retry.RetryStrategy;
 
 /** The contract for SDK configurables. A configuration must have a transport strategy. */
@@ -11,35 +10,16 @@ public class Configuration {
 
   private final TransportStrategy transportStrategy;
   private final RetryStrategy retryStrategy;
-  private final RetryEligibilityStrategy retryEligibilityStrategy;
-
-  public static final int MAX_RETRIES = 3;
 
   /**
    * Creates a new configuration object.
    *
    * @param transportStrategy Responsible for configuring network tunables.
    * @param retryStrategy Responsible for configuring retries
-   * @param retryEligibilityStrategy Responsible for configuring retry eligbility
    */
-  public Configuration(
-      TransportStrategy transportStrategy,
-      RetryStrategy retryStrategy,
-      RetryEligibilityStrategy retryEligibilityStrategy) {
+  public Configuration(TransportStrategy transportStrategy, RetryStrategy retryStrategy) {
     this.transportStrategy = transportStrategy;
     this.retryStrategy = retryStrategy;
-    this.retryEligibilityStrategy = retryEligibilityStrategy;
-  }
-
-  /**
-   * Creates a new configuration object with default retry and eligibility strategies
-   *
-   * @param transportStrategy
-   */
-  public Configuration(TransportStrategy transportStrategy) {
-    this.transportStrategy = transportStrategy;
-    this.retryStrategy = new FixedCountRetryStrategy(MAX_RETRIES);
-    this.retryEligibilityStrategy = new DefaultRetryEligibilityStrategy();
   }
 
   /**
@@ -52,7 +32,7 @@ public class Configuration {
   }
 
   /**
-   * Configuration for retry tunables. By default, {@link momento.sdk.retry.FixedDelayRetryStrategy}
+   * Configuration for retry tunables. By default, {@link momento.sdk.retry.FixedCountRetryStrategy}
    * gets used.
    *
    * @return The retry strategy
@@ -61,38 +41,15 @@ public class Configuration {
     return retryStrategy;
   }
 
-  /**
-   * Strategy to determine if a request is eligible for retry. By default, {@link
-   * DefaultRetryEligibilityStrategy} gets used.
-   *
-   * @return The retry eligibility strategy
-   */
-  public RetryEligibilityStrategy getRetryEligibilityStrategy() {
-    return retryEligibilityStrategy;
+  public Configuration withTimeout(final Duration timeout) {
+    final GrpcConfiguration newGrpcConfiguration =
+        this.getTransportStrategy().getGrpcConfiguration().withDeadline(timeout);
+    final TransportStrategy newTransportStrategy =
+        this.getTransportStrategy().withGrpcConfiguration(newGrpcConfiguration);
+    return new Configuration(newTransportStrategy, this.retryStrategy);
   }
 
-  /**
-   * Creates a new instance of the configuration object updated to use the given transport strategy.
-   *
-   * @param transportStrategy Responsible for configuring network tunables.
-   * @return A copy of this Configuration using the new transport strategy
-   */
-  public Configuration withTransportStrategy(TransportStrategy transportStrategy) {
-    return new Configuration(transportStrategy);
-  }
-
-  /**
-   * Creates a new instance of the configuration object updated to use the given strategies.
-   *
-   * @param transportStrategy Responsible for configuring network tunables.
-   * @param retryStrategy Responsible for configuring retries
-   * @param retryEligibilityStrategy Responsible for configuring retry eligibility
-   * @return A copy of this Configuration using the new strategies
-   */
-  public Configuration withTransportStrategy(
-      TransportStrategy transportStrategy,
-      RetryStrategy retryStrategy,
-      RetryEligibilityStrategy retryEligibilityStrategy) {
-    return new Configuration(transportStrategy, retryStrategy, retryEligibilityStrategy);
+  public Configuration withRetryStrategy(final RetryStrategy retryStrategy) {
+    return new Configuration(this.transportStrategy, retryStrategy);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
@@ -1,19 +1,45 @@
 package momento.sdk.config;
 
 import momento.sdk.config.transport.TransportStrategy;
+import momento.sdk.retry.DefaultRetryEligibilityStrategy;
+import momento.sdk.retry.FixedCountRetryStrategy;
+import momento.sdk.retry.RetryEligibilityStrategy;
+import momento.sdk.retry.RetryStrategy;
 
 /** The contract for SDK configurables. A configuration must have a transport strategy. */
 public class Configuration {
 
   private final TransportStrategy transportStrategy;
+  private final RetryStrategy retryStrategy;
+  private final RetryEligibilityStrategy retryEligibilityStrategy;
+
+  public static final int MAX_RETRIES = 3;
 
   /**
    * Creates a new configuration object.
    *
    * @param transportStrategy Responsible for configuring network tunables.
+   * @param retryStrategy Responsible for configuring retries
+   * @param retryEligibilityStrategy Responsible for configuring retry eligbility
+   */
+  public Configuration(
+      TransportStrategy transportStrategy,
+      RetryStrategy retryStrategy,
+      RetryEligibilityStrategy retryEligibilityStrategy) {
+    this.transportStrategy = transportStrategy;
+    this.retryStrategy = retryStrategy;
+    this.retryEligibilityStrategy = retryEligibilityStrategy;
+  }
+
+  /**
+   * Creates a new configuration object with default retry and eligibility strategies
+   *
+   * @param transportStrategy
    */
   public Configuration(TransportStrategy transportStrategy) {
     this.transportStrategy = transportStrategy;
+    this.retryStrategy = new FixedCountRetryStrategy(MAX_RETRIES);
+    this.retryEligibilityStrategy = new DefaultRetryEligibilityStrategy();
   }
 
   /**
@@ -26,6 +52,26 @@ public class Configuration {
   }
 
   /**
+   * Configuration for retry tunables. By default, {@link momento.sdk.retry.FixedDelayRetryStrategy}
+   * gets used.
+   *
+   * @return The retry strategy
+   */
+  public RetryStrategy getRetryStrategy() {
+    return retryStrategy;
+  }
+
+  /**
+   * Strategy to determine if a request is eligible for retry. By default, {@link
+   * DefaultRetryEligibilityStrategy} gets used.
+   *
+   * @return The retry eligibility strategy
+   */
+  public RetryEligibilityStrategy getRetryEligibilityStrategy() {
+    return retryEligibilityStrategy;
+  }
+
+  /**
    * Creates a new instance of the configuration object updated to use the given transport strategy.
    *
    * @param transportStrategy Responsible for configuring network tunables.
@@ -33,5 +79,20 @@ public class Configuration {
    */
   public Configuration withTransportStrategy(TransportStrategy transportStrategy) {
     return new Configuration(transportStrategy);
+  }
+
+  /**
+   * Creates a new instance of the configuration object updated to use the given strategies.
+   *
+   * @param transportStrategy Responsible for configuring network tunables.
+   * @param retryStrategy Responsible for configuring retries
+   * @param retryEligibilityStrategy Responsible for configuring retry eligibility
+   * @return A copy of this Configuration using the new strategies
+   */
+  public Configuration withTransportStrategy(
+      TransportStrategy transportStrategy,
+      RetryStrategy retryStrategy,
+      RetryEligibilityStrategy retryEligibilityStrategy) {
+    return new Configuration(transportStrategy, retryStrategy, retryEligibilityStrategy);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/Configurations.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configurations.java
@@ -4,6 +4,10 @@ import java.time.Duration;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.config.transport.StaticTransportStrategy;
 import momento.sdk.config.transport.TransportStrategy;
+import momento.sdk.retry.DefaultRetryEligibilityStrategy;
+import momento.sdk.retry.FixedCountRetryStrategy;
+import momento.sdk.retry.RetryEligibilityStrategy;
+import momento.sdk.retry.RetryStrategy;
 
 /** Prebuilt {@link Configuration}s for different environments. */
 public class Configurations {
@@ -14,8 +18,11 @@ public class Configurations {
    */
   public static class Laptop extends Configuration {
 
-    private Laptop(TransportStrategy transportStrategy) {
-      super(transportStrategy);
+    private Laptop(
+        TransportStrategy transportStrategy,
+        RetryStrategy retryStrategy,
+        RetryEligibilityStrategy retryEligibilityStrategy) {
+      super(transportStrategy, retryStrategy, retryEligibilityStrategy);
     }
 
     /**
@@ -39,7 +46,40 @@ public class Configurations {
     public static Configuration v1() {
       final TransportStrategy transportStrategy =
           new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(15000)));
-      return new Laptop(transportStrategy);
+      return new Laptop(
+          transportStrategy,
+          new FixedCountRetryStrategy(Configuration.MAX_RETRIES),
+          new DefaultRetryEligibilityStrategy());
+    }
+
+    /**
+     * Provides v1 configuration for a laptop environment with a custom {@link RetryStrategy}. This
+     * configuration is guaranteed not to change in future releases of the Momento Java SDK.
+     *
+     * @param retryStrategy the retry strategy
+     * @return the v1 laptop configuration
+     */
+    public static Configuration v1(RetryStrategy retryStrategy) {
+      final TransportStrategy transportStrategy =
+          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(15000)));
+      return new Laptop(transportStrategy, retryStrategy, new DefaultRetryEligibilityStrategy());
+    }
+
+    /**
+     * Provides v1 configuration for a laptop environment with a custom {@link RetryStrategy} and a
+     * {@link RetryEligibilityStrategy}
+     *
+     * <p>This configuration is guaranteed not to change in future releases of the Momento Java SDK.
+     *
+     * @param retryStrategy the retry strategy
+     * @param retryEligibilityStrategy the retry eligibility strategy
+     * @return the v1 laptop configuration
+     */
+    public static Configuration v1(
+        RetryStrategy retryStrategy, RetryEligibilityStrategy retryEligibilityStrategy) {
+      final TransportStrategy transportStrategy =
+          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(15000)));
+      return new Laptop(transportStrategy, retryStrategy, retryEligibilityStrategy);
     }
   }
 
@@ -50,8 +90,11 @@ public class Configurations {
    */
   public static class InRegion extends Configuration {
 
-    private InRegion(TransportStrategy transportStrategy) {
-      super(transportStrategy);
+    private InRegion(
+        TransportStrategy transportStrategy,
+        RetryStrategy retryStrategy,
+        RetryEligibilityStrategy retryEligibilityStrategy) {
+      super(transportStrategy, retryStrategy, retryEligibilityStrategy);
     }
 
     /**
@@ -75,7 +118,40 @@ public class Configurations {
     public static Configuration v1() {
       final TransportStrategy transportStrategy =
           new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(1100)));
-      return new Laptop(transportStrategy);
+      return new InRegion(
+          transportStrategy,
+          new FixedCountRetryStrategy(Configuration.MAX_RETRIES),
+          new DefaultRetryEligibilityStrategy());
+    }
+
+    /**
+     * Provides v1 configuration for an in-region environment with a custom {@link RetryStrategy}.
+     * This configuration is guaranteed not to change in future releases of the Momento Java SDK.
+     *
+     * @param retryStrategy the retry strategy
+     * @return the v1 in-region configuration
+     */
+    public static Configuration v1(RetryStrategy retryStrategy) {
+      final TransportStrategy transportStrategy =
+          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(1100)));
+      return new InRegion(transportStrategy, retryStrategy, new DefaultRetryEligibilityStrategy());
+    }
+
+    /**
+     * Provides v1 configuration for an in-region environment with a custom {@link RetryStrategy}
+     * and a {@link RetryEligibilityStrategy}
+     *
+     * <p>This configuration is guaranteed not to change in future releases of the Momento Java SDK.
+     *
+     * @param retryStrategy the retry strategy
+     * @param retryEligibilityStrategy the retry eligibility strategy
+     * @return the v1 in-region configuration
+     */
+    public static Configuration v1(
+        RetryStrategy retryStrategy, RetryEligibilityStrategy retryEligibilityStrategy) {
+      final TransportStrategy transportStrategy =
+          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(1100)));
+      return new InRegion(transportStrategy, retryStrategy, retryEligibilityStrategy);
     }
   }
 
@@ -86,8 +162,11 @@ public class Configurations {
    */
   public static class LowLatency extends Configuration {
 
-    private LowLatency(TransportStrategy transportStrategy) {
-      super(transportStrategy);
+    private LowLatency(
+        TransportStrategy transportStrategy,
+        RetryStrategy retryStrategy,
+        RetryEligibilityStrategy retryEligibilityStrategy) {
+      super(transportStrategy, retryStrategy, retryEligibilityStrategy);
     }
 
     /**
@@ -111,7 +190,40 @@ public class Configurations {
     public static Configuration v1() {
       final TransportStrategy transportStrategy =
           new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(500)));
-      return new Laptop(transportStrategy);
+      return new LowLatency(
+          transportStrategy,
+          new FixedCountRetryStrategy(Configuration.MAX_RETRIES),
+          new DefaultRetryEligibilityStrategy());
+    }
+
+    /**
+     * Provides v1 configuration for a low-latency environment with a custom {@link RetryStrategy}.
+     * This configuration is guaranteed not to change in future releases of the Momento Java SDK.
+     *
+     * @param retryStrategy the retry strategy
+     * @return the v1 low-latency configuration
+     */
+    public static Configuration v1(RetryStrategy retryStrategy) {
+      final TransportStrategy transportStrategy =
+          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(500)));
+      return new LowLatency(
+          transportStrategy, retryStrategy, new DefaultRetryEligibilityStrategy());
+    }
+
+    /**
+     * Provides v1 configuration for a low-latency environment with a custom {@link RetryStrategy}
+     * and a {@link RetryEligibilityStrategy} This configuration is guaranteed not to change in
+     * future releases of the Momento Java SDK.
+     *
+     * @param retryStrategy the retry strategy
+     * @param retryEligibilityStrategy the retry eligibility strategy
+     * @return the v1 low-latency configuration
+     */
+    public static Configuration v1(
+        RetryStrategy retryStrategy, RetryEligibilityStrategy retryEligibilityStrategy) {
+      final TransportStrategy transportStrategy =
+          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(500)));
+      return new LowLatency(transportStrategy, retryStrategy, retryEligibilityStrategy);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/Configurations.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configurations.java
@@ -4,7 +4,9 @@ import java.time.Duration;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.config.transport.StaticTransportStrategy;
 import momento.sdk.config.transport.TransportStrategy;
-import momento.sdk.retry.*;
+import momento.sdk.retry.DefaultRetryEligibilityStrategy;
+import momento.sdk.retry.FixedCountRetryStrategy;
+import momento.sdk.retry.RetryStrategy;
 
 /** Prebuilt {@link Configuration}s for different environments. */
 public class Configurations {

--- a/momento-sdk/src/main/java/momento/sdk/config/Configurations.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configurations.java
@@ -4,13 +4,12 @@ import java.time.Duration;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.config.transport.StaticTransportStrategy;
 import momento.sdk.config.transport.TransportStrategy;
-import momento.sdk.retry.DefaultRetryEligibilityStrategy;
-import momento.sdk.retry.FixedCountRetryStrategy;
-import momento.sdk.retry.RetryEligibilityStrategy;
-import momento.sdk.retry.RetryStrategy;
+import momento.sdk.retry.*;
 
 /** Prebuilt {@link Configuration}s for different environments. */
 public class Configurations {
+
+  public static final int DEFAULT_MAX_RETRIES = 3;
 
   /**
    * Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts,
@@ -18,11 +17,8 @@ public class Configurations {
    */
   public static class Laptop extends Configuration {
 
-    private Laptop(
-        TransportStrategy transportStrategy,
-        RetryStrategy retryStrategy,
-        RetryEligibilityStrategy retryEligibilityStrategy) {
-      super(transportStrategy, retryStrategy, retryEligibilityStrategy);
+    private Laptop(TransportStrategy transportStrategy, RetryStrategy retryStrategy) {
+      super(transportStrategy, retryStrategy);
     }
 
     /**
@@ -46,40 +42,9 @@ public class Configurations {
     public static Configuration v1() {
       final TransportStrategy transportStrategy =
           new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(15000)));
-      return new Laptop(
-          transportStrategy,
-          new FixedCountRetryStrategy(Configuration.MAX_RETRIES),
-          new DefaultRetryEligibilityStrategy());
-    }
-
-    /**
-     * Provides v1 configuration for a laptop environment with a custom {@link RetryStrategy}. This
-     * configuration is guaranteed not to change in future releases of the Momento Java SDK.
-     *
-     * @param retryStrategy the retry strategy
-     * @return the v1 laptop configuration
-     */
-    public static Configuration v1(RetryStrategy retryStrategy) {
-      final TransportStrategy transportStrategy =
-          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(15000)));
-      return new Laptop(transportStrategy, retryStrategy, new DefaultRetryEligibilityStrategy());
-    }
-
-    /**
-     * Provides v1 configuration for a laptop environment with a custom {@link RetryStrategy} and a
-     * {@link RetryEligibilityStrategy}
-     *
-     * <p>This configuration is guaranteed not to change in future releases of the Momento Java SDK.
-     *
-     * @param retryStrategy the retry strategy
-     * @param retryEligibilityStrategy the retry eligibility strategy
-     * @return the v1 laptop configuration
-     */
-    public static Configuration v1(
-        RetryStrategy retryStrategy, RetryEligibilityStrategy retryEligibilityStrategy) {
-      final TransportStrategy transportStrategy =
-          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(15000)));
-      return new Laptop(transportStrategy, retryStrategy, retryEligibilityStrategy);
+      final RetryStrategy retryStrategy =
+          new FixedCountRetryStrategy(DEFAULT_MAX_RETRIES, new DefaultRetryEligibilityStrategy());
+      return new Laptop(transportStrategy, retryStrategy);
     }
   }
 
@@ -90,11 +55,8 @@ public class Configurations {
    */
   public static class InRegion extends Configuration {
 
-    private InRegion(
-        TransportStrategy transportStrategy,
-        RetryStrategy retryStrategy,
-        RetryEligibilityStrategy retryEligibilityStrategy) {
-      super(transportStrategy, retryStrategy, retryEligibilityStrategy);
+    private InRegion(TransportStrategy transportStrategy, RetryStrategy retryStrategy) {
+      super(transportStrategy, retryStrategy);
     }
 
     /**
@@ -118,40 +80,9 @@ public class Configurations {
     public static Configuration v1() {
       final TransportStrategy transportStrategy =
           new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(1100)));
-      return new InRegion(
-          transportStrategy,
-          new FixedCountRetryStrategy(Configuration.MAX_RETRIES),
-          new DefaultRetryEligibilityStrategy());
-    }
-
-    /**
-     * Provides v1 configuration for an in-region environment with a custom {@link RetryStrategy}.
-     * This configuration is guaranteed not to change in future releases of the Momento Java SDK.
-     *
-     * @param retryStrategy the retry strategy
-     * @return the v1 in-region configuration
-     */
-    public static Configuration v1(RetryStrategy retryStrategy) {
-      final TransportStrategy transportStrategy =
-          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(1100)));
-      return new InRegion(transportStrategy, retryStrategy, new DefaultRetryEligibilityStrategy());
-    }
-
-    /**
-     * Provides v1 configuration for an in-region environment with a custom {@link RetryStrategy}
-     * and a {@link RetryEligibilityStrategy}
-     *
-     * <p>This configuration is guaranteed not to change in future releases of the Momento Java SDK.
-     *
-     * @param retryStrategy the retry strategy
-     * @param retryEligibilityStrategy the retry eligibility strategy
-     * @return the v1 in-region configuration
-     */
-    public static Configuration v1(
-        RetryStrategy retryStrategy, RetryEligibilityStrategy retryEligibilityStrategy) {
-      final TransportStrategy transportStrategy =
-          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(1100)));
-      return new InRegion(transportStrategy, retryStrategy, retryEligibilityStrategy);
+      final RetryStrategy retryStrategy =
+          new FixedCountRetryStrategy(DEFAULT_MAX_RETRIES, new DefaultRetryEligibilityStrategy());
+      return new InRegion(transportStrategy, retryStrategy);
     }
   }
 
@@ -162,11 +93,8 @@ public class Configurations {
    */
   public static class LowLatency extends Configuration {
 
-    private LowLatency(
-        TransportStrategy transportStrategy,
-        RetryStrategy retryStrategy,
-        RetryEligibilityStrategy retryEligibilityStrategy) {
-      super(transportStrategy, retryStrategy, retryEligibilityStrategy);
+    private LowLatency(TransportStrategy transportStrategy, RetryStrategy retryStrategy) {
+      super(transportStrategy, retryStrategy);
     }
 
     /**
@@ -190,40 +118,9 @@ public class Configurations {
     public static Configuration v1() {
       final TransportStrategy transportStrategy =
           new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(500)));
-      return new LowLatency(
-          transportStrategy,
-          new FixedCountRetryStrategy(Configuration.MAX_RETRIES),
-          new DefaultRetryEligibilityStrategy());
-    }
-
-    /**
-     * Provides v1 configuration for a low-latency environment with a custom {@link RetryStrategy}.
-     * This configuration is guaranteed not to change in future releases of the Momento Java SDK.
-     *
-     * @param retryStrategy the retry strategy
-     * @return the v1 low-latency configuration
-     */
-    public static Configuration v1(RetryStrategy retryStrategy) {
-      final TransportStrategy transportStrategy =
-          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(500)));
-      return new LowLatency(
-          transportStrategy, retryStrategy, new DefaultRetryEligibilityStrategy());
-    }
-
-    /**
-     * Provides v1 configuration for a low-latency environment with a custom {@link RetryStrategy}
-     * and a {@link RetryEligibilityStrategy} This configuration is guaranteed not to change in
-     * future releases of the Momento Java SDK.
-     *
-     * @param retryStrategy the retry strategy
-     * @param retryEligibilityStrategy the retry eligibility strategy
-     * @return the v1 low-latency configuration
-     */
-    public static Configuration v1(
-        RetryStrategy retryStrategy, RetryEligibilityStrategy retryEligibilityStrategy) {
-      final TransportStrategy transportStrategy =
-          new StaticTransportStrategy(new GrpcConfiguration(Duration.ofMillis(500)));
-      return new LowLatency(transportStrategy, retryStrategy, retryEligibilityStrategy);
+      final RetryStrategy retryStrategy =
+          new FixedCountRetryStrategy(DEFAULT_MAX_RETRIES, new DefaultRetryEligibilityStrategy());
+      return new LowLatency(transportStrategy, retryStrategy);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -16,6 +16,7 @@ public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy
   static {
     RETRYABLE_STATUS_CODES.add(Status.Code.UNAVAILABLE);
     RETRYABLE_STATUS_CODES.add(Status.Code.INTERNAL);
+    RETRYABLE_STATUS_CODES.add(Status.Code.NOT_FOUND);
   }
 
   private static final Set<String> RETRYABLE_GRPC_FULL_METHOD_NAMES =

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -30,16 +30,17 @@ public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy
           add("cache_client.Scs/DictionaryGet");
           add("cache_client.Scs/DictionaryFetch");
           add("cache_client.Scs/DictionaryDelete");
-          add("cache_client.Scs/SortedSetPut");
+          // not idempotent: "/cache_client.Scs/SortedSetPut"
           add("cache_client.Scs/SortedSetFetch");
           add("cache_client.Scs/SortedSetGetScore");
-          add("cache_client.Scs/SortedSetRemove");
+          // not idempotent: "/cache_client.Scs/SortedSetRemove"
           add("cache_client.Scs/SortedSetGetRank");
           add("cache_client.Scs/SortedSetLength");
           add("cache_client.Scs/SortedSetLengthByScore");
           // not idempotent: "/cache_client.Scs/SortedSetIncrement"
-          add("cache_client.Scs/SetUnion");
-          add("cache_client.Scs/SetDifference");
+          // not idempotent: "/cache_client.Scs/SetUnion"
+          // not idempotent: "/cache_client.Scs/SetDifference"
+          add("cache_client.Scs/SetContains");
           add("cache_client.Scs/SetFetch");
           add("cache_client.Scs/SetLength");
           // not idempotent: "/cache_client.Scs/SetIfNotExists"

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -4,7 +4,7 @@ import io.grpc.Status;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
+/**iiinter
  * DefaultRetryEligibilityStrategy is an implementation of the RetryEligibilityStrategy interface
  * that determines whether a gRPC call is eligible for retry based on its method name and status
  * code.
@@ -30,9 +30,18 @@ public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy
           add("cache_client.Scs/DictionaryGet");
           add("cache_client.Scs/DictionaryFetch");
           add("cache_client.Scs/DictionaryDelete");
+          add("cache_client.Scs/SortedSetPut");
+          add("cache_client.Scs/SortedSetFetch");
+          add("cache_client.Scs/SortedSetGetScore");
+          add("cache_client.Scs/SortedSetRemove");
+          add("cache_client.Scs/SortedSetGetRank");
+          add("cache_client.Scs/SortedSetLength");
+          add("cache_client.Scs/SortedSetLengthByScore");
+          // not idempotent: "/cache_client.Scs/SortedSetIncrement"
           add("cache_client.Scs/SetUnion");
           add("cache_client.Scs/SetDifference");
           add("cache_client.Scs/SetFetch");
+          add("cache_client.Scs/SetLength");
           // not idempotent: "/cache_client.Scs/SetIfNotExists"
           // not idempotent: "/cache_client.Scs/ListPushFront",
           // not idempotent: "/cache_client.Scs/ListPushBack",

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -16,7 +16,6 @@ public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy
   static {
     RETRYABLE_STATUS_CODES.add(Status.Code.UNAVAILABLE);
     RETRYABLE_STATUS_CODES.add(Status.Code.INTERNAL);
-    RETRYABLE_STATUS_CODES.add(Status.Code.NOT_FOUND);
   }
 
   private static final Set<String> RETRYABLE_GRPC_FULL_METHOD_NAMES =

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -4,10 +4,10 @@ import io.grpc.Status;
 import java.util.HashSet;
 import java.util.Set;
 
-/**iiinter
- * DefaultRetryEligibilityStrategy is an implementation of the RetryEligibilityStrategy interface
- * that determines whether a gRPC call is eligible for retry based on its method name and status
- * code.
+/**
+ * DefaultRetryEligibilityStrategy is an implementation of the RetryEligibilityStrategy
+ * interface that determines whether a gRPC call is eligible for retry based on its method name and
+ * status code.
  */
 public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy {
 

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -1,0 +1,58 @@
+package momento.sdk.retry;
+
+import io.grpc.Status;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * DefaultRetryEligibilityStrategy is an implementation of the RetryEligibilityStrategy interface
+ * that determines whether a gRPC call is eligible for retry based on its method name and status
+ * code.
+ */
+public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy {
+
+  private static final Set<Status.Code> RETRYABLE_STATUS_CODES = new HashSet<>();
+
+  static {
+    RETRYABLE_STATUS_CODES.add(Status.Code.UNAVAILABLE);
+    RETRYABLE_STATUS_CODES.add(Status.Code.INTERNAL);
+  }
+
+  private static final Set<String> RETRYABLE_GRPC_FULL_METHOD_NAMES =
+      new HashSet<String>() {
+        {
+          add("cache_client.Scs/Get");
+          add("cache_client.Scs/Set");
+          add("cache_client.Scs/Delete");
+          // not idempotent "/cache_client.Scs/Increment"
+          add("cache_client.Scs/DictionarySet");
+          // not idempotent: "/cache_client.Scs/DictionaryIncrement",
+          add("cache_client.Scs/DictionaryGet");
+          add("cache_client.Scs/DictionaryFetch");
+          add("cache_client.Scs/DictionaryDelete");
+          add("cache_client.Scs/SetUnion");
+          add("cache_client.Scs/SetDifference");
+          add("cache_client.Scs/SetFetch");
+          // not idempotent: "/cache_client.Scs/SetIfNotExists"
+          // not idempotent: "/cache_client.Scs/ListPushFront",
+          // not idempotent: "/cache_client.Scs/ListPushBack",
+          // not idempotent: "/cache_client.Scs/ListPopFront",
+          // not idempotent: "/cache_client.Scs/ListPopBack"
+          add("cache_client.Scs/ListFetch");
+          // Warning: in the future, this may not be idempotent
+          // Currently it supports removing all occurrences of a value.
+          // In the future, we may also add "the first/last N occurrences of a value".
+          // In the latter case it is not idempotent.
+          add("cache_client.Scs/ListRemove");
+          add("cache_client.Scs/ListLength");
+          // not idempotent: "/cache_client.Scs/ListConcatenateFront",
+          // not idempotent: "/cache_client.Scs/ListConcatenateBack"
+        }
+      };
+
+  /** {@inheritDoc} */
+  public boolean isEligibileForRetry(final Status status, final String methodName) {
+    return RETRYABLE_GRPC_FULL_METHOD_NAMES.contains(methodName)
+        && RETRYABLE_STATUS_CODES.contains(status.getCode());
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -5,9 +5,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * DefaultRetryEligibilityStrategy is an implementation of the RetryEligibilityStrategy
- * interface that determines whether a gRPC call is eligible for retry based on its method name and
- * status code.
+ * DefaultRetryEligibilityStrategy is an implementation of the RetryEligibilityStrategy interface
+ * that determines whether a gRPC call is eligible for retry based on its method name and status
+ * code.
  */
 public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy {
 

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
@@ -34,8 +34,7 @@ public class FixedCountRetryStrategy implements RetryStrategy {
   public FixedCountRetryStrategy(
       final int maxAttempts, final RetryEligibilityStrategy eligibilityStrategy) {
     assert maxAttempts > 0 : "Total number " + "of retry attempts should be greater than 0";
-    Objects.requireNonNull(
-        eligibilityStrategy, "Retry eligibility strategy should not be null");
+    Objects.requireNonNull(eligibilityStrategy, "Retry eligibility strategy should not be null");
     this.maxAttempts = maxAttempts;
     this.retryEligibilityStrategy = eligibilityStrategy;
   }

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
@@ -3,6 +3,7 @@ package momento.sdk.retry;
 import com.google.common.base.Preconditions;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -51,7 +52,7 @@ public class FixedCountRetryStrategy implements RetryStrategy {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<Long> determineWhenToRetry(
+  public Optional<Duration> determineWhenToRetry(
       final Status status, final MethodDescriptor methodDescriptor, final int currentAttempt) {
 
     if (!retryEligibilityStrategy.isEligibileForRetry(
@@ -62,6 +63,7 @@ public class FixedCountRetryStrategy implements RetryStrategy {
     if (currentAttempt > maxAttempts) {
       return Optional.empty();
     }
-    return Optional.of(0L); // Retry immediately with no delay for the fixed number of attempts.
+    return Optional.of(
+        Duration.ofMillis(0)); // Retry immediately with no delay for the fixed number of attempts.
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
@@ -1,0 +1,42 @@
+package momento.sdk.retry;
+
+import com.google.common.base.Preconditions;
+import java.util.Optional;
+
+/**
+ * A retry strategy that retries a failed gRPC call a fixed number of times, with no delay between
+ * retry attempts.
+ *
+ * <p>The `FixedCountRetryStrategy` implements the {@link RetryStrategy} interface and provides a
+ * fixed number of retry attempts without any delay between retries. It allows clients to specify
+ * the maximum number of retry attempts.
+ *
+ * <p>When a gRPC call encounters an error, the `FixedCountRetryStrategy` retries the call a total
+ * of maxAttempts times. The strategy does not introduce any delay between retries, effectively
+ * retrying the call immediately for the fixed number of attempts specified.
+ */
+public class FixedCountRetryStrategy implements RetryStrategy {
+  private final int maxAttempts;
+
+  /**
+   * Constructs a `FixedCountRetryStrategy` with the provided maximum number of retry attempts.
+   *
+   * @param maxAttempts The maximum number of retry attempts. After reaching this limit, no more
+   *     retries will be performed, and the strategy will return an empty optional.
+   * @throws IllegalArgumentException if maxAttempts is not greater than 0.
+   */
+  public FixedCountRetryStrategy(final int maxAttempts) {
+    Preconditions.checkArgument(
+        maxAttempts > 0, "Total number " + "of retry attempts should be greater than 0");
+    this.maxAttempts = maxAttempts;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<Long> getDelay(final int currentAttempt) {
+    if (currentAttempt > maxAttempts) {
+      return Optional.empty(); // No more retries after reaching the maximum attempts.
+    }
+    return Optional.of(0L); // Retry immediately with no delay for the fixed number of attempts.
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedCountRetryStrategy.java
@@ -1,9 +1,9 @@
 package momento.sdk.retry;
 
-import com.google.common.base.Preconditions;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -33,19 +33,16 @@ public class FixedCountRetryStrategy implements RetryStrategy {
    */
   public FixedCountRetryStrategy(
       final int maxAttempts, final RetryEligibilityStrategy eligibilityStrategy) {
-    Preconditions.checkArgument(
-        maxAttempts > 0, "Total number " + "of retry attempts should be greater than 0");
-    Preconditions.checkNotNull(
-        eligibilityStrategy, "Retry eligibility strategy should" + " not be null");
+    assert maxAttempts > 0 : "Total number " + "of retry attempts should be greater than 0";
+    Objects.requireNonNull(
+        eligibilityStrategy, "Retry eligibility strategy should not be null");
     this.maxAttempts = maxAttempts;
     this.retryEligibilityStrategy = eligibilityStrategy;
   }
 
   /** {@inheritDoc} * */
   public FixedCountRetryStrategy(final int maxAttempts) {
-    Preconditions.checkArgument(
-        maxAttempts > 0, "Total number " + "of retry attempts should be greater than 0");
-
+    assert maxAttempts > 0 : "Total number of retry attempts should be greater than 0";
     this.maxAttempts = maxAttempts;
     this.retryEligibilityStrategy = new DefaultRetryEligibilityStrategy();
   }

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
@@ -1,9 +1,9 @@
 package momento.sdk.retry;
 
-import com.google.common.base.Preconditions;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -46,11 +46,10 @@ public class FixedDelayRetryStrategy implements RetryStrategy {
       long delayMillis,
       long maxDelayMillis,
       RetryEligibilityStrategy retryEligibilityStrategy) {
-    Preconditions.checkArgument(
-        delayMillis <= maxDelayMillis,
-        "Delay amount should be " + "less than or equal to the maximum delay");
-    Preconditions.checkNotNull(
-        retryEligibilityStrategy, "Retry eligibility strategy should" + " not be null");
+    assert delayMillis <= maxDelayMillis : "Delay amount should be " + "less than or equal " +
+            "to the maximum delay";
+    Objects.requireNonNull(
+        retryEligibilityStrategy, "Retry eligibility strategy should not be null");
     this.maxAttempts = maxAttempts;
     this.delayMillis = delayMillis;
     this.maxDelayMillis = maxDelayMillis;
@@ -59,9 +58,8 @@ public class FixedDelayRetryStrategy implements RetryStrategy {
 
   /** {@inheritDoc} * */
   public FixedDelayRetryStrategy(int maxAttempts, long delayMillis, long maxDelayMillis) {
-    Preconditions.checkArgument(
-        delayMillis <= maxDelayMillis,
-        "Delay amount should be " + "less than or equal to the maximum delay");
+    assert delayMillis <= maxDelayMillis : "Delay amount should be less than or equal " +
+            "to the maximum delay";
     this.maxAttempts = maxAttempts;
     this.delayMillis = delayMillis;
     this.maxDelayMillis = maxDelayMillis;

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
@@ -1,0 +1,61 @@
+package momento.sdk.retry;
+
+import com.google.common.base.Preconditions;
+import java.util.Optional;
+
+/**
+ * A retry strategy that uses a fixed delay between consecutive retry attempts for a failed gRPC
+ * call.
+ *
+ * <p>The `FixedDelayRetryStrategy` implements the {@link RetryStrategy} interface and provides a
+ * fixed delay for each retry attempt. It allows clients to specify the maximum number of retry
+ * attempts, the initial delay, and the maximum delay between attempts.
+ *
+ * <p>When a gRPC call encounters an error, the `FixedDelayRetryStrategy` calculates the delay for
+ * each retry attempt based on the provided delayMillis. The delay for each retry attempt is
+ * cumulative, where the nth attempt has a delay of n * delayMillis. If the cumulative delay exceeds
+ * the specified maxDelayMillis or the number of attempts exceeds maxAttempts, the retry strategy
+ * stops further retries and returns an empty optional to indicate that no more retry attempts
+ * should be made.
+ */
+public class FixedDelayRetryStrategy implements RetryStrategy {
+  private final int maxAttempts;
+  private final long delayMillis;
+  private final long maxDelayMillis;
+
+  /**
+   * Constructs a `FixedDelayRetryStrategy` with the provided parameters.
+   *
+   * @param maxAttempts The maximum number of retry attempts. After reaching this limit, no more
+   *     retries will be performed, and the strategy will return an empty optional.
+   * @param delayMillis The delay in milliseconds for each retry attempt.
+   * @param maxDelayMillis The maximum cumulative delay in milliseconds that is allowed for all
+   *     retry attempts combined. If the cumulative delay exceeds this value, no more retries will
+   *     be performed, and the strategy will return an empty optional.
+   * @throws IllegalArgumentException if delayMillis is greater than maxDelayMillis.
+   */
+  public FixedDelayRetryStrategy(int maxAttempts, long delayMillis, long maxDelayMillis) {
+    Preconditions.checkArgument(
+        delayMillis <= maxDelayMillis,
+        "Delay amount should be " + "less than or equal to the maximum delay");
+    this.maxAttempts = maxAttempts;
+    this.delayMillis = delayMillis;
+    this.maxDelayMillis = maxDelayMillis;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<Long> getDelay(int currentAttempt) {
+    if (currentAttempt > maxAttempts) {
+      return Optional.empty(); // Exceeded the maximum number of retry attempts.
+    }
+
+    long cumulativeDelay = delayMillis * currentAttempt;
+    // If the cumulative delay exceeds the maximum allowed delay, stop further retries.
+    if (cumulativeDelay > maxDelayMillis) {
+      return Optional.empty();
+    }
+
+    return Optional.of(delayMillis); // Return the fixed delay for the current attempt.
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
@@ -46,8 +46,8 @@ public class FixedDelayRetryStrategy implements RetryStrategy {
       long delayMillis,
       long maxDelayMillis,
       RetryEligibilityStrategy retryEligibilityStrategy) {
-    assert delayMillis <= maxDelayMillis : "Delay amount should be " + "less than or equal " +
-            "to the maximum delay";
+    assert delayMillis <= maxDelayMillis
+        : "Delay amount should be " + "less than or equal " + "to the maximum delay";
     Objects.requireNonNull(
         retryEligibilityStrategy, "Retry eligibility strategy should not be null");
     this.maxAttempts = maxAttempts;
@@ -58,8 +58,8 @@ public class FixedDelayRetryStrategy implements RetryStrategy {
 
   /** {@inheritDoc} * */
   public FixedDelayRetryStrategy(int maxAttempts, long delayMillis, long maxDelayMillis) {
-    assert delayMillis <= maxDelayMillis : "Delay amount should be less than or equal " +
-            "to the maximum delay";
+    assert delayMillis <= maxDelayMillis
+        : "Delay amount should be less than or equal " + "to the maximum delay";
     this.maxAttempts = maxAttempts;
     this.delayMillis = delayMillis;
     this.maxDelayMillis = maxDelayMillis;

--- a/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/FixedDelayRetryStrategy.java
@@ -3,6 +3,7 @@ package momento.sdk.retry;
 import com.google.common.base.Preconditions;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -69,7 +70,7 @@ public class FixedDelayRetryStrategy implements RetryStrategy {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<Long> determineWhenToRetry(
+  public Optional<Duration> determineWhenToRetry(
       final Status status, final MethodDescriptor methodDescriptor, final int currentAttempt) {
 
     if (!retryEligibilityStrategy.isEligibileForRetry(
@@ -87,6 +88,7 @@ public class FixedDelayRetryStrategy implements RetryStrategy {
       return Optional.empty();
     }
 
-    return Optional.of(delayMillis); // Return the fixed delay for the current attempt.
+    return Optional.of(
+        Duration.ofMillis(delayMillis)); // Return the fixed delay for the current attempt.
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/retry/RetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/RetryEligibilityStrategy.java
@@ -1,0 +1,34 @@
+package momento.sdk.retry;
+
+import io.grpc.Status;
+
+/**
+ * An interface representing a strategy for determining whether a gRPC request is eligible for
+ * retrying based on the status and method name.
+ *
+ * <p>Implementations of this interface allow clients to customize the criteria for retrying a
+ * failed gRPC call. The {@link #isEligibileForRetry(Status, String)} method is called by the
+ * RetryClientInterceptor to determine whether a specific gRPC request is eligible for retrying or
+ * not.
+ *
+ * <p>A gRPC call may encounter different types of errors, such as network issues, server-side
+ * errors, or client-side errors. The retry eligibility strategy can evaluate the gRPC status and
+ * the associated method name to make an informed decision on whether to retry the call or not.
+ *
+ * <p>For example, a simple implementation of this interface could check the status code of the gRPC
+ * response and return true if the status code represents a transient error (e.g., 503 Service
+ * Unavailable). More advanced implementations could take into account other factors such as the
+ * error message, specific error codes, or custom conditions specific to the application.
+ */
+public interface RetryEligibilityStrategy {
+  /**
+   * Determines whether a gRPC request is eligible for retrying based on the provided status and
+   * method name.
+   *
+   * @param status The gRPC status returned by the server after the initial request.
+   * @param methodName The full method name of the gRPC request (e.g.,
+   *     "com.example.FooService/BarMethod").
+   * @return {@code true} if the request is eligible for retry, {@code false} otherwise.
+   */
+  boolean isEligibileForRetry(Status status, String methodName);
+}

--- a/momento-sdk/src/main/java/momento/sdk/retry/RetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/RetryStrategy.java
@@ -10,8 +10,9 @@ import java.util.Optional;
  *
  * <p>Implementations of this interface allow clients to customize the delay between consecutive
  * retry attempts when a gRPC call fails. The {@link #determineWhenToRetry(Status, MethodDescriptor,
- * int)} method is called by the RetryClientInterceptor to retrieve the delay for the next retry attempt
- * based on the status of the gRPC failure, the request properties, and the current attempt number.
+ * int)} method is called by the RetryClientInterceptor to retrieve the delay for the next retry
+ * attempt based on the status of the gRPC failure, the request properties, and the current attempt
+ * number.
  *
  * <p>When a gRPC call encounters an error, the retry strategy can decide how long the client should
  * wait before attempting to retry the call. The delay can be constant, incrementally increasing, or

--- a/momento-sdk/src/main/java/momento/sdk/retry/RetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/RetryStrategy.java
@@ -2,6 +2,7 @@ package momento.sdk.retry;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -46,6 +47,6 @@ public interface RetryStrategy {
    * @return An {@link Optional} containing the delay in milliseconds for the next retry attempt, or
    *     an empty optional to indicate that no further retry attempts should be made.
    */
-  Optional<Long> determineWhenToRetry(
+  Optional<Duration> determineWhenToRetry(
       Status grpcStatus, MethodDescriptor request, int currentAttempt);
 }

--- a/momento-sdk/src/main/java/momento/sdk/retry/RetryStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/RetryStrategy.java
@@ -1,0 +1,44 @@
+package momento.sdk.retry;
+
+import java.util.Optional;
+
+/**
+ * An interface representing a strategy for determining the delay between retry attempts for a
+ * failed gRPC call.
+ *
+ * <p>Implementations of this interface allow clients to customize the delay between consecutive
+ * retry attempts when a gRPC call fails. The {@link #getDelay(int)} method when provided to a
+ * Configuration, is called by the RetryClientInterceptor to retrieve the delay for the next retry
+ * attempt based on the current attempt number.
+ *
+ * <p>When a gRPC call encounters an error, the retry strategy can decide how long the client should
+ * wait before attempting to retry the call. The delay can be constant, incrementally increasing, or
+ * even follow a custom exponential or backoff pattern.
+ *
+ * <p>If the retry strategy returns an empty optional (Optional.empty()), it indicates that the
+ * retry will not be performed based on the implemented contract. In such cases, the
+ * RetryClientInterceptor will propagate the final result to the original listener after the last
+ * failed attempt, effectively completing the call with the last status received without further
+ * retries.
+ *
+ * <p>The value returned by {@link #getDelay(int)} should be a non-negative long value representing
+ * the delay in milliseconds for the next retry attempt. If the returned value is 0 or a negative
+ * number, the interceptor may interpret it as a request to retry immediately without any delay.
+ *
+ * <p>Note that the decision to retry and the specific delay calculation can be influenced by
+ * various factors such as network conditions, server load, and the specific requirements of the
+ * application.
+ */
+public interface RetryStrategy {
+
+  /**
+   * Retrieves the delay in milliseconds for the next retry attempt based on the current attempt
+   * number.
+   *
+   * @param currentAttempt The current attempt number of the retry. Starts from 1 for the first
+   *     retry attempt.
+   * @return An {@link Optional} containing the delay in milliseconds for the next retry attempt, or
+   *     an empty optional to indicate that no further retry attempts should be made.
+   */
+  Optional<Long> getDelay(int currentAttempt);
+}

--- a/momento-sdk/src/main/java/momento/sdk/retry/RetryingUnaryClientCall.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/RetryingUnaryClientCall.java
@@ -1,0 +1,109 @@
+package momento.sdk.retry;
+
+import com.google.common.base.Preconditions;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import javax.annotation.Nullable;
+
+/**
+ * A custom implementation of {@link ClientCall} that handles retrying unary (single request, single
+ * response) operations. This class is used by the RetryClientInterceptor to manage retry logic for
+ * failed gRPC calls.
+ *
+ * <p>The {@code RetryingUnaryClientCall} wraps an original {@link ClientCall} and intercepts the
+ * methods related to starting, sending messages, and handling the response. If the original call
+ * encounters an error, the interceptor schedules a retry attempt based on the configured retry
+ * strategy and eligibility rules.
+ *
+ * <p>Each instance of {@code RetryingUnaryClientCall} maintains its own state, including the
+ * request message, response listener, headers, and other properties specific to the call. When a
+ * retry is needed, a new instance of this class is created with the original request details, and
+ * the retry attempt is initiated.
+ *
+ * <p>Note that this implementation assumes that the gRPC call is unary, meaning the client sends
+ * one message and receives one response. For streaming calls or other call types, a different
+ * approach or implementation would be required.
+ */
+public class RetryingUnaryClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
+
+  private ClientCall<ReqT, RespT> delegate;
+  private Listener<RespT> responseListener;
+  private Metadata headers;
+  private ReqT message;
+  private int numMessages;
+  private boolean compressionEnabled;
+
+  /**
+   * Constructs a new instance of {@code RetryingUnaryClientCall} with the provided delegate.
+   *
+   * @param delegate The original {@link ClientCall} to be wrapped and managed by this retrying
+   *     call.
+   */
+  public RetryingUnaryClientCall(final ClientCall<ReqT, RespT> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void start(Listener<RespT> responseListener, Metadata headers) {
+    Preconditions.checkNotNull(responseListener, "responseListener cannot be null");
+    Preconditions.checkNotNull(headers, "Headers cannot be null");
+    this.responseListener = responseListener;
+    this.headers = headers;
+    this.delegate.start(responseListener, headers);
+  }
+
+  @Override
+  public void request(int numMessages) {
+    this.numMessages = numMessages;
+    this.delegate.request(numMessages);
+  }
+
+  @Override
+  public void cancel(@Nullable String message, @Nullable Throwable cause) {
+    this.delegate.cancel(message, cause);
+  }
+
+  @Override
+  public void halfClose() {
+    this.delegate.halfClose();
+  }
+
+  @Override
+  public void setMessageCompression(boolean enabled) {
+    this.compressionEnabled = enabled;
+    this.delegate.setMessageCompression(enabled);
+  }
+
+  @Override
+  public void sendMessage(ReqT message) {
+    Preconditions.checkState(this.message == null, "Expecting only one message to be sent");
+    this.message = message;
+    this.delegate.sendMessage(message);
+  }
+
+  @Override
+  public boolean isReady() {
+    return delegate.isReady();
+  }
+
+  /**
+   * This method is called by the RetryClientInterceptor's listener if there was an error in the
+   * original request. It is responsible for scheduling a retry attempt with the same request
+   * details as the original call.
+   *
+   * @param delegate The new {@link ClientCall} instance to be used for the retry attempt.
+   */
+  public void retry(ClientCall<ReqT, RespT> delegate) {
+    this.delegate = delegate;
+    try {
+      this.delegate.start(responseListener, headers);
+      this.delegate.setMessageCompression(compressionEnabled);
+      this.delegate.request(numMessages);
+      this.delegate.sendMessage(message);
+      this.delegate.halfClose();
+    } catch (Throwable t) {
+      // we try to cancel the request on any errors
+      this.delegate.cancel(t.getMessage(), t);
+    }
+  }
+}

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedCountRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedCountRetryStrategyTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,11 +42,11 @@ class FixedCountRetryStrategyTest {
         new FixedCountRetryStrategy(maxAttempts, eligibilityStrategy);
 
     // When getting the delay for the first attempt
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
 
     // Then the delay should be 0, indicating an immediate retry
     assertTrue(delay.isPresent());
-    assertEquals(0L, delay.get());
+    assertEquals(0L, delay.get().toMillis());
   }
 
   @Test
@@ -56,7 +57,7 @@ class FixedCountRetryStrategyTest {
         new FixedCountRetryStrategy(maxAttempts, eligibilityStrategy);
 
     // When getting the delay for the fourth attempt
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 4);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 4);
 
     // Then the delay should be empty, indicating no more retries
     assertFalse(delay.isPresent());
@@ -71,7 +72,7 @@ class FixedCountRetryStrategyTest {
         new FixedCountRetryStrategy(maxAttempts, eligibilityStrategy);
 
     // valid attempt but not eligible
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
 
     // Then the delay should be empty, indicating no more retries
     assertFalse(delay.isPresent());

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedCountRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedCountRetryStrategyTest.java
@@ -3,20 +3,45 @@ package momento.sdk.retry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class FixedCountRetryStrategyTest {
+
+  @Mock private MethodDescriptor methodDescriptor;
+  @Mock private Status status;
+  @Mock private RetryEligibilityStrategy eligibilityStrategy;
+
+  @BeforeEach
+  public void setup() {
+    lenient().when(methodDescriptor.getFullMethodName()).thenReturn("methodName");
+    lenient()
+        .when(eligibilityStrategy.isEligibileForRetry(eq(status), anyString()))
+        .thenReturn(true);
+  }
 
   @Test
   void testGetDelay_SuccessfulRetry() {
+
     // Given a successful retry attempt
     int maxAttempts = 3;
-    FixedCountRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts);
+    FixedCountRetryStrategy retryStrategy =
+        new FixedCountRetryStrategy(maxAttempts, eligibilityStrategy);
 
     // When getting the delay for the first attempt
-    Optional<Long> delay = retryStrategy.getDelay(1);
+    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
 
     // Then the delay should be 0, indicating an immediate retry
     assertTrue(delay.isPresent());
@@ -27,10 +52,26 @@ class FixedCountRetryStrategyTest {
   void testGetDelay_ExceededMaxAttempts() {
     // Given that retry attempts have exceeded the maximum allowed attempts
     int maxAttempts = 3;
-    FixedCountRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts);
+    FixedCountRetryStrategy retryStrategy =
+        new FixedCountRetryStrategy(maxAttempts, eligibilityStrategy);
 
     // When getting the delay for the fourth attempt
-    Optional<Long> delay = retryStrategy.getDelay(4);
+    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 4);
+
+    // Then the delay should be empty, indicating no more retries
+    assertFalse(delay.isPresent());
+  }
+
+  @Test
+  void testGetDelay_IneligibleToRetry() {
+    when(eligibilityStrategy.isEligibileForRetry(eq(status), anyString())).thenReturn(false);
+
+    int maxAttempts = 3;
+    FixedCountRetryStrategy retryStrategy =
+        new FixedCountRetryStrategy(maxAttempts, eligibilityStrategy);
+
+    // valid attempt but not eligible
+    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
 
     // Then the delay should be empty, indicating no more retries
     assertFalse(delay.isPresent());

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedCountRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedCountRetryStrategyTest.java
@@ -1,0 +1,38 @@
+package momento.sdk.retry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FixedCountRetryStrategyTest {
+
+  @Test
+  void testGetDelay_SuccessfulRetry() {
+    // Given a successful retry attempt
+    int maxAttempts = 3;
+    FixedCountRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts);
+
+    // When getting the delay for the first attempt
+    Optional<Long> delay = retryStrategy.getDelay(1);
+
+    // Then the delay should be 0, indicating an immediate retry
+    assertTrue(delay.isPresent());
+    assertEquals(0L, delay.get());
+  }
+
+  @Test
+  void testGetDelay_ExceededMaxAttempts() {
+    // Given that retry attempts have exceeded the maximum allowed attempts
+    int maxAttempts = 3;
+    FixedCountRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts);
+
+    // When getting the delay for the fourth attempt
+    Optional<Long> delay = retryStrategy.getDelay(4);
+
+    // Then the delay should be empty, indicating no more retries
+    assertFalse(delay.isPresent());
+  }
+}

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
@@ -1,0 +1,60 @@
+package momento.sdk.retry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FixedDelayRetryStrategyTest {
+
+  @Test
+  void testGetDelay_SuccessfulRetry() {
+    // Given a successful retry attempt
+    int maxAttempts = 3;
+    long delayMillis = 1000L;
+    long maxDelayMillis = 3000L;
+    FixedDelayRetryStrategy retryStrategy =
+        new FixedDelayRetryStrategy(maxAttempts, delayMillis, maxDelayMillis);
+
+    // When getting the delay for the first attempt
+    Optional<Long> delay = retryStrategy.getDelay(1);
+
+    // Then the delay should be equal to the fixed delay
+    assertTrue(delay.isPresent());
+    assertEquals(delayMillis, delay.get());
+  }
+
+  @Test
+  void testGetDelay_ExceededMaxAttempts() {
+    // Given that retry attempts have exceeded the maximum allowed attempts
+    int maxAttempts = 3;
+    long delayMillis = 1000L;
+    long maxDelayMillis = 3000L;
+    FixedDelayRetryStrategy retryStrategy =
+        new FixedDelayRetryStrategy(maxAttempts, delayMillis, maxDelayMillis);
+
+    // When getting the delay for the fourth attempt
+    Optional<Long> delay = retryStrategy.getDelay(4);
+
+    // Then the delay should be empty, indicating no more retries
+    assertFalse(delay.isPresent());
+  }
+
+  @Test
+  void testGetDelay_ExceededMaxDelay() {
+    // Given that the cumulative delay has exceeded the maximum delay
+    int maxAttempts = 10;
+    long delayMillis = 100L;
+    long maxDelayMillis = 500L;
+    FixedDelayRetryStrategy retryStrategy =
+        new FixedDelayRetryStrategy(maxAttempts, delayMillis, maxDelayMillis);
+
+    // When getting the delay for the tenth attempt
+    Optional<Long> delay = retryStrategy.getDelay(10);
+
+    // Then the delay should be empty, indicating no more retries
+    assertFalse(delay.isPresent());
+  }
+}

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
@@ -3,7 +3,9 @@ package momento.sdk.retry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +31,8 @@ class FixedDelayRetryStrategyTest {
   public void setup() {
     lenient().when(methodDescriptor.getFullMethodName()).thenReturn("methodName");
     lenient()
-        .when(eligibilityStrategy.isEligibileForRetry(eq(status), anyString()))
+        .when(eligibilityStrategy.isEligibileForRetry(eq(status),
+                anyString()))
         .thenReturn(true);
   }
 

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
@@ -3,7 +3,6 @@ package momento.sdk.retry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -31,8 +30,7 @@ class FixedDelayRetryStrategyTest {
   public void setup() {
     lenient().when(methodDescriptor.getFullMethodName()).thenReturn("methodName");
     lenient()
-        .when(eligibilityStrategy.isEligibileForRetry(eq(status),
-                anyString()))
+        .when(eligibilityStrategy.isEligibileForRetry(eq(status), anyString()))
         .thenReturn(true);
   }
 

--- a/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/retry/FixedDelayRetryStrategyTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,11 +43,11 @@ class FixedDelayRetryStrategyTest {
         new FixedDelayRetryStrategy(maxAttempts, delayMillis, maxDelayMillis, eligibilityStrategy);
 
     // When getting the delay for the first attempt
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
 
     // Then the delay should be equal to the fixed delay
     assertTrue(delay.isPresent());
-    assertEquals(delayMillis, delay.get());
+    assertEquals(delayMillis, delay.get().toMillis());
   }
 
   @Test
@@ -59,7 +60,7 @@ class FixedDelayRetryStrategyTest {
         new FixedDelayRetryStrategy(maxAttempts, delayMillis, maxDelayMillis, eligibilityStrategy);
 
     // When getting the delay for the fourth attempt
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 4);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 4);
 
     // Then the delay should be empty, indicating no more retries
     assertFalse(delay.isPresent());
@@ -75,7 +76,7 @@ class FixedDelayRetryStrategyTest {
         new FixedDelayRetryStrategy(maxAttempts, delayMillis, maxDelayMillis, eligibilityStrategy);
 
     // When getting the delay for the tenth attempt
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 6);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 6);
 
     // Then the delay should be empty, indicating no more retries
     assertFalse(delay.isPresent());
@@ -90,7 +91,7 @@ class FixedDelayRetryStrategyTest {
         new FixedDelayRetryStrategy(maxAttempts, 100, 500, eligibilityStrategy);
 
     // valid attempt but not eligible
-    Optional<Long> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
+    Optional<Duration> delay = retryStrategy.determineWhenToRetry(status, methodDescriptor, 1);
 
     // Then the delay should be empty, indicating no more retries
     assertFalse(delay.isPresent());


### PR DESCRIPTION
### **Note**: 

Apart from adding retries, this PR contains backward incompatible changes with respect to cache client initialization. We made this decision as the SDK is relatively young and to follow better and consistent practices with other SDKs. Previously, if a user wanted to override the gRPC request deadline, they did:

```
  CacheClient.builder(
                        credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
                    .setDeadline(Duration.ofMillis(0))
                    .build());
```

The `setDeadline` method violates the builder pattern and overrides an already initialized configuration. We also want to remove the word deadline as it's not conventional and gRPC specific. This PR removes `setDeadline` from the builder, and adds a `withTimeout` to the Configuration object which returns a new Configuration object with the appropriate gRPC transport strategy based on the timeout/deadline. The initialization now looks like

```
  CacheClient.builder(
                        credentialProvider,
                        Configurations.Laptop.latest()
                                    .withTimeout(Duration.ofMillis(100)),
                        DEFAULT_TTL_SECONDS)
                    .build());
```

### Overview 

Added a ```RetryInterceptor``` to intercept gRPC requests to add SDK/client-side retries. I have added enough JavaDocs on the code to make sense of what's going on, but please call out if you want more details here or over a call. Note that this hasn't been wrapped as a middleware, but there's nothing stopping us in future if we want to do so.

There are 2 new constructs in this PR from a client perspective:

- **Retry Strategy**: This interface contains a contract ```determineWhenToRetry``` (optional) which can be overridden by clients to provide their own retry strategy. Otherwise, we default to our own flavor of ```FixedCountRetryStrategy``` that simply retries upto 3 times without any delay. The PR also adds a ```FixedDelayRetryStrategy``` that clients can directly use if they want to, though that's not the default.
- **Retry Eligbility Strategy**: This is composed int the RetryStrategy class and a default is available.```DefaultRetryEligibiliyStrategy``` kicks in if clients don't provide the eligibility, which checks for eligible status codes and method names to retry on.
 
The code is backwards compatible from a client initialization perspective, so if they do

```
      CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
            .build();
```

like before, they get the retry and eligiblity strategies for free for the default. They can override both like:

```
      RetryStrategy retryStrategy = new FixedCountRetryStrategy(10);
      CacheClient.builder(credentialProvider, Configurations.Laptop.latest().withRetryStrategy(retryStrategy), DEFAULT_TTL_SECONDS)
            .build();
```

OR

```
      RetryEligibilityStrategy eligibilityStrategy = new CustomEligibilityStrategy();
      RetryStrategy retryStrategy = new FixedCountRetryStrategy(10, eligibilityStrategy);

      CacheClient.builder(credentialProvider, Configurations.Laptop.latest().withRetryStrategy(retryStrategy), DEFAULT_TTL_SECONDS)
            .build();
```

### Testing

- I have manually tested that retry kicks in by tinkering with the status codes and method names; to check if the retry logic kicks in on an authentication or cache doesn't exist error. It's hard to reproduce a timeout/network error so I will run a loadgen against this.
- Will do some more custom testing but sending out PR for feedback.

References: https://github.com/facebook/buck/blob/main/src/com/facebook/buck/remoteexecution/grpc/retry/RetryClientInterceptor.java