### PR TITLE
chore: improve missing env var message, illustrate how to build examples against local SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,6 @@ To fix the formatting either reformat the code using the IDE based plugin or run
 
 `./gradlew :momento-sdk:spotlessApply`
 
+### Examples
+
+The example code can be found in the `examples` directory. If you would like to run the examples against your local copy of the SDK source code, uncomment the `includeBuild` stanza in the `examples/settings.gradle.kts` file. This will allow you to test the example code against local changes that you have made to the SDK.

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -8,6 +8,19 @@
  */
 
 rootProject.name = "java-gradle"
+
+/*
+ * Uncomment the code below if you would like to develop the examples against your local
+ * copy of the SDK code. This is useful if you are making changes to the SDK and want to
+ * test them in the examples before committing them.
+ */
+//includeBuild("..") {
+//    dependencySubstitution {
+//        substitute(module("software.momento.java:sdk")).using(project(":momento-sdk"))
+//    }
+//}
+
 include("cache")
 include("cache-with-aws")
 include("lambda:docker")
+

--- a/momento-sdk/src/main/java/momento/sdk/auth/EnvVarCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/EnvVarCredentialProvider.java
@@ -15,7 +15,7 @@ public class EnvVarCredentialProvider extends StringCredentialProvider {
    * @param envVarName the environment variable containing the Momento authentication token.
    */
   public EnvVarCredentialProvider(@Nonnull String envVarName) {
-    super(System.getenv(envVarName), null, null);
+    super(getApiKeyValueFromEnvVar(envVarName), null, null);
   }
 
   /**
@@ -28,6 +28,15 @@ public class EnvVarCredentialProvider extends StringCredentialProvider {
    */
   public EnvVarCredentialProvider(
       @Nonnull String envVarName, @Nullable String controlHost, @Nullable String cacheHost) {
-    super(System.getenv(envVarName), controlHost, cacheHost);
+    super(getApiKeyValueFromEnvVar(envVarName), controlHost, cacheHost);
+  }
+
+  private static String getApiKeyValueFromEnvVar(String envVarName) {
+    String authToken = System.getenv(envVarName);
+    if (authToken == null) {
+      throw new IllegalArgumentException(
+          "Missing required Momento API Key environment variable: " + envVarName);
+    }
+    return authToken;
   }
 }


### PR DESCRIPTION
This commit adds a bit more error handling to the EnvVarCredentialProvider so that if the
environment variable is missing, we will give a slightly more helpful error message.

Also includes a commented-out gradle snippet for the examples project which allows you to
compile the examples against your local copy of the SDK, so that it is easier to test changes
as you are developing.
