### PR TITLE
fix: don't checkout repo with private token inside of ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,8 +41,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
       - name: Generate README
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v2


### PR DESCRIPTION
Using a special private token to checkout our repo is not a realistic way a customer may checkout our repo. I think this might be an artifact stemming from when we were using git submodules