### PR TITLE
feat: add onConnectionLost and onConnectionRestored callback functions

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/IScsTopicConnection.java
+++ b/momento-sdk/src/main/java/momento/sdk/IScsTopicConnection.java
@@ -1,0 +1,34 @@
+package momento.sdk;
+
+import grpc.cache_client.pubsub._SubscriptionItem;
+import grpc.cache_client.pubsub._SubscriptionRequest;
+
+/** Represents a connection to an ScsTopic for subscribing to events. */
+interface IScsTopicConnection {
+
+  /**
+   * Closes the connection.
+   *
+   * <p>Note: This method is intended for testing purposes and should never be called from outside
+   * of tests.
+   */
+  void close();
+
+  /**
+   * Opens the connection.
+   *
+   * <p>Note: This method is intended for testing purposes and should never be called from outside
+   * of tests.
+   */
+  void open();
+
+  /**
+   * Subscribes to a specific topic using the provided subscription request and observer.
+   *
+   * @param subscriptionRequest The subscription request containing details about the subscription.
+   * @param subscription The observer to handle incoming subscription items.
+   */
+  void subscribe(
+      _SubscriptionRequest subscriptionRequest,
+      CancelableClientCallStreamObserver<_SubscriptionItem> subscription);
+}

--- a/momento-sdk/src/main/java/momento/sdk/ISubscriptionCallbacks.java
+++ b/momento-sdk/src/main/java/momento/sdk/ISubscriptionCallbacks.java
@@ -1,9 +1,12 @@
 package momento.sdk;
 
 import momento.sdk.responses.topic.TopicMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Represents options for a topic subscription callback. */
 public interface ISubscriptionCallbacks {
+  Logger logger = LoggerFactory.getLogger(SubscriptionWrapper.class);
   /**
    * Called when a new message is received on the subscribed topic.
    *
@@ -20,4 +23,14 @@ public interface ISubscriptionCallbacks {
    * @param t The throwable representing the error.
    */
   void onError(Throwable t);
+
+  /** Called when the connection to the topic is lost. */
+  default void onConnectionLost() {
+    logger.info("Connection to topic lost");
+  }
+
+  /** Called when the connection to the topic is restored. */
+  default void onConnectionRestored() {
+    logger.info("Connection to topic restored");
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
@@ -73,6 +73,8 @@ public class ScsTopicClient extends ScsClient {
             options::onItem,
             options::onCompleted,
             options::onError,
+            options::onConnectionLost,
+            options::onConnectionRestored,
             subscriptionState,
             subscription);
 

--- a/momento-sdk/src/main/java/momento/sdk/SendSubscribeOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/SendSubscribeOptions.java
@@ -10,6 +10,8 @@ class SendSubscribeOptions implements ISubscriptionCallbacks {
   ItemCallback onItem;
   CompletedCallback onCompleted;
   ErrorCallback onError;
+  ConnectionLostCallback onConnectionLost;
+  ConnectionRestoredCallback onConnectionRestored;
   SubscriptionState subscriptionState;
   TopicSubscribeResponse.Subscription subscription;
 
@@ -19,6 +21,8 @@ class SendSubscribeOptions implements ISubscriptionCallbacks {
       ItemCallback onItem,
       CompletedCallback onCompleted,
       ErrorCallback onError,
+      ConnectionLostCallback onConnectionLost,
+      ConnectionRestoredCallback onConnectionRestored,
       SubscriptionState subscriptionState,
       TopicSubscribeResponse.Subscription subscription) {
     this.cacheName = cacheName;
@@ -26,6 +30,8 @@ class SendSubscribeOptions implements ISubscriptionCallbacks {
     this.onItem = onItem;
     this.onCompleted = onCompleted;
     this.onError = onError;
+    this.onConnectionLost = onConnectionLost;
+    this.onConnectionRestored = onConnectionRestored;
     this.subscriptionState = subscriptionState;
     this.subscription = subscription;
   }
@@ -73,6 +79,16 @@ class SendSubscribeOptions implements ISubscriptionCallbacks {
     onError.onError(t);
   }
 
+  @Override
+  public void onConnectionLost() {
+    onConnectionLost.onConnectionLost();
+  }
+
+  @Override
+  public void onConnectionRestored() {
+    onConnectionRestored.onConnectionRestored();
+  }
+
   @FunctionalInterface
   public interface ItemCallback {
     void onItem(TopicMessage message);
@@ -86,5 +102,15 @@ class SendSubscribeOptions implements ISubscriptionCallbacks {
   @FunctionalInterface
   public interface ErrorCallback {
     void onError(Throwable t);
+  }
+
+  @FunctionalInterface
+  public interface ConnectionLostCallback {
+    void onConnectionLost();
+  }
+
+  @FunctionalInterface
+  public interface ConnectionRestoredCallback {
+    void onConnectionRestored();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/SubscriptionWrapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/SubscriptionWrapper.java
@@ -34,14 +34,14 @@ class SubscriptionWrapper implements AutoCloseable {
   }
 
   /**
-   * Public method for testing purposes only. Do not call this method
-   * in production code or any context other than testing the topic client.
-   * <p>
-   * This method returns a CompletableFuture that represents the asynchronous
-   * execution of the internal subscription logic with retry mechanism.
+   * Public method for testing purposes only. Do not call this method in production code or any
+   * context other than testing the topic client.
    *
-   * @return A CompletableFuture representing the asynchronous execution
-   *         of the internal subscription logic with retry mechanism.
+   * <p>This method returns a CompletableFuture that represents the asynchronous execution of the
+   * internal subscription logic with retry mechanism.
+   *
+   * @return A CompletableFuture representing the asynchronous execution of the internal
+   *     subscription logic with retry mechanism.
    */
   public CompletableFuture<Void> subscribeWithRetry() {
     CompletableFuture<Void> future = new CompletableFuture<>();

--- a/momento-sdk/src/main/java/momento/sdk/SubscriptionWrapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/SubscriptionWrapper.java
@@ -33,6 +33,16 @@ class SubscriptionWrapper implements AutoCloseable {
     this.options = options;
   }
 
+  /**
+   * Public method for testing purposes only. Do not call this method
+   * in production code or any context other than testing the topic client.
+   * <p>
+   * This method returns a CompletableFuture that represents the asynchronous
+   * execution of the internal subscription logic with retry mechanism.
+   *
+   * @return A CompletableFuture representing the asynchronous execution
+   *         of the internal subscription logic with retry mechanism.
+   */
   public CompletableFuture<Void> subscribeWithRetry() {
     CompletableFuture<Void> future = new CompletableFuture<>();
     subscribeWithRetryInternal(future);

--- a/momento-sdk/src/test/java/momento/sdk/SubscriptionWrapperTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/SubscriptionWrapperTest.java
@@ -1,0 +1,112 @@
+package momento.sdk;
+
+import grpc.cache_client.pubsub._Heartbeat;
+import grpc.cache_client.pubsub._SubscriptionItem;
+import grpc.cache_client.pubsub._SubscriptionRequest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import momento.sdk.internal.SubscriptionState;
+import momento.sdk.responses.topic.TopicSubscribeResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SubscriptionWrapperTest {
+  private final Logger logger = LoggerFactory.getLogger(SubscriptionWrapperTest.class);
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testConnectionLostAndRestored() throws InterruptedException {
+    SubscriptionState state = new SubscriptionState();
+    TopicSubscribeResponse.Subscription subscription =
+        new TopicSubscribeResponse.Subscription(state);
+
+    AtomicBoolean gotConnectionLostCallback = new AtomicBoolean(false);
+    AtomicBoolean gotConnectionRestoredCallback = new AtomicBoolean(false);
+
+    Semaphore waitingForSubscriptionAttempt = new Semaphore(0);
+
+    SendSubscribeOptions options =
+        new SendSubscribeOptions(
+            "cache",
+            "topic",
+            (message) -> {},
+            () -> {},
+            (err) -> {},
+            () -> {
+              logger.info("Got to our connection lost callback!");
+              gotConnectionLostCallback.set(true);
+            },
+            () -> {
+              logger.info("Got to our connection restored callback!");
+              gotConnectionRestoredCallback.set(true);
+            },
+            state,
+            subscription);
+
+    IScsTopicConnection connection =
+        new IScsTopicConnection() {
+          boolean isOpen = true;
+          CancelableClientCallStreamObserver<_SubscriptionItem> subscription;
+
+          @Override
+          public void close() {
+            logger.info("Connection closed");
+            isOpen = false;
+            subscription.onError(new StatusRuntimeException(Status.UNAVAILABLE));
+          }
+
+          @Override
+          public void open() {
+            logger.info("Connection opened");
+            isOpen = true;
+          }
+
+          @Override
+          public void subscribe(
+              _SubscriptionRequest subscriptionRequest,
+              CancelableClientCallStreamObserver<_SubscriptionItem> subscription) {
+            this.subscription = subscription;
+            if (isOpen) {
+              _SubscriptionItem heartbeat =
+                  _SubscriptionItem.newBuilder()
+                      .setHeartbeat(_Heartbeat.newBuilder().build())
+                      .build();
+              subscription.onNext(heartbeat);
+            } else {
+              subscription.onError(new StatusRuntimeException(Status.UNAVAILABLE));
+            }
+            waitingForSubscriptionAttempt.release();
+          }
+        };
+
+    SubscriptionWrapper subscriptionWrapper = new SubscriptionWrapper(connection, options);
+    CompletableFuture<Void> subscribeWithRetryResult = subscriptionWrapper.subscribeWithRetry();
+    subscribeWithRetryResult.join();
+
+    waitingForSubscriptionAttempt.acquire();
+
+    connection.close();
+
+    assertTrue(gotConnectionLostCallback.get());
+    assertFalse(gotConnectionRestoredCallback.get());
+
+    connection.open();
+    waitingForSubscriptionAttempt.acquire();
+
+    assertTrue(gotConnectionRestoredCallback.get());
+  }
+}

--- a/momento-sdk/src/test/java/momento/sdk/SubscriptionWrapperTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/SubscriptionWrapperTest.java
@@ -1,10 +1,16 @@
 package momento.sdk;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import grpc.cache_client.pubsub._Heartbeat;
 import grpc.cache_client.pubsub._SubscriptionItem;
 import grpc.cache_client.pubsub._SubscriptionRequest;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import momento.sdk.internal.SubscriptionState;
 import momento.sdk.responses.topic.TopicSubscribeResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,13 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SubscriptionWrapperTest {
   private final Logger logger = LoggerFactory.getLogger(SubscriptionWrapperTest.class);

--- a/momento-sdk/src/test/resources/logback.xml
+++ b/momento-sdk/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## PR Description:
-  add onConnectionLost and onConnectionRestored callback functions
- make them default so that the user is not compelled to implement the functions 

## Testing

### Manual Testing
- Run TopicExample in the examples/topics directory
- Switch off the wifi in the middle of messages being published
- Wait for the server to throw an exception (UNAVAILABLE) exception
- Switch on the wifi
- Verify logging statements in the default `onConnectionLost` and default `onConnectionRestored` are invoked

### Unit Testing
- `SubscriptionWrapperTest` in unit tests. 