### PR TITLE
feat: add support for configuring minimum num gRPC channels on CacheClient

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
@@ -32,6 +32,16 @@ public class Configuration {
   }
 
   /**
+   * Copy constructor that modifies the transport strategy.
+   *
+   * @param transportStrategy
+   * @return a new Configuration with the updated transport strategy
+   */
+  public Configuration withTransportStrategy(final TransportStrategy transportStrategy) {
+    return new Configuration(transportStrategy, this.retryStrategy);
+  }
+
+  /**
    * Configuration for retry tunables. By default, {@link momento.sdk.retry.FixedCountRetryStrategy}
    * gets used.
    *

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/GrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/GrpcConfiguration.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 public class GrpcConfiguration {
 
   private final Duration deadline;
+  private final int minNumGrpcChannels;
 
   /**
    * Constructs a GrpcConfiguration.
@@ -16,8 +17,19 @@ public class GrpcConfiguration {
    * @param deadline The maximum duration of a gRPC call.
    */
   public GrpcConfiguration(@Nonnull Duration deadline) {
+    this(deadline, 1);
+  }
+
+  /**
+   * Constructs a GrpcConfiguration.
+   *
+   * @param deadline The maximum duration of a gRPC call.
+   * @param minNumGrpcChannels The minimum number of gRPC channels to keep open at any given time.
+   */
+  public GrpcConfiguration(@Nonnull Duration deadline, int minNumGrpcChannels) {
     ensureRequestDeadlineValid(deadline);
     this.deadline = deadline;
+    this.minNumGrpcChannels = minNumGrpcChannels;
   }
 
   /**
@@ -38,5 +50,24 @@ public class GrpcConfiguration {
    */
   public GrpcConfiguration withDeadline(Duration deadline) {
     return new GrpcConfiguration(deadline);
+  }
+
+  /**
+   * The minimum number of gRPC channels to keep open at any given time.
+   *
+   * @return the minimum number of gRPC channels.
+   */
+  public int getMinNumGrpcChannels() {
+    return minNumGrpcChannels;
+  }
+
+  /**
+   * Copy constructor that updates the minimum number of gRPC channels.
+   *
+   * @param minNumGrpcChannels The new minimum number of gRPC channels.
+   * @return The updated GrpcConfiguration.
+   */
+  public GrpcConfiguration withMinNumGrpcChannels(int minNumGrpcChannels) {
+    return new GrpcConfiguration(deadline, minNumGrpcChannels);
   }
 }


### PR DESCRIPTION
Prior to this commit, each instance of the CacheClient would always
open a single gRPC channel to the server. This commit adds a configuration
setting on the GrpcConfiguration object which allows a user to configure
a minimum number of channels; this is useful for cases where callers will
be issuing more than 100 concurrent requests, since 100 is the maximum
number of requests that can be multiplexed over a single channel.
