### PR TITLE
feat: persistent store spike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: clean build test format lint precommit help
+
+## Clean the project
+clean:
+	./gradlew clean
+
+## Build the project
+build:
+	./gradlew build
+
+## Run the tests
+test:
+	./gradlew test
+
+## Format the code
+format:
+	./gradlew spotlessApply
+
+## Lint the code
+lint:
+	./gradlew spotlessCheck
+
+## Run the precommit checks
+precommit: format lint test
+
+# See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
+help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)";echo;sed -ne"/^## /{h;s/.*//;:d" -e"H;n;s/^## //;td" -e"s/:.*//;G;s/\\n## /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'|more $(shell test $(shell uname) == Darwin && echo '-Xr')

--- a/momento-sdk/src/main/java/PersistentStoreDriver.java
+++ b/momento-sdk/src/main/java/PersistentStoreDriver.java
@@ -1,0 +1,90 @@
+import momento.sdk.IPersistentStoreClient;
+import momento.sdk.PersistentStoreClient;
+import momento.sdk.exceptions.ClientSdkException;
+import momento.sdk.responses.persistent_store.control.CreatePersistentStoreResponse;
+import momento.sdk.responses.persistent_store.control.ListPersistentStoresResponse;
+import momento.sdk.responses.persistent_store.data.GetResponse;
+
+public class PersistentStoreDriver {
+  public static void main(String[] args) {
+    // Instantiating the client will be largely the same as compared to cache/topics.
+    IPersistentStoreClient client = new PersistentStoreClient();
+
+    // Create a store
+    CreatePersistentStoreResponse createResponse = client.createStore("myStore").join();
+    if (createResponse instanceof CreatePersistentStoreResponse.Success) {
+      System.out.println("Store created successfully");
+    } else {
+      // Would inspect for Already exists, etc.
+      System.out.println("Error creating store");
+    }
+
+    // List all stores
+    final ListPersistentStoresResponse listResponse = client.listStores().join();
+    if (listResponse instanceof ListPersistentStoresResponse.Success) {
+      ListPersistentStoresResponse.Success success =
+          (ListPersistentStoresResponse.Success) listResponse;
+      System.out.println("Stores:");
+      success.getStores().forEach(store -> System.out.println("- Store: " + store.getName()));
+    } else if (listResponse instanceof ListPersistentStoresResponse.Error) {
+      System.out.println(
+          "Error listing stores: "
+              + ((ListPersistentStoresResponse.Error) listResponse).getMessage());
+    } else {
+      System.out.println("Unknown response type");
+    }
+
+    // Set a value in the store
+    client.set("myStore", "myKey", "myValue").join();
+
+    // Get the value from the store
+    final GetResponse stringResponse = client.get("myStore", "string").join();
+    printGenericGetResponse(stringResponse);
+
+    final GetResponse doubleResponse = client.get("myStore", "double").join();
+    printGenericGetResponse(doubleResponse);
+
+    if (stringResponse instanceof GetResponse.Success) {
+      GetResponse.Success success = (GetResponse.Success) doubleResponse;
+      System.out.println("Value type for \"double\" was: " + success.getType());
+      System.out.println("Value: " + success.getValueAsDouble());
+
+      // Exception
+      try {
+        System.out.println("Value: " + success.getValueAsString());
+      } catch (ClientSdkException e) {
+        System.out.println("Error trying to access the value of \"double\" as a string: " + e.getMessage());
+      }
+    } else if (stringResponse instanceof GetResponse.Error) {
+      GetResponse.Error error = (GetResponse.Error) doubleResponse;
+      System.out.println("Error: " + error.getMessage());
+    } else {
+      System.out.println("Unknown response type");
+    }
+  }
+
+  /** Demos how to handle a get response with an unknown type. */
+  public static void printGenericGetResponse(GetResponse response) {
+    if (response instanceof GetResponse.Success) {
+      final GetResponse.Success success = (GetResponse.Success) response;
+      // IntelliJ has an option to enforce enum switch completeness
+      switch (success.getType()) {
+        case STRING:
+          System.out.println("Value: " + success.getValueAsString());
+          break;
+        case BYTE_ARRAY:
+          System.out.println("Value: " + new String(success.getValueAsByteArray()));
+          break;
+        case LONG:
+          System.out.println("Value: " + success.getValueAsLong());
+          break;
+        case DOUBLE:
+          System.out.println("Value: " + success.getValueAsDouble());
+          break;
+      }
+    } else if (response instanceof GetResponse.Error) {
+      final GetResponse.Error error = (GetResponse.Error) response;
+      System.out.println("Error: " + error.getMessage());
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/IPersistentStoreClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/IPersistentStoreClient.java
@@ -1,0 +1,31 @@
+package momento.sdk;
+
+import java.util.concurrent.CompletableFuture;
+import momento.sdk.responses.persistent_store.control.CreatePersistentStoreResponse;
+import momento.sdk.responses.persistent_store.control.DeletePersistentStoreResponse;
+import momento.sdk.responses.persistent_store.control.ListPersistentStoresResponse;
+import momento.sdk.responses.persistent_store.data.DeleteResponse;
+import momento.sdk.responses.persistent_store.data.GetResponse;
+import momento.sdk.responses.persistent_store.data.SetResponse;
+
+public interface IPersistentStoreClient {
+  /** Control operations */
+  CompletableFuture<CreatePersistentStoreResponse> createStore(String storeName);
+
+  CompletableFuture<DeletePersistentStoreResponse> deleteStore(String storeName);
+
+  CompletableFuture<ListPersistentStoresResponse> listStores();
+
+  /** Data operations */
+  CompletableFuture<GetResponse> get(String storeName, String key);
+
+  CompletableFuture<SetResponse> set(String storeName, String key, byte[] value);
+
+  CompletableFuture<SetResponse> set(String storeName, String key, String value);
+
+  CompletableFuture<SetResponse> set(String storeName, String key, long value);
+
+  CompletableFuture<SetResponse> set(String storeName, String key, double value);
+
+  CompletableFuture<DeleteResponse> delete(String storeName, String key);
+}

--- a/momento-sdk/src/main/java/momento/sdk/PersistentStoreClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/PersistentStoreClient.java
@@ -1,0 +1,62 @@
+package momento.sdk;
+
+import java.util.concurrent.CompletableFuture;
+import momento.sdk.exceptions.NotFoundException;
+import momento.sdk.responses.persistent_store.control.CreatePersistentStoreResponse;
+import momento.sdk.responses.persistent_store.control.DeletePersistentStoreResponse;
+import momento.sdk.responses.persistent_store.control.ListPersistentStoresResponse;
+import momento.sdk.responses.persistent_store.data.DeleteResponse;
+import momento.sdk.responses.persistent_store.data.GetResponse;
+import momento.sdk.responses.persistent_store.data.SetResponse;
+
+public class PersistentStoreClient implements IPersistentStoreClient {
+  /** Control operations */
+  public CompletableFuture<CreatePersistentStoreResponse> createStore(String storeName) {
+    return CompletableFuture.completedFuture(new CreatePersistentStoreResponse.Success());
+  }
+
+  public CompletableFuture<DeletePersistentStoreResponse> deleteStore(String storeName) {
+    return CompletableFuture.completedFuture(new DeletePersistentStoreResponse.Success());
+  }
+
+  public CompletableFuture<ListPersistentStoresResponse> listStores() {
+
+    return CompletableFuture.completedFuture(new ListPersistentStoresResponse.Success());
+  }
+
+  /** Data operations */
+  public CompletableFuture<GetResponse> get(String storeName, String key) {
+    if (key.equalsIgnoreCase("byte array")) {
+      return CompletableFuture.completedFuture(GetResponse.Success.of(new byte[0]));
+    } else if (key.equalsIgnoreCase("string")) {
+      return CompletableFuture.completedFuture(GetResponse.Success.of("string"));
+    } else if (key.equalsIgnoreCase("long")) {
+      return CompletableFuture.completedFuture(GetResponse.Success.of(42L));
+    } else if (key.equalsIgnoreCase("double")) {
+      return CompletableFuture.completedFuture(GetResponse.Success.of(3.14));
+    } else {
+      return CompletableFuture.completedFuture(
+          new GetResponse.Error(new NotFoundException(new Exception("Key not found"), null)));
+    }
+  }
+
+  public CompletableFuture<SetResponse> set(String storeName, String key, byte[] value) {
+    return CompletableFuture.completedFuture(new SetResponse.Success());
+  }
+
+  public CompletableFuture<SetResponse> set(String storeName, String key, String value) {
+    return CompletableFuture.completedFuture(new SetResponse.Success());
+  }
+
+  public CompletableFuture<SetResponse> set(String storeName, String key, long value) {
+    return CompletableFuture.completedFuture(new SetResponse.Success());
+  }
+
+  public CompletableFuture<SetResponse> set(String storeName, String key, double value) {
+    return CompletableFuture.completedFuture(new SetResponse.Success());
+  }
+
+  public CompletableFuture<DeleteResponse> delete(String storeName, String key) {
+    return CompletableFuture.completedFuture(new DeleteResponse.Success());
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/CreatePersistentStoreResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/CreatePersistentStoreResponse.java
@@ -1,0 +1,26 @@
+package momento.sdk.responses.persistent_store.control;
+
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a create persistent store operation */
+public interface CreatePersistentStoreResponse {
+  /** A successful create persistent store operation. */
+  class Success implements CreatePersistentStoreResponse {}
+
+  /**
+   * A failed create persistent store operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements CreatePersistentStoreResponse {
+
+    /**
+     * Constructs a cache creation error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/DeletePersistentStoreResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/DeletePersistentStoreResponse.java
@@ -1,0 +1,27 @@
+package momento.sdk.responses.persistent_store.control;
+
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a delete persistent store operation */
+public interface DeletePersistentStoreResponse {
+
+  /** A successful delete persistent store operation. */
+  class Success implements DeletePersistentStoreResponse {}
+
+  /**
+   * A failed delete persistent store operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements DeletePersistentStoreResponse {
+
+    /**
+     * Constructs a persistent store delete error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/ListPersistentStoresResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/ListPersistentStoresResponse.java
@@ -1,0 +1,39 @@
+package momento.sdk.responses.persistent_store.control;
+
+import java.util.Arrays;
+import java.util.List;
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a list persistent stores operation */
+public interface ListPersistentStoresResponse {
+
+  /** A successful list persistent stores operation. */
+  class Success implements ListPersistentStoresResponse {
+    private final List<StoreInfo> stores;
+
+    public Success() {
+      this.stores = Arrays.asList(new StoreInfo("myStore"), new StoreInfo("testStore"));
+    }
+
+    public List<StoreInfo> getStores() {
+      return stores;
+    }
+  }
+
+  /**
+   * A failed list persistent stores operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements ListPersistentStoresResponse {
+
+    /**
+     * Constructs a persistent store delete error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/StoreInfo.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/control/StoreInfo.java
@@ -1,0 +1,13 @@
+package momento.sdk.responses.persistent_store.control;
+
+public class StoreInfo {
+  private final String name;
+
+  public StoreInfo(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/DeleteResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/DeleteResponse.java
@@ -1,0 +1,27 @@
+package momento.sdk.responses.persistent_store.data;
+
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a delete operation */
+public interface DeleteResponse {
+
+  /** A successful delete operation. */
+  class Success implements DeleteResponse {}
+
+  /**
+   * A failed delete operation. The response itself is an exception, so it can be directly thrown,
+   * or the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of
+   * the message of the cause.
+   */
+  class Error extends SdkException implements DeleteResponse {
+
+    /**
+     * Constructs a persistent store delete error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/GetResponse.java
@@ -1,0 +1,85 @@
+package momento.sdk.responses.persistent_store.data;
+
+import momento.sdk.exceptions.ClientSdkException;
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a get operation */
+public interface GetResponse {
+
+  /** A successful get operation. */
+  class Success implements GetResponse {
+    private final Object value;
+    private final ValueType valueType;
+
+    private Success(Object value, ValueType valueType) {
+      this.value = value;
+      this.valueType = valueType;
+    }
+
+    public static Success of(byte[] value) {
+      return new Success(value, ValueType.BYTE_ARRAY);
+    }
+
+    public static Success of(String value) {
+      return new Success(value, ValueType.STRING);
+    }
+
+    public static Success of(long value) {
+      return new Success(value, ValueType.LONG);
+    }
+
+    public static Success of(double value) {
+      return new Success(value, ValueType.DOUBLE);
+    }
+
+    public ValueType getType() {
+      return valueType;
+    }
+
+    public byte[] getValueAsByteArray() {
+      ensureCorrectTypeOrThrowException(ValueType.BYTE_ARRAY, valueType);
+      return (byte[]) value;
+    }
+
+    public String getValueAsString() {
+      ensureCorrectTypeOrThrowException(ValueType.STRING, valueType);
+      return (String) value;
+    }
+
+    public long getValueAsLong() {
+      ensureCorrectTypeOrThrowException(ValueType.LONG, valueType);
+      return (long) value;
+    }
+
+    public double getValueAsDouble() {
+      ensureCorrectTypeOrThrowException(ValueType.DOUBLE, valueType);
+      return (double) value;
+    }
+
+    private void ensureCorrectTypeOrThrowException(ValueType requested, ValueType actual) {
+      if (requested != actual) {
+        // In a regular Java context, ClassCastException or IllegalStateException could be appropriate here
+        throw new ClientSdkException(
+            String.format(
+                "Value is not a %s but was: %s".format(requested.toString(), actual.toString())));
+      }
+    }
+  }
+
+  /**
+   * A failed get operation. The response itself is an exception, so it can be directly thrown, or
+   * the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of the
+   * message of the cause.
+   */
+  class Error extends SdkException implements GetResponse {
+
+    /**
+     * Constructs a persistent store get error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/SetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/SetResponse.java
@@ -1,0 +1,27 @@
+package momento.sdk.responses.persistent_store.data;
+
+import momento.sdk.exceptions.SdkException;
+
+/** Response for a set operation */
+public interface SetResponse {
+
+  /** A successful set operation. */
+  class Success implements SetResponse {}
+
+  /**
+   * A failed set operation. The response itself is an exception, so it can be directly thrown, or
+   * the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of the
+   * message of the cause.
+   */
+  class Error extends SdkException implements SetResponse {
+
+    /**
+     * Constructs a persistent store set error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/ValueType.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/persistent_store/data/ValueType.java
@@ -1,0 +1,8 @@
+package momento.sdk.responses.persistent_store.data;
+
+public enum ValueType {
+  BYTE_ARRAY,
+  STRING,
+  LONG,
+  DOUBLE
+}


### PR DESCRIPTION
Adds a POC Persistent Store client, complete with client interface,
client, driver program, and response types.

The design focus is around the get request and set response. Since the
persistent store allows users to store and retrieve data of various
types, we must handle those cases carefully.

To store data, we overload the `set` method. There is a `set` overload
for each of the supported value types.

To retrieve data, we have a single `GetResponse` class. This class
stores the value as an object and the type as reported from the server
as an enumerated field. Users can inspect the type of the value by
calling the accessor `getType` and then calling the corresponding
value accessor for strongly typed access (`getValueAsString`,
`getValueAsByteArray`, ...).

In the event a user calls the wrong method for the underlying type, we
throw an exception.

We add a driver program to demonstrate usage in
`PersistentStoreDriver`. This shows how to exhaustively check a get
response when the underlying type is unknown. We also show what to do
when the type is expected.
