### PR TITLE
refactor: introduce `Store(Item)?NotFoundException` classes

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
@@ -11,7 +11,7 @@ import momento.sdk.config.StorageConfigurations;
 import momento.sdk.exceptions.AuthenticationException;
 import momento.sdk.exceptions.BadRequestException;
 import momento.sdk.exceptions.InvalidArgumentException;
-import momento.sdk.exceptions.NotFoundException;
+import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.responses.storage.CreateStoreResponse;
 import momento.sdk.responses.storage.DeleteStoreResponse;
 import momento.sdk.responses.storage.ListStoresResponse;
@@ -57,7 +57,7 @@ public class ControlTests extends BaseTestClass {
     assertThat(client.deleteStore(randomString("name")))
         .succeedsWithin(TEN_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DeleteStoreResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(StoreNotFoundException.class));
   }
 
   @Test
@@ -125,7 +125,7 @@ public class ControlTests extends BaseTestClass {
       assertThat(client.deleteStore(storeName))
           .succeedsWithin(TEN_SECONDS)
           .asInstanceOf(InstanceOfAssertFactories.type(DeleteStoreResponse.Error.class))
-          .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+          .satisfies(error -> assertThat(error).hasCauseInstanceOf(StoreNotFoundException.class));
     } finally {
       // Just in case the second create or delete fails
       client.deleteStore(storeName).join();

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
@@ -44,7 +44,6 @@ final class StorageControlClient extends ScsClientBase {
       return sendCreateStore(storeName);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
-          // TODO need to generalize exception mapper
           new CreateStoreResponse.Error(CacheServiceExceptionMapper.convert(e)));
     }
   }

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
@@ -9,7 +9,6 @@ import grpc.control_client._DeleteStoreRequest;
 import grpc.control_client._DeleteStoreResponse;
 import grpc.control_client._ListStoresRequest;
 import grpc.control_client._ListStoresResponse;
-import io.grpc.Status;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -17,7 +16,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.StorageConfiguration;
+import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
+import momento.sdk.exceptions.SdkException;
 import momento.sdk.responses.storage.CreateStoreResponse;
 import momento.sdk.responses.storage.DeleteStoreResponse;
 import momento.sdk.responses.storage.ListStoresResponse;
@@ -80,12 +81,9 @@ final class StorageControlClient extends ScsClientBase {
 
     final Function<Throwable, CreateStoreResponse> failure =
         e -> {
-          if (e instanceof io.grpc.StatusRuntimeException) {
-            io.grpc.StatusRuntimeException statusRuntimeException =
-                (io.grpc.StatusRuntimeException) e;
-            if (statusRuntimeException.getStatus().getCode() == Status.Code.ALREADY_EXISTS) {
-              return new CreateStoreResponse.AlreadyExists();
-            }
+          final SdkException sdkException = CacheServiceExceptionMapper.convert(e);
+          if (sdkException instanceof AlreadyExistsException) {
+            return new CreateStoreResponse.AlreadyExists();
           }
           return new CreateStoreResponse.Error(CacheServiceExceptionMapper.convert(e));
         };

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
@@ -161,8 +161,7 @@ final class StorageDataClient extends StorageClientBase {
             if (sdkException instanceof momento.sdk.exceptions.StoreItemNotFoundException) {
               returnFuture.complete(GetResponse.Success.of());
             } else {
-              returnFuture.complete(
-                  new GetResponse.Error(CacheServiceExceptionMapper.convert(e, metadata)));
+              returnFuture.complete(new GetResponse.Error(CacheServiceExceptionMapper.convert(e)));
             }
           }
         },
@@ -204,8 +203,7 @@ final class StorageDataClient extends StorageClientBase {
 
           @Override
           public void onFailure(@Nonnull Throwable e) {
-            returnFuture.complete(
-                new PutResponse.Error(CacheServiceExceptionMapper.convert(e, new Metadata())));
+            returnFuture.complete(new PutResponse.Error(CacheServiceExceptionMapper.convert(e)));
           }
         },
         // Execute on same thread that called execute on CompletionStage
@@ -245,8 +243,7 @@ final class StorageDataClient extends StorageClientBase {
 
           @Override
           public void onFailure(@Nonnull Throwable e) {
-            returnFuture.complete(
-                new DeleteResponse.Error(CacheServiceExceptionMapper.convert(e, metadata)));
+            returnFuture.complete(new DeleteResponse.Error(CacheServiceExceptionMapper.convert(e)));
           }
         },
         // Execute on same thread that called execute on CompletionStage

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
@@ -160,10 +160,10 @@ final class StorageDataClient extends StorageClientBase {
             final SdkException sdkException = CacheServiceExceptionMapper.convert(e, metadata);
             if (sdkException instanceof momento.sdk.exceptions.StoreItemNotFoundException) {
               returnFuture.complete(GetResponse.Success.of());
-              return;
+            } else {
+              returnFuture.complete(
+                  new GetResponse.Error(CacheServiceExceptionMapper.convert(e, metadata)));
             }
-            returnFuture.complete(
-                new GetResponse.Error(CacheServiceExceptionMapper.convert(e, metadata)));
           }
         },
         // Execute on same thread that called execute on CompletionStage

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -49,6 +49,8 @@ public final class CacheServiceExceptionMapper {
           new MomentoTransportErrorDetails(
               new MomentoGrpcErrorDetails(statusCode, grpcException.getMessage(), metadata));
 
+      final String errorCause = grpcException.getMessage();
+
       switch (statusCode) {
         case INVALID_ARGUMENT:
           // fall through
@@ -75,8 +77,13 @@ public final class CacheServiceExceptionMapper {
           return new LimitExceededException(grpcException, errorDetails);
 
         case NOT_FOUND:
-          return new NotFoundException(grpcException, errorDetails);
-
+          if (errorCause.contains("Element not found")) {
+            return new StoreItemNotFoundException(grpcException, errorDetails);
+          } else if (errorCause.contains("Store with name")) {
+            return new StoreNotFoundException(grpcException, errorDetails);
+          } else {
+            return new NotFoundException(grpcException, errorDetails);
+          }
         case ALREADY_EXISTS:
           return new AlreadyExistsException(grpcException, errorDetails);
 

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/StoreItemNotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/StoreItemNotFoundException.java
@@ -1,0 +1,34 @@
+package momento.sdk.exceptions;
+
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
+/** The item requested from the store doesn't exist. */
+public class StoreItemNotFoundException extends SdkException {
+
+  private static final String MESSAGE =
+      "The item requested from the store does not exist. To resolve this error, "
+          + "if the requested item was expected to be found, put it in the store.";
+
+  /**
+   * Constructs a StoreItemNotFound with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public StoreItemNotFoundException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(
+        MomentoErrorCode.NOT_FOUND_ERROR,
+        completeMessage(transportErrorDetails),
+        cause,
+        transportErrorDetails);
+  }
+
+  private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
+    return transportErrorDetails
+        .getGrpcErrorDetails()
+        .getCacheName()
+        .map(s -> MESSAGE + " Store name: " + s)
+        .orElse(MESSAGE);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/StoreNotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/StoreNotFoundException.java
@@ -1,0 +1,34 @@
+package momento.sdk.exceptions;
+
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
+/** The store requested doesn't exist. */
+public class StoreNotFoundException extends MomentoServiceException {
+
+  private static final String MESSAGE =
+      "A store with the specified name does not exist. To resolve this error, "
+          + "make sure you have created the store before attempting to use it.";
+
+  /**
+   * Constructs a StoreNotFoundException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public StoreNotFoundException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(
+        MomentoErrorCode.NOT_FOUND_ERROR,
+        completeMessage(transportErrorDetails),
+        cause,
+        transportErrorDetails);
+  }
+
+  private static String completeMessage(MomentoTransportErrorDetails transportErrorDetails) {
+    return transportErrorDetails
+        .getGrpcErrorDetails()
+        .getCacheName()
+        .map(s -> MESSAGE + " Store name: " + s)
+        .orElse(MESSAGE);
+  }
+}


### PR DESCRIPTION
This PR detects when a `NOT_FOUND` gRPC error was specific to the
storage client or not. For the storage client `NOT_FOUND`, there are
two cases: the store was not found and the item was not found.

To distinguish these two cases we use string matching on the
grpcException message.
