### PR TITLE
refactor: specialize not-found and already-exists exceptions

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
@@ -14,8 +14,8 @@ import momento.sdk.auth.CredentialProvider;
 import momento.sdk.auth.StringCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AuthenticationException;
+import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.exceptions.InvalidArgumentException;
-import momento.sdk.exceptions.NotFoundException;
 import momento.sdk.exceptions.ServerUnavailableException;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetBatchResponse;
@@ -148,7 +148,7 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(target.flushCache(randomString("name")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheFlushResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -643,7 +643,7 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(target.getBatch(randomString("cache"), items))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(GetBatchResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -662,7 +662,7 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(target.setBatch(randomString("cache"), items))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetBatchResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -702,6 +702,6 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(target.setBatchStringBytes(randomString("cache"), items))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetBatchResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -7,9 +7,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import java.time.Duration;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configurations;
-import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.exceptions.AuthenticationException;
 import momento.sdk.exceptions.BadRequestException;
+import momento.sdk.exceptions.CacheAlreadyExistsException;
 import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.responses.cache.control.CacheCreateResponse;
@@ -74,7 +74,8 @@ final class CacheControlPlaneTest extends BaseTestClass {
     assertThat(target.createCache(existingCache))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(AlreadyExistsException.class));
+        .satisfies(
+            error -> assertThat(error).hasCauseInstanceOf(CacheAlreadyExistsException.class));
   }
 
   @Test
@@ -140,7 +141,8 @@ final class CacheControlPlaneTest extends BaseTestClass {
     assertThat(target.createCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(AlreadyExistsException.class));
+        .satisfies(
+            error -> assertThat(error).hasCauseInstanceOf(CacheAlreadyExistsException.class));
 
     assertThat(target.deleteCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -10,8 +10,8 @@ import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.exceptions.AuthenticationException;
 import momento.sdk.exceptions.BadRequestException;
+import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.exceptions.InvalidArgumentException;
-import momento.sdk.exceptions.NotFoundException;
 import momento.sdk.responses.cache.control.CacheCreateResponse;
 import momento.sdk.responses.cache.control.CacheDeleteResponse;
 import momento.sdk.responses.cache.control.CacheListResponse;
@@ -82,7 +82,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
     assertThat(target.deleteCache(randomString("name")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDeleteResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -149,7 +149,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
     assertThat(target.deleteCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDeleteResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
@@ -8,7 +8,7 @@ import momento.sdk.auth.CredentialProvider;
 import momento.sdk.auth.StringCredentialProvider;
 import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.AuthenticationException;
-import momento.sdk.exceptions.NotFoundException;
+import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.exceptions.TimeoutException;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetResponse;
@@ -101,11 +101,11 @@ final class CacheDataPlaneTest extends BaseTestClass {
 
     final GetResponse getResponse = client.get(cacheName, "").join();
     assertThat(getResponse).isInstanceOf(GetResponse.Error.class);
-    assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(NotFoundException.class);
+    assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(CacheNotFoundException.class);
 
     final SetResponse setResponse = client.set(cacheName, "", "", Duration.ofSeconds(10)).join();
     assertThat(setResponse).isInstanceOf(SetResponse.Error.class);
-    assertThat(((SetResponse.Error) setResponse)).hasCauseInstanceOf(NotFoundException.class);
+    assertThat(((SetResponse.Error) setResponse)).hasCauseInstanceOf(CacheNotFoundException.class);
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import momento.sdk.config.Configurations;
+import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.exceptions.InvalidArgumentException;
-import momento.sdk.exceptions.NotFoundException;
 import momento.sdk.requests.CollectionTtl;
 import momento.sdk.responses.SortOrder;
 import momento.sdk.responses.cache.sortedset.ScoredElement;
@@ -166,14 +166,14 @@ public class SortedSetTest extends BaseTestClass {
     assertThat(client.sortedSetPutElement(randomString("cache"), sortedSetName, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetPutElement(
                 randomString("cache"), sortedSetName, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -279,7 +279,7 @@ public class SortedSetTest extends BaseTestClass {
                 randomString("cache"), sortedSetName, Collections.singletonMap("element", 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetPutElementsByteArray(
@@ -288,7 +288,7 @@ public class SortedSetTest extends BaseTestClass {
                 Collections.singletonMap("element".getBytes(), 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -434,7 +434,7 @@ public class SortedSetTest extends BaseTestClass {
     assertThat(client.sortedSetFetchByRank(randomString("cache"), sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -558,7 +558,7 @@ public class SortedSetTest extends BaseTestClass {
                 randomString("cache"), sortedSetName, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -627,14 +627,14 @@ public class SortedSetTest extends BaseTestClass {
                 randomString("cache"), sortedSetName, "element", SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetGetRank(
                 randomString("cache"), sortedSetName, "element".getBytes(), SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -743,12 +743,12 @@ public class SortedSetTest extends BaseTestClass {
     assertThat(client.sortedSetGetScore(randomString("cache"), sortedSetName, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(client.sortedSetGetScore(randomString("cache"), sortedSetName, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -848,14 +848,14 @@ public class SortedSetTest extends BaseTestClass {
                 randomString("cache"), sortedSetName, Collections.singleton("element")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetGetScoresByteArray(
                 randomString("cache"), sortedSetName, Collections.singleton("element".getBytes())))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -986,14 +986,14 @@ public class SortedSetTest extends BaseTestClass {
     assertThat(client.sortedSetIncrementScore(randomString("cache"), sortedSetName, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetIncrementScore(
                 randomString("cache"), sortedSetName, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -1106,14 +1106,14 @@ public class SortedSetTest extends BaseTestClass {
     assertThat(client.sortedSetRemoveElement(randomString("cache"), sortedSetName, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetRemoveElement(
                 randomString("cache"), sortedSetName, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test
@@ -1226,14 +1226,14 @@ public class SortedSetTest extends BaseTestClass {
                 randomString("cache"), sortedSetName, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
             client.sortedSetRemoveElementsByteArray(
                 randomString("cache"), sortedSetName, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(NotFoundException.class));
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -7,7 +7,7 @@ import momento.sdk.BaseTestClass;
 import momento.sdk.PreviewStorageClient;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.StorageConfigurations;
-import momento.sdk.exceptions.NotFoundException;
+import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.responses.storage.DeleteResponse;
 import momento.sdk.responses.storage.GetResponse;
 import momento.sdk.responses.storage.PutResponse;
@@ -112,11 +112,11 @@ public class DataTests extends BaseTestClass {
 
     final GetResponse getResponse = client.get(storeName, "").join();
     assertThat(getResponse).isInstanceOf(GetResponse.Error.class);
-    assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(NotFoundException.class);
+    assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(CacheNotFoundException.class);
 
     final PutResponse putResponse = client.put(storeName, "", "").join();
     assertThat(putResponse).isInstanceOf(PutResponse.Error.class);
-    assertThat(((PutResponse.Error) putResponse)).hasCauseInstanceOf(NotFoundException.class);
+    assertThat(((PutResponse.Error) putResponse)).hasCauseInstanceOf(CacheNotFoundException.class);
   }
 
   @Test

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.StorageConfiguration;
-import momento.sdk.exceptions.AlreadyExistsException;
+import momento.sdk.exceptions.CacheAlreadyExistsException;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.responses.storage.CreateStoreResponse;
@@ -81,7 +81,7 @@ final class StorageControlClient extends ScsClientBase {
     final Function<Throwable, CreateStoreResponse> failure =
         e -> {
           final SdkException sdkException = CacheServiceExceptionMapper.convert(e);
-          if (sdkException instanceof AlreadyExistsException) {
+          if (sdkException instanceof CacheAlreadyExistsException) {
             return new CreateStoreResponse.AlreadyExists();
           }
           return new CreateStoreResponse.Error(CacheServiceExceptionMapper.convert(e));

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
@@ -16,9 +16,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.StorageConfiguration;
-import momento.sdk.exceptions.CacheAlreadyExistsException;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.exceptions.StoreAlreadyExistsException;
 import momento.sdk.responses.storage.CreateStoreResponse;
 import momento.sdk.responses.storage.DeleteStoreResponse;
 import momento.sdk.responses.storage.ListStoresResponse;
@@ -81,7 +81,7 @@ final class StorageControlClient extends ScsClientBase {
     final Function<Throwable, CreateStoreResponse> failure =
         e -> {
           final SdkException sdkException = CacheServiceExceptionMapper.convert(e);
-          if (sdkException instanceof CacheAlreadyExistsException) {
+          if (sdkException instanceof StoreAlreadyExistsException) {
             return new CreateStoreResponse.AlreadyExists();
           }
           return new CreateStoreResponse.Error(CacheServiceExceptionMapper.convert(e));

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/AlreadyExistsException.java
@@ -1,0 +1,19 @@
+package momento.sdk.exceptions;
+
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
+/** A resource already exists. */
+@Deprecated // Use CacheAlreadyExistsException instead
+public class AlreadyExistsException extends CacheAlreadyExistsException {
+
+  /**
+   * Constructs an AlreadyExistsException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public AlreadyExistsException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(cause, transportErrorDetails);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheAlreadyExistsException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheAlreadyExistsException.java
@@ -3,7 +3,7 @@ package momento.sdk.exceptions;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** A resource already exists. */
-public class AlreadyExistsException extends MomentoServiceException {
+public class CacheAlreadyExistsException extends MomentoServiceException {
 
   private static final String MESSAGE =
       "A cache with the specified name already exists. To resolve this error, "
@@ -15,7 +15,7 @@ public class AlreadyExistsException extends MomentoServiceException {
    * @param cause the cause.
    * @param transportErrorDetails details about the request and error.
    */
-  public AlreadyExistsException(
+  public CacheAlreadyExistsException(
       Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
     super(
         MomentoErrorCode.ALREADY_EXISTS_ERROR,

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheNotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheNotFoundException.java
@@ -3,7 +3,7 @@ package momento.sdk.exceptions;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Requested resource or the resource on which an operation was requested doesn't exist. */
-public class NotFoundException extends MomentoServiceException {
+public class CacheNotFoundException extends MomentoServiceException {
 
   private static final String MESSAGE =
       "A cache with the specified name does not exist. To resolve this error, "
@@ -15,7 +15,8 @@ public class NotFoundException extends MomentoServiceException {
    * @param cause the cause.
    * @param transportErrorDetails details about the request and error.
    */
-  public NotFoundException(Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+  public CacheNotFoundException(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
     super(
         MomentoErrorCode.NOT_FOUND_ERROR,
         completeMessage(transportErrorDetails),

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -91,7 +91,7 @@ public final class CacheServiceExceptionMapper {
             return new CacheNotFoundException(grpcException, errorDetails);
           }
         case ALREADY_EXISTS:
-          return new AlreadyExistsException(grpcException, errorDetails);
+          return new CacheAlreadyExistsException(grpcException, errorDetails);
 
         case UNKNOWN:
           return new UnknownServiceException(grpcException, errorDetails);

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -91,8 +91,11 @@ public final class CacheServiceExceptionMapper {
             return new CacheNotFoundException(grpcException, errorDetails);
           }
         case ALREADY_EXISTS:
-          return new CacheAlreadyExistsException(grpcException, errorDetails);
-
+          if (errorCause.contains("Store with name")) {
+            return new StoreAlreadyExistsException(grpcException, errorDetails);
+          } else {
+            return new CacheAlreadyExistsException(grpcException, errorDetails);
+          }
         case UNKNOWN:
           return new UnknownServiceException(grpcException, errorDetails);
 

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -88,7 +88,7 @@ public final class CacheServiceExceptionMapper {
           } else if (errorCause.contains("Store with name")) {
             return new StoreNotFoundException(grpcException, errorDetails);
           } else {
-            return new NotFoundException(grpcException, errorDetails);
+            return new CacheNotFoundException(grpcException, errorDetails);
           }
         case ALREADY_EXISTS:
           return new AlreadyExistsException(grpcException, errorDetails);

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/NotFoundException.java
@@ -1,0 +1,18 @@
+package momento.sdk.exceptions;
+
+import momento.sdk.internal.MomentoTransportErrorDetails;
+
+/** Requested resource or the resource on which an operation was requested doesn't exist. */
+@Deprecated // Use CacheNotFoundException instead
+public class NotFoundException extends CacheNotFoundException {
+
+  /**
+   * Constructs a NotFoundException with a cause and error details.
+   *
+   * @param cause the cause.
+   * @param transportErrorDetails details about the request and error.
+   */
+  public NotFoundException(Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
+    super(cause, transportErrorDetails);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/StoreAlreadyExistsException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/StoreAlreadyExistsException.java
@@ -3,19 +3,19 @@ package momento.sdk.exceptions;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** A resource already exists. */
-public class CacheAlreadyExistsException extends MomentoServiceException {
+public class StoreAlreadyExistsException extends MomentoServiceException {
 
   private static final String MESSAGE =
-      "A cache with the specified name already exists. To resolve this error, "
-          + "either delete the existing cache and make a new one, or use a different name.";
+      "A store with the specified name already exists. To resolve this error, "
+          + "either delete the existing store and make a new one, or use a different name.";
 
   /**
-   * Constructs a CacheAlreadyExistsException with a cause and error details.
+   * Constructs an StoreAlreadyExistsException with a cause and error details.
    *
    * @param cause the cause.
    * @param transportErrorDetails details about the request and error.
    */
-  public CacheAlreadyExistsException(
+  public StoreAlreadyExistsException(
       Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
     super(
         MomentoErrorCode.ALREADY_EXISTS_ERROR,

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -1,7 +1,7 @@
 package momento.sdk.responses.storage;
 
 import io.grpc.Status;
-import momento.sdk.exceptions.CacheNotFoundException;
+import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.internal.MomentoGrpcErrorDetails;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ public class GetResponseTest {
     // TODO distinguish store not found from key not found
     GetResponse.Error error =
         new GetResponse.Error(
-            new CacheNotFoundException(
+            new StoreNotFoundException(
                 new Exception(),
                 new MomentoTransportErrorDetails(
                     new MomentoGrpcErrorDetails(Status.Code.NOT_FOUND, "not found"))));

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -1,7 +1,7 @@
 package momento.sdk.responses.storage;
 
 import io.grpc.Status;
-import momento.sdk.exceptions.NotFoundException;
+import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.internal.MomentoGrpcErrorDetails;
 import momento.sdk.internal.MomentoTransportErrorDetails;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ public class GetResponseTest {
     // TODO distinguish store not found from key not found
     GetResponse.Error error =
         new GetResponse.Error(
-            new NotFoundException(
+            new CacheNotFoundException(
                 new Exception(),
                 new MomentoTransportErrorDetails(
                     new MomentoGrpcErrorDetails(Status.Code.NOT_FOUND, "not found"))));


### PR DESCRIPTION
Refactors `NotFoundException` and `AlreadyExistsException` to cache- and storage-specific exceptions.