### PR TITLE
chore: add to string implementations to relevant storage responses

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -78,6 +78,11 @@ public interface GetResponse {
     public Optional<Success> success() {
       return Optional.of(this);
     }
+
+    @Override
+    public String toString() {
+      return super.toString() + ": value: " + value;
+    }
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/ListStoresResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/ListStoresResponse.java
@@ -17,6 +17,11 @@ public interface ListStoresResponse {
     public List<StoreInfo> getStores() {
       return stores;
     }
+
+    @Override
+    public String toString() {
+      return super.toString() + ": stores: " + stores;
+    }
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
@@ -1,6 +1,7 @@
 package momento.sdk.responses.storage;
 
 import java.util.Optional;
+import momento.sdk.internal.StringHelpers;
 
 /**
  * A value stored in the storage.
@@ -98,5 +99,14 @@ public class StorageValue {
       return Optional.empty();
     }
     return Optional.of((double) value);
+  }
+
+  @Override
+  public String toString() {
+    return super.toString()
+        + ": value: "
+        + StringHelpers.truncate(value.toString())
+        + ", itemType:"
+        + itemType;
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StoreInfo.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StoreInfo.java
@@ -16,4 +16,9 @@ public class StoreInfo {
   public String getName() {
     return name;
   }
+
+  @Override
+  public String toString() {
+    return super.toString() + ": name: " + name;
+  }
 }


### PR DESCRIPTION
`GetResponse` and `ListStoresResponse` should have meaningful to
string implementations. This PR adds them.
