### PR TITLE
refactor: make storage to string more human friendly

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
@@ -76,6 +76,9 @@ public class ControlTests extends BaseTestClass {
               success ->
                   assertThat(success.getStores())
                       .anyMatch(storeInfo -> storeInfo.getName().equals(storeName)));
+
+      final ListStoresResponse response = client.listStores().join();
+      assertThat(response).isInstanceOf(ListStoresResponse.Success.class);
     } finally {
       // cleanup
       assertThat(client.deleteStore(storeName))

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
@@ -113,4 +113,18 @@ public class SdkException extends RuntimeException {
   public Optional<MomentoTransportErrorDetails> getTransportErrorDetails() {
     return Optional.ofNullable(transportErrorDetails);
   }
+
+  protected String toStringTemplate(String className) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(className).append("{");
+    sb.append("message=\"").append(getMessage()).append("\"");
+    sb.append(", errorCode=").append(errorCode);
+    if (transportErrorDetails != null) {
+      sb.append(", transportErrorDetails=").append(transportErrorDetails);
+    } else {
+      sb.append(", transportErrorDetails=null");
+    }
+    sb.append("}");
+    return sb.toString();
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/SdkException.java
@@ -114,7 +114,7 @@ public class SdkException extends RuntimeException {
     return Optional.ofNullable(transportErrorDetails);
   }
 
-  protected String toStringTemplate(String className) {
+  protected String buildToString(String className) {
     StringBuilder sb = new StringBuilder();
     sb.append(className).append("{");
     sb.append("message=\"").append(getMessage()).append("\"");

--- a/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/MomentoGrpcErrorDetails.java
@@ -71,4 +71,15 @@ public class MomentoGrpcErrorDetails {
     return Optional.ofNullable(metadata)
         .map(m -> m.get(Metadata.Key.of("cache", ASCII_STRING_MARSHALLER)));
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("MomentoGrpcErrorDetails{");
+    sb.append("statusCode=").append(statusCode);
+    sb.append(", details=\"").append(details).append('\"');
+    sb.append(", metadata=").append(metadata);
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/internal/MomentoTransportErrorDetails.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/MomentoTransportErrorDetails.java
@@ -22,4 +22,9 @@ public class MomentoTransportErrorDetails {
   public MomentoGrpcErrorDetails getGrpcErrorDetails() {
     return grpcErrorDetails;
   }
+
+  @Override
+  public String toString() {
+    return "MomentoTransportErrorDetails{" + "grpcErrorDetails=" + grpcErrorDetails + '}';
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/internal/StringHelpers.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/StringHelpers.java
@@ -31,4 +31,8 @@ public class StringHelpers {
 
     return input.substring(0, maxLength) + "...";
   }
+
+  public static String emptyToString(String className) {
+    return className + "{}";
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/CreateStoreResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/CreateStoreResponse.java
@@ -39,7 +39,7 @@ public interface CreateStoreResponse {
 
     @Override
     public String toString() {
-      return toStringTemplate("CreateStoreResponse.Error");
+      return buildToString("CreateStoreResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/CreateStoreResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/CreateStoreResponse.java
@@ -1,14 +1,25 @@
 package momento.sdk.responses.storage;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
 
 /** Response for a create store operation */
 public interface CreateStoreResponse {
   /** A successful create store operation. */
-  class Success implements CreateStoreResponse {}
+  class Success implements CreateStoreResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("CreateStoreResponse.Success");
+    }
+  }
 
   /** Indicates that the store already exists, so there was no need to create it. */
-  class AlreadyExists implements CreateStoreResponse {}
+  class AlreadyExists implements CreateStoreResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("CreateStoreResponse.AlreadyExists");
+    }
+  }
 
   /**
    * A failed create store operation. The response itself is an exception, so it can be directly
@@ -24,6 +35,11 @@ public interface CreateStoreResponse {
      */
     public Error(SdkException cause) {
       super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return toStringTemplate("CreateStoreResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteResponse.java
@@ -1,12 +1,18 @@
 package momento.sdk.responses.storage;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
 
 /** Response for a delete operation */
 public interface DeleteResponse {
 
   /** A successful delete operation. */
-  class Success implements DeleteResponse {}
+  class Success implements DeleteResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("DeleteResponse.Success");
+    }
+  }
 
   /**
    * A failed delete operation. The response itself is an exception, so it can be directly thrown,
@@ -22,6 +28,11 @@ public interface DeleteResponse {
      */
     public Error(SdkException cause) {
       super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return toStringTemplate("DeleteResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteResponse.java
@@ -32,7 +32,7 @@ public interface DeleteResponse {
 
     @Override
     public String toString() {
-      return toStringTemplate("DeleteResponse.Error");
+      return buildToString("DeleteResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteStoreResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteStoreResponse.java
@@ -1,12 +1,18 @@
 package momento.sdk.responses.storage;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
 
 /** Response for a delete store operation */
 public interface DeleteStoreResponse {
 
   /** A successful delete store operation. */
-  class Success implements DeleteStoreResponse {}
+  class Success implements DeleteStoreResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("DeleteStoreResponse.Success");
+    }
+  }
 
   /**
    * A failed delete store operation. The response itself is an exception, so it can be directly
@@ -22,6 +28,11 @@ public interface DeleteStoreResponse {
      */
     public Error(SdkException cause) {
       super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return toStringTemplate("DeleteStoreResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteStoreResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/DeleteStoreResponse.java
@@ -32,7 +32,7 @@ public interface DeleteStoreResponse {
 
     @Override
     public String toString() {
-      return toStringTemplate("DeleteStoreResponse.Error");
+      return buildToString("DeleteStoreResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -108,7 +108,7 @@ public interface GetResponse {
 
     @Override
     public String toString() {
-      return toStringTemplate("GetResponse.Error");
+      return buildToString("GetResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -78,6 +78,11 @@ public interface GetResponse {
     public Optional<Success> success() {
       return Optional.of(this);
     }
+
+    @Override
+    public String toString() {
+      return "GetResponse.Success{value=" + value + "}";
+    }
   }
 
   /**
@@ -99,6 +104,11 @@ public interface GetResponse {
     @Override
     public Optional<Success> success() {
       return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+      return toStringTemplate("GetResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/ListStoresResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/ListStoresResponse.java
@@ -48,7 +48,7 @@ public interface ListStoresResponse {
 
     @Override
     public String toString() {
-      return toStringTemplate("ListStoresResponse.Error");
+      return buildToString("ListStoresResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/ListStoresResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/ListStoresResponse.java
@@ -17,6 +17,17 @@ public interface ListStoresResponse {
     public List<StoreInfo> getStores() {
       return stores;
     }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("ListStoresResponse.Success{");
+      sb.append("stores=[");
+      sb.append(String.join(", ", stores.stream().map(StoreInfo::toString).toArray(String[]::new)));
+      sb.append("]");
+      sb.append("}");
+      return sb.toString();
+    }
   }
 
   /**
@@ -33,6 +44,11 @@ public interface ListStoresResponse {
      */
     public Error(SdkException cause) {
       super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return toStringTemplate("ListStoresResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/PutResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/PutResponse.java
@@ -32,7 +32,7 @@ public interface PutResponse {
 
     @Override
     public String toString() {
-      return toStringTemplate("PutResponse.Error");
+      return buildToString("PutResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/PutResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/PutResponse.java
@@ -1,12 +1,18 @@
 package momento.sdk.responses.storage;
 
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
 
 /** Response for a set operation */
 public interface PutResponse {
 
   /** A successful set operation. */
-  class Success implements PutResponse {}
+  class Success implements PutResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("PutResponse.Success");
+    }
+  }
 
   /**
    * A failed set operation. The response itself is an exception, so it can be directly thrown, or
@@ -22,6 +28,11 @@ public interface PutResponse {
      */
     public Error(SdkException cause) {
       super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return toStringTemplate("PutResponse.Error");
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
@@ -99,4 +99,22 @@ public class StorageValue {
     }
     return Optional.of((double) value);
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("StorageValue{");
+    sb.append("value=");
+    if (itemType == StorageItemType.STRING) {
+      sb.append('"');
+      sb.append(value);
+      sb.append('"');
+    } else {
+      sb.append(value);
+    }
+    sb.append(", itemType=");
+    sb.append(itemType);
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StoreInfo.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StoreInfo.java
@@ -16,4 +16,9 @@ public class StoreInfo {
   public String getName() {
     return name;
   }
+
+  @Override
+  public String toString() {
+    return "StoreInfo{" + "name=\"" + name + "\"}";
+  }
 }


### PR DESCRIPTION
# Overview
Refactors the `toString` implementations to depart from the cache
client pattern. Ensures human readable `toString`s across the board,
adds helpers for trivial `toString`s and error-type `toString`s.

# Examples

## Get Response
![image](https://github.com/momentohq/client-sdk-java/assets/3690240/6e011bc9-104a-48fb-80a8-68d289bb808b)

## List stores response
![image](https://github.com/momentohq/client-sdk-java/assets/3690240/02b1b448-dd9e-4c28-a007-34ebc46eb5b7)

## Delete
![image](https://github.com/momentohq/client-sdk-java/assets/3690240/4efb4cd9-8c54-466e-9208-c52fc82fa0b3)

## Store not found error
(error message will be adjusted later)
![image](https://github.com/momentohq/client-sdk-java/assets/3690240/b85bde36-d73b-435f-b0ef-13574f9b6594)

