### PR TITLE
fix: use server metadata for item not found

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -52,8 +52,7 @@ public final class CacheServiceExceptionMapper {
 
       String errorCause = trailers.get(Metadata.Key.of("err", Metadata.ASCII_STRING_MARSHALLER));
       if (errorCause == null) {
-        // TODO remove once control service is updated to send "err" in metadata
-        errorCause = grpcException.getMessage();
+        errorCause = grpcException.getMessage()
       }
 
       switch (statusCode) {
@@ -84,8 +83,7 @@ public final class CacheServiceExceptionMapper {
         case NOT_FOUND:
           if (errorCause.contains("element_not_found")) {
             return new StoreItemNotFoundException(grpcException, errorDetails);
-            // TODO change once control service is updated to send "Store with name" in metadata
-          } else if (errorCause.contains("Store with name")) {
+          } else if (errorCause.contains("store_not_found")) {
             return new StoreNotFoundException(grpcException, errorDetails);
           } else {
             return new CacheNotFoundException(grpcException, errorDetails);

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -52,7 +52,7 @@ public final class CacheServiceExceptionMapper {
 
       String errorCause = trailers.get(Metadata.Key.of("err", Metadata.ASCII_STRING_MARSHALLER));
       if (errorCause == null) {
-        errorCause = grpcException.getMessage()
+        errorCause = grpcException.getMessage();
       }
 
       switch (statusCode) {

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -81,9 +81,9 @@ public final class CacheServiceExceptionMapper {
           return new LimitExceededException(grpcException, errorDetails);
 
         case NOT_FOUND:
-          if (errorCause.contains("element_not_found")) {
+          if (errorCause.contains("item_not_found")) {
             return new StoreItemNotFoundException(grpcException, errorDetails);
-          } else if (errorCause.contains("store_not_found")) {
+          } else if (errorCause.contains("Store with name")) {
             return new StoreNotFoundException(grpcException, errorDetails);
           } else {
             return new CacheNotFoundException(grpcException, errorDetails);


### PR DESCRIPTION
Consumes the server metadata change from `element_not_found` to `item_not_found`.