### PR TITLE
fix: use store_not_found metadata and appropriate exceptions

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -7,7 +7,7 @@ import momento.sdk.BaseTestClass;
 import momento.sdk.PreviewStorageClient;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.StorageConfigurations;
-import momento.sdk.exceptions.CacheNotFoundException;
+import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.responses.storage.DeleteResponse;
 import momento.sdk.responses.storage.GetResponse;
 import momento.sdk.responses.storage.PutResponse;
@@ -112,11 +112,11 @@ public class DataTests extends BaseTestClass {
 
     final GetResponse getResponse = client.get(storeName, "").join();
     assertThat(getResponse).isInstanceOf(GetResponse.Error.class);
-    assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(CacheNotFoundException.class);
+    assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(StoreNotFoundException.class);
 
     final PutResponse putResponse = client.put(storeName, "", "").join();
     assertThat(putResponse).isInstanceOf(PutResponse.Error.class);
-    assertThat(((PutResponse.Error) putResponse)).hasCauseInstanceOf(CacheNotFoundException.class);
+    assertThat(((PutResponse.Error) putResponse)).hasCauseInstanceOf(StoreNotFoundException.class);
   }
 
   @Test

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -83,7 +83,7 @@ public final class CacheServiceExceptionMapper {
         case NOT_FOUND:
           if (errorCause.contains("item_not_found")) {
             return new StoreItemNotFoundException(grpcException, errorDetails);
-          } else if (errorCause.contains("Store with name")) {
+          } else if (errorCause.contains("store_not_found")) {
             return new StoreNotFoundException(grpcException, errorDetails);
           } else {
             return new CacheNotFoundException(grpcException, errorDetails);


### PR DESCRIPTION
Update the client to read `store_not_found` metadata to distinguish
cache vs store not found. Use `StoreNotFoundException` in tests.
