### PR TITLE
feat: storage get response 2.0

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -51,7 +51,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getByteArray()).isEqualTo(value.getBytes());
+    assertThat(getResponse.found().get().value().getByteArray().get()).isEqualTo(value.getBytes());
   }
 
   @Test
@@ -81,7 +81,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getLong()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getLong().get()).isEqualTo(value);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getDouble()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getDouble().get()).isEqualTo(value);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, emptyKey, emptyValue).get();
     final GetResponse response = client.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
-    assert response.found().get().value().getString().isEmpty();
+    assert response.found().get().value().getString().get().isEmpty();
   }
 
   @Test
@@ -140,7 +140,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, key, value).get();
     final GetResponse getResponse = client.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
 
     final DeleteResponse deleteResponse = client.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -49,7 +49,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
+    assertThat(getResponse.asFound().value().getString()).isEqualTo(value);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getByteArray()).isEqualTo(value.getBytes());
+    assertThat(getResponse.asFound().value().getByteArray()).isEqualTo(value.getBytes());
   }
 
   @Test
@@ -79,7 +79,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getLong()).isEqualTo(value);
+    assertThat(getResponse.asFound().value().getLong()).isEqualTo(value);
   }
 
   @Test
@@ -94,7 +94,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getDouble()).isEqualTo(value);
+    assertThat(getResponse.asFound().value().getDouble()).isEqualTo(value);
   }
 
   @Test
@@ -126,7 +126,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, emptyKey, emptyValue).get();
     final GetResponse response = client.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
-    assert response.found().get().value().getString().isEmpty();
+    assert response.asFound().value().getString().isEmpty();
   }
 
   @Test
@@ -137,7 +137,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, key, value).get();
     final GetResponse getResponse = client.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
+    assertThat(getResponse.asFound().value().getString()).isEqualTo(value);
 
     final DeleteResponse deleteResponse = client.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -48,8 +48,8 @@ public class DataTests extends BaseTestClass {
 
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
-    assertThat(getResponse).isInstanceOf(GetResponse.Success.class);
-    assertThat(getResponse.success().get().value().get().getString().get()).isEqualTo(value);
+    assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
+    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
   }
 
   @Test
@@ -63,9 +63,8 @@ public class DataTests extends BaseTestClass {
 
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
-    assertThat(getResponse).isInstanceOf(GetResponse.Success.class);
-    assertThat(getResponse.success().get().value().get().getByteArray().get())
-        .isEqualTo(value.getBytes());
+    assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
+    assertThat(getResponse.found().get().value().getByteArray().get()).isEqualTo(value.getBytes());
   }
 
   @Test
@@ -79,8 +78,8 @@ public class DataTests extends BaseTestClass {
 
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
-    assertThat(getResponse).isInstanceOf(GetResponse.Success.class);
-    assertThat(getResponse.success().get().value().get().getLong().get()).isEqualTo(value);
+    assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
+    assertThat(getResponse.found().get().value().getLong().get()).isEqualTo(value);
   }
 
   @Test
@@ -94,16 +93,17 @@ public class DataTests extends BaseTestClass {
 
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
-    assertThat(getResponse).isInstanceOf(GetResponse.Success.class);
-    assertThat(getResponse.success().get().value().get().getDouble().get()).isEqualTo(value);
+    assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
+    assertThat(getResponse.found().get().value().getDouble().get()).isEqualTo(value);
   }
 
   @Test
   void storeKeyNotFound() {
     // Get key that was not set
     final GetResponse response = client.get(storeName, randomString("key")).join();
-    assertThat(response).isInstanceOf(GetResponse.Success.class);
-    assert !response.success().get().value().isPresent();
+    assertThat(response).isInstanceOf(GetResponse.NotFound.class);
+    assert !response.found().isPresent();
+    assert response instanceof GetResponse.NotFound;
   }
 
   @Test
@@ -125,8 +125,8 @@ public class DataTests extends BaseTestClass {
     final String emptyValue = "";
     client.put(storeName, emptyKey, emptyValue).get();
     final GetResponse response = client.get(storeName, emptyKey).get();
-    assertThat(response).isInstanceOf(GetResponse.Success.class);
-    assert response.success().get().value().get().getString().get().isEmpty();
+    assertThat(response).isInstanceOf(GetResponse.Found.class);
+    assert response.found().get().value().getString().get().isEmpty();
   }
 
   @Test
@@ -136,14 +136,15 @@ public class DataTests extends BaseTestClass {
 
     client.put(storeName, key, value).get();
     final GetResponse getResponse = client.get(storeName, key).get();
-    assertThat(getResponse).isInstanceOf(GetResponse.Success.class);
-    assertThat(getResponse.success().get().value().get().getString().get()).isEqualTo(value);
+    assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
+    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
 
     final DeleteResponse deleteResponse = client.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
 
     final GetResponse getAfterDeleteResponse = client.get(storeName, key).get();
-    assert !getAfterDeleteResponse.success().get().value().isPresent();
+    assert !getAfterDeleteResponse.found().isPresent();
+    assert getAfterDeleteResponse instanceof GetResponse.NotFound;
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -51,7 +51,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
+    assertThat(getResponse.valueWhenFound().get().getString().get()).isEqualTo(value);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getByteArray().get()).isEqualTo(value.getBytes());
+    assertThat(getResponse.valueWhenFound().get().getByteArray().get()).isEqualTo(value.getBytes());
   }
 
   @Test
@@ -81,7 +81,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getLong().get()).isEqualTo(value);
+    assertThat(getResponse.valueWhenFound().get().getLong().get()).isEqualTo(value);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getDouble().get()).isEqualTo(value);
+    assertThat(getResponse.valueWhenFound().get().getDouble().get()).isEqualTo(value);
   }
 
   @Test
@@ -104,9 +104,9 @@ public class DataTests extends BaseTestClass {
     // Get key that was not set
     final GetResponse response = client.get(storeName, randomString("key")).join();
     assertThat(response).isInstanceOf(GetResponse.NotFound.class);
-    assert response.found().isEmpty();
+    assert response.valueWhenFound().isEmpty();
     assert response instanceof GetResponse.NotFound;
-    assertThrows(ClientSdkException.class, response.found()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.valueWhenFound()::orElseThrow);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, emptyKey, emptyValue).get();
     final GetResponse response = client.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
-    assert response.found().get().value().getString().get().isEmpty();
+    assert response.valueWhenFound().get().getString().get().isEmpty();
   }
 
   @Test
@@ -140,13 +140,13 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, key, value).get();
     final GetResponse getResponse = client.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
+    assertThat(getResponse.valueWhenFound().get().getString().get()).isEqualTo(value);
 
     final DeleteResponse deleteResponse = client.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
 
     final GetResponse getAfterDeleteResponse = client.get(storeName, key).get();
-    assert getAfterDeleteResponse.found().isEmpty();
+    assert getAfterDeleteResponse.valueWhenFound().isEmpty();
     assert getAfterDeleteResponse instanceof GetResponse.NotFound;
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -2,11 +2,13 @@ package momento.sdk.storage;
 
 import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import momento.sdk.BaseTestClass;
 import momento.sdk.PreviewStorageClient;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.StorageConfigurations;
+import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.responses.storage.DeleteResponse;
 import momento.sdk.responses.storage.GetResponse;
@@ -102,8 +104,9 @@ public class DataTests extends BaseTestClass {
     // Get key that was not set
     final GetResponse response = client.get(storeName, randomString("key")).join();
     assertThat(response).isInstanceOf(GetResponse.NotFound.class);
-    assert !response.found().isPresent();
+    assert response.found().isEmpty();
     assert response instanceof GetResponse.NotFound;
+    assertThrows(ClientSdkException.class, response.found()::orElseThrow);
   }
 
   @Test
@@ -143,7 +146,7 @@ public class DataTests extends BaseTestClass {
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
 
     final GetResponse getAfterDeleteResponse = client.get(storeName, key).get();
-    assert !getAfterDeleteResponse.found().isPresent();
+    assert getAfterDeleteResponse.found().isEmpty();
     assert getAfterDeleteResponse instanceof GetResponse.NotFound;
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -49,7 +49,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getByteArray().get()).isEqualTo(value.getBytes());
+    assertThat(getResponse.found().get().value().getByteArray()).isEqualTo(value.getBytes());
   }
 
   @Test
@@ -79,7 +79,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getLong().get()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getLong()).isEqualTo(value);
   }
 
   @Test
@@ -94,7 +94,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getDouble().get()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getDouble()).isEqualTo(value);
   }
 
   @Test
@@ -126,7 +126,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, emptyKey, emptyValue).get();
     final GetResponse response = client.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
-    assert response.found().get().value().getString().get().isEmpty();
+    assert response.found().get().value().getString().isEmpty();
   }
 
   @Test
@@ -137,7 +137,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, key, value).get();
     final GetResponse getResponse = client.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.found().get().value().getString().get()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
 
     final DeleteResponse deleteResponse = client.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -51,7 +51,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.asFound().value().getString()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.asFound().value().getByteArray()).isEqualTo(value.getBytes());
+    assertThat(getResponse.found().get().value().getByteArray()).isEqualTo(value.getBytes());
   }
 
   @Test
@@ -81,7 +81,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.asFound().value().getLong()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getLong()).isEqualTo(value);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class DataTests extends BaseTestClass {
     // Successful Get
     final GetResponse getResponse = client.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.asFound().value().getDouble()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getDouble()).isEqualTo(value);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, emptyKey, emptyValue).get();
     final GetResponse response = client.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
-    assert response.asFound().value().getString().isEmpty();
+    assert response.found().get().value().getString().isEmpty();
   }
 
   @Test
@@ -140,7 +140,7 @@ public class DataTests extends BaseTestClass {
     client.put(storeName, key, value).get();
     final GetResponse getResponse = client.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
-    assertThat(getResponse.asFound().value().getString()).isEqualTo(value);
+    assertThat(getResponse.found().get().value().getString()).isEqualTo(value);
 
     final DeleteResponse deleteResponse = client.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
@@ -136,16 +136,16 @@ final class StorageDataClient extends StorageClientBase {
             _StoreValue value = rsp.getValue();
             switch (value.getValueCase()) {
               case BYTES_VALUE:
-                returnFuture.complete(GetResponse.Success.of(value.getBytesValue().toByteArray()));
+                returnFuture.complete(GetResponse.Found.of(value.getBytesValue().toByteArray()));
                 break;
               case STRING_VALUE:
-                returnFuture.complete(GetResponse.Success.of(value.getStringValue()));
+                returnFuture.complete(GetResponse.Found.of(value.getStringValue()));
                 break;
               case INTEGER_VALUE:
-                returnFuture.complete(GetResponse.Success.of(value.getIntegerValue()));
+                returnFuture.complete(GetResponse.Found.of(value.getIntegerValue()));
                 break;
               case DOUBLE_VALUE:
-                returnFuture.complete(GetResponse.Success.of(value.getDoubleValue()));
+                returnFuture.complete(GetResponse.Found.of(value.getDoubleValue()));
                 break;
               case VALUE_NOT_SET:
                 returnFuture.complete(
@@ -159,7 +159,7 @@ final class StorageDataClient extends StorageClientBase {
           public void onFailure(@Nonnull Throwable e) {
             final SdkException sdkException = CacheServiceExceptionMapper.convert(e, metadata);
             if (sdkException instanceof momento.sdk.exceptions.StoreItemNotFoundException) {
-              returnFuture.complete(GetResponse.Success.of());
+              returnFuture.complete(new GetResponse.NotFound());
             } else {
               returnFuture.complete(new GetResponse.Error(CacheServiceExceptionMapper.convert(e)));
             }

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -2,21 +2,21 @@ package momento.sdk.responses.storage;
 
 import java.util.Optional;
 import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
 
 /**
  * Response for a get operation.
  *
- * <p>The response can be either a {@link Success} or an {@link Error}.
+ * <p>The response can be either a {@link Found}, {@link NotFound}, or an {@link Error}.
  *
- * <p>To shortcut access to the success response, use {@link #success()}. If the operation was
- * successful, the response will be an optional of {@link Success}, otherwise it will be an empty
- * optional.
+ * <p>To shortcut access to found response, use {@link #found()}. If the operation was successful
+ * but the key was not found, the response will be an empty optional. If the operation failed, the
+ * response will be an empty optional.
  *
  * <p>To handle the response otherwise, use pattern matching or an instanceof to check if the
- * response is a {@link Success} or an {@link Error}.
+ * response is a {@link Found}, {@link NotFound}, or an {@link Error}.
  *
- * <p>Upon a success, the value can be retrieved with {@link Success#value()}. If the value was
- * found in the store, it will be present, otherwise it will be empty.
+ * <p>Upon a found response, the value can be retrieved with {@link Found#value()}.
  */
 public interface GetResponse {
   /**
@@ -27,7 +27,7 @@ public interface GetResponse {
    *
    * @return The success response, or an empty optional if the operation failed.
    */
-  Optional<Success> success();
+  Optional<Found> found();
 
   /**
    * A successful get operation.
@@ -38,31 +38,27 @@ public interface GetResponse {
    * <p>Use the appropriate type-based accessor on the value to retrieve the value in its
    * corresponding type.
    */
-  class Success implements GetResponse {
-    private final Optional<StorageValue> value;
+  class Found implements GetResponse {
+    private final StorageValue value;
 
-    private Success(Optional<StorageValue> value) {
+    private Found(StorageValue value) {
       this.value = value;
     }
 
-    public static Success of() {
-      return new Success(Optional.empty());
+    public static Found of(byte[] value) {
+      return new Found(StorageValue.of(value));
     }
 
-    public static Success of(byte[] value) {
-      return new Success(Optional.of(StorageValue.of(value)));
+    public static Found of(String value) {
+      return new Found(StorageValue.of(value));
     }
 
-    public static Success of(String value) {
-      return new Success(Optional.of(StorageValue.of(value)));
+    public static Found of(long value) {
+      return new Found(StorageValue.of(value));
     }
 
-    public static Success of(long value) {
-      return new Success(Optional.of(StorageValue.of(value)));
-    }
-
-    public static Success of(double value) {
-      return new Success(Optional.of(StorageValue.of(value)));
+    public static Found of(double value) {
+      return new Found(StorageValue.of(value));
     }
 
     /**
@@ -70,18 +66,32 @@ public interface GetResponse {
      *
      * @return The value, or an empty optional if the value does not exist.
      */
-    public Optional<StorageValue> value() {
+    public StorageValue value() {
       return value;
     }
 
     @Override
-    public Optional<Success> success() {
+    public Optional<Found> found() {
       return Optional.of(this);
     }
 
     @Override
     public String toString() {
-      return "GetResponse.Success{value=" + value + "}";
+      return "GetResponse.Found{value=" + value + "}";
+    }
+  }
+
+  class NotFound implements GetResponse {
+    public NotFound() {}
+
+    @Override
+    public Optional<Found> found() {
+      return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("GetResponse.NotFound");
     }
   }
 
@@ -102,7 +112,7 @@ public interface GetResponse {
     }
 
     @Override
-    public Optional<Success> success() {
+    public Optional<Found> found() {
       return Optional.empty();
     }
 

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -1,9 +1,9 @@
 package momento.sdk.responses.storage;
 
-import java.util.Optional;
 import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
+import momento.sdk.utils.MomentoOptional;
 
 /**
  * Response for a get operation.
@@ -28,7 +28,7 @@ public interface GetResponse {
    *
    * @return The success response, or an empty optional if the operation failed.
    */
-  Optional<GetResponseFound> found();
+  MomentoOptional<GetResponseFound> found();
 
   /**
    * Returns the found response if the operation was successful, or throws an exception if the
@@ -80,8 +80,8 @@ public interface GetResponse {
     }
 
     @Override
-    public Optional<GetResponseFound> found() {
-      return Optional.of(this);
+    public MomentoOptional<GetResponseFound> found() {
+      return MomentoOptional.of(this);
     }
 
     @Override
@@ -99,8 +99,8 @@ public interface GetResponse {
     public NotFound() {}
 
     @Override
-    public Optional<GetResponseFound> found() {
-      return Optional.empty();
+    public MomentoOptional<GetResponseFound> found() {
+      return MomentoOptional.empty("Value was not found in the store.");
     }
 
     @Override
@@ -131,8 +131,8 @@ public interface GetResponse {
     }
 
     @Override
-    public Optional<GetResponseFound> found() {
-      return Optional.empty();
+    public MomentoOptional<GetResponseFound> found() {
+      return MomentoOptional.empty("The get operation failed: " + this);
     }
 
     @Override

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -9,9 +9,9 @@ import momento.sdk.utils.MomentoOptional;
  *
  * <p>The response can be either a {@link Found}, {@link NotFound}, or an {@link Error}.
  *
- * <p>To shortcut access to found response, use {@link #found()}. If the operation was successful
- * but the key was not found, the response will be an empty optional. If the operation failed, the
- * response will be an empty optional.
+ * <p>To shortcut access to found value, use {@link #valueWhenFound()}. If the operation was
+ * successful but the key was not found, the response will be an empty optional. If the operation
+ * failed, the response will also be an empty optional.
  *
  * <p>To handle the response otherwise, use pattern matching or an instanceof to check if the
  * response is a {@link Found}, {@link NotFound}, or an {@link Error}.
@@ -20,14 +20,15 @@ import momento.sdk.utils.MomentoOptional;
  */
 public interface GetResponse {
   /**
-   * Returns the success response if the operation was successful, or an empty optional if the
-   * operation failed.
+   * Returns the found value if the operation was successful and the key found, or an empty optional
+   * if the key was not found or the operation failed.
    *
    * <p>This is a convenience method that can be used to avoid instanceof checks and casting.
    *
-   * @return The success response, or an empty optional if the operation failed.
+   * @return The found value if the operation was successful and the key found, or an empty
+   *     optional.
    */
-  MomentoOptional<GetResponseFound> found();
+  MomentoOptional<StorageValue> valueWhenFound();
 
   /**
    * A successful get operation.
@@ -38,7 +39,7 @@ public interface GetResponse {
    * <p>Use the appropriate type-based accessor on the value to retrieve the value in its
    * corresponding type.
    */
-  class Found implements GetResponse, GetResponseFound {
+  class Found implements GetResponse {
     private final StorageValue value;
 
     private Found(StorageValue value) {
@@ -71,8 +72,8 @@ public interface GetResponse {
     }
 
     @Override
-    public MomentoOptional<GetResponseFound> found() {
-      return MomentoOptional.of(this);
+    public MomentoOptional<StorageValue> valueWhenFound() {
+      return MomentoOptional.of(value());
     }
 
     @Override
@@ -85,7 +86,7 @@ public interface GetResponse {
     public NotFound() {}
 
     @Override
-    public MomentoOptional<GetResponseFound> found() {
+    public MomentoOptional<StorageValue> valueWhenFound() {
       return MomentoOptional.empty("Value was not found in the store.");
     }
 
@@ -112,7 +113,7 @@ public interface GetResponse {
     }
 
     @Override
-    public MomentoOptional<GetResponseFound> found() {
+    public MomentoOptional<StorageValue> valueWhenFound() {
       return MomentoOptional.empty("The get operation failed: " + this);
     }
 

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -1,6 +1,5 @@
 package momento.sdk.responses.storage;
 
-import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
 import momento.sdk.utils.MomentoOptional;
@@ -29,14 +28,6 @@ public interface GetResponse {
    * @return The success response, or an empty optional if the operation failed.
    */
   MomentoOptional<GetResponseFound> found();
-
-  /**
-   * Returns the found response if the operation was successful, or throws an exception if the
-   * operation failed.
-   *
-   * @return The found response.
-   */
-  GetResponseFound asFound();
 
   /**
    * A successful get operation.
@@ -85,11 +76,6 @@ public interface GetResponse {
     }
 
     @Override
-    public GetResponseFound asFound() {
-      return this;
-    }
-
-    @Override
     public String toString() {
       return "GetResponse.Found{value=" + value + "}";
     }
@@ -101,11 +87,6 @@ public interface GetResponse {
     @Override
     public MomentoOptional<GetResponseFound> found() {
       return MomentoOptional.empty("Value was not found in the store.");
-    }
-
-    @Override
-    public GetResponseFound asFound() {
-      throw new ClientSdkException("GetResponse::asFound cannot be called on GetResponse.NotFound");
     }
 
     @Override
@@ -133,11 +114,6 @@ public interface GetResponse {
     @Override
     public MomentoOptional<GetResponseFound> found() {
       return MomentoOptional.empty("The get operation failed: " + this);
-    }
-
-    @Override
-    public GetResponseFound asFound() {
-      throw new ClientSdkException("GetResponse::asFound cannot be called on GetResponse.Error");
     }
 
     @Override

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -1,6 +1,7 @@
 package momento.sdk.responses.storage;
 
 import java.util.Optional;
+import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.SdkException;
 import momento.sdk.internal.StringHelpers;
 
@@ -28,6 +29,14 @@ public interface GetResponse {
    * @return The success response, or an empty optional if the operation failed.
    */
   Optional<GetResponseFound> found();
+
+  /**
+   * Returns the found response if the operation was successful, or throws an exception if the
+   * operation failed.
+   *
+   * @return The found response.
+   */
+  GetResponseFound asFound();
 
   /**
    * A successful get operation.
@@ -76,6 +85,11 @@ public interface GetResponse {
     }
 
     @Override
+    public GetResponseFound asFound() {
+      return this;
+    }
+
+    @Override
     public String toString() {
       return "GetResponse.Found{value=" + value + "}";
     }
@@ -87,6 +101,11 @@ public interface GetResponse {
     @Override
     public Optional<GetResponseFound> found() {
       return Optional.empty();
+    }
+
+    @Override
+    public GetResponseFound asFound() {
+      throw new ClientSdkException("GetResponse::asFound cannot be called on GetResponse.NotFound");
     }
 
     @Override
@@ -114,6 +133,11 @@ public interface GetResponse {
     @Override
     public Optional<GetResponseFound> found() {
       return Optional.empty();
+    }
+
+    @Override
+    public GetResponseFound asFound() {
+      throw new ClientSdkException("GetResponse::asFound cannot be called on GetResponse.Error");
     }
 
     @Override

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponse.java
@@ -27,7 +27,7 @@ public interface GetResponse {
    *
    * @return The success response, or an empty optional if the operation failed.
    */
-  Optional<Found> found();
+  Optional<GetResponseFound> found();
 
   /**
    * A successful get operation.
@@ -38,7 +38,7 @@ public interface GetResponse {
    * <p>Use the appropriate type-based accessor on the value to retrieve the value in its
    * corresponding type.
    */
-  class Found implements GetResponse {
+  class Found implements GetResponse, GetResponseFound {
     private final StorageValue value;
 
     private Found(StorageValue value) {
@@ -71,7 +71,7 @@ public interface GetResponse {
     }
 
     @Override
-    public Optional<Found> found() {
+    public Optional<GetResponseFound> found() {
       return Optional.of(this);
     }
 
@@ -85,7 +85,7 @@ public interface GetResponse {
     public NotFound() {}
 
     @Override
-    public Optional<Found> found() {
+    public Optional<GetResponseFound> found() {
       return Optional.empty();
     }
 
@@ -112,7 +112,7 @@ public interface GetResponse {
     }
 
     @Override
-    public Optional<Found> found() {
+    public Optional<GetResponseFound> found() {
       return Optional.empty();
     }
 

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponseFound.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponseFound.java
@@ -1,5 +1,0 @@
-package momento.sdk.responses.storage;
-
-public interface GetResponseFound {
-  StorageValue value();
-}

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponseFound.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/GetResponseFound.java
@@ -1,0 +1,5 @@
+package momento.sdk.responses.storage;
+
+public interface GetResponseFound {
+  StorageValue value();
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
@@ -58,7 +58,7 @@ public class StorageValue {
    *     thrown.
    */
   public byte[] getByteArray() {
-    ensureCorrectTypeOrThrowException(StorageItemType.BYTE_ARRAY, itemType);
+    ensureCorrectTypeOrThrowException(StorageItemType.BYTE_ARRAY);
     return (byte[]) value;
   }
 
@@ -68,7 +68,7 @@ public class StorageValue {
    * @return the value as a string. If the value is not a string, an exception will be thrown.
    */
   public String getString() {
-    ensureCorrectTypeOrThrowException(StorageItemType.STRING, itemType);
+    ensureCorrectTypeOrThrowException(StorageItemType.STRING);
     return (String) value;
   }
 
@@ -78,7 +78,7 @@ public class StorageValue {
    * @return the value as a long. If the value is not a long, an exception will be thrown.
    */
   public long getLong() {
-    ensureCorrectTypeOrThrowException(StorageItemType.LONG, itemType);
+    ensureCorrectTypeOrThrowException(StorageItemType.LONG);
     return (long) value;
   }
 
@@ -88,18 +88,17 @@ public class StorageValue {
    * @return the value as a double. If the value is not a double, an exception will be thrown.
    */
   public double getDouble() {
-    ensureCorrectTypeOrThrowException(StorageItemType.DOUBLE, itemType);
+    ensureCorrectTypeOrThrowException(StorageItemType.DOUBLE);
     return (double) value;
   }
 
-  private void ensureCorrectTypeOrThrowException(
-      StorageItemType requested, StorageItemType actual) {
-    if (requested != actual) {
+  private void ensureCorrectTypeOrThrowException(StorageItemType requested) {
+    if (requested != itemType) {
       // In a regular Java context, ClassCastException or IllegalStateException could be
       // appropriate here.
       throw new ClientSdkException(
           String.format(
-              "Value is not a %s but was: %s".format(requested.toString(), actual.toString())));
+              "Value is not a %s but was: %s".format(requested.toString(), itemType.toString())));
     }
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
@@ -1,6 +1,6 @@
 package momento.sdk.responses.storage;
 
-import java.util.Optional;
+import momento.sdk.exceptions.ClientSdkException;
 
 /**
  * A value stored in the storage.
@@ -15,7 +15,7 @@ import java.util.Optional;
  * </ul>
  *
  * <p>Use the appropriate accessor to retrieve the value in its corresponding type. If the
- * underlying value is not of the requested type, an empty optional will be returned.
+ * underlying value is not of the requested type, an exception will be thrown.
  */
 public class StorageValue {
   private final Object value;
@@ -54,50 +54,53 @@ public class StorageValue {
   /**
    * Get the value as a byte array.
    *
-   * @return the value as a byte array. If the value is not a byte array, an empty optional is
-   *     returned.
+   * @return the value as a byte array. If the value is not a byte array, an exception will be
+   *     thrown.
    */
-  public Optional<byte[]> getByteArray() {
-    if (itemType != StorageItemType.BYTE_ARRAY) {
-      return Optional.empty();
-    }
-    return Optional.of((byte[]) value);
+  public byte[] getByteArray() {
+    ensureCorrectTypeOrThrowException(StorageItemType.BYTE_ARRAY, itemType);
+    return (byte[]) value;
   }
 
   /**
    * Get the value as a string.
    *
-   * @return the value as a string. If the value is not a string, an empty optional is returned.
+   * @return the value as a string. If the value is not a string, an exception will be thrown.
    */
-  public Optional<String> getString() {
-    if (itemType != StorageItemType.STRING) {
-      return Optional.empty();
-    }
-    return Optional.of((String) value);
+  public String getString() {
+    ensureCorrectTypeOrThrowException(StorageItemType.STRING, itemType);
+    return (String) value;
   }
 
   /**
    * Get the value as a long.
    *
-   * @return the value as a long. If the value is not a long, an empty optional is returned.
+   * @return the value as a long. If the value is not a long, an exception will be thrown.
    */
-  public Optional<Long> getLong() {
-    if (itemType != StorageItemType.LONG) {
-      return Optional.empty();
-    }
-    return Optional.of((long) value);
+  public long getLong() {
+    ensureCorrectTypeOrThrowException(StorageItemType.LONG, itemType);
+    return (long) value;
   }
 
   /**
    * Get the value as a double.
    *
-   * @return the value as a double. If the value is not a double, an empty optional is returned.
+   * @return the value as a double. If the value is not a double, an exception will be thrown.
    */
-  public Optional<Double> getDouble() {
-    if (itemType != StorageItemType.DOUBLE) {
-      return Optional.empty();
+  public double getDouble() {
+    ensureCorrectTypeOrThrowException(StorageItemType.DOUBLE, itemType);
+    return (double) value;
+  }
+
+  private void ensureCorrectTypeOrThrowException(
+      StorageItemType requested, StorageItemType actual) {
+    if (requested != actual) {
+      // In a regular Java context, ClassCastException or IllegalStateException could be
+      // appropriate here.
+      throw new ClientSdkException(
+          String.format(
+              "Value is not a %s but was: %s".format(requested.toString(), actual.toString())));
     }
-    return Optional.of((double) value);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/storage/StorageValue.java
@@ -1,6 +1,6 @@
 package momento.sdk.responses.storage;
 
-import momento.sdk.exceptions.ClientSdkException;
+import momento.sdk.utils.MomentoOptional;
 
 /**
  * A value stored in the storage.
@@ -54,52 +54,63 @@ public class StorageValue {
   /**
    * Get the value as a byte array.
    *
-   * @return the value as a byte array. If the value is not a byte array, an exception will be
-   *     thrown.
+   * @return the value as an optional byte array. If the value is not a byte array, an empty
+   *     optional will be returned. Call {@link MomentoOptional#orElseThrow()} to short circuit the
+   *     operation and throw an exception.
    */
-  public byte[] getByteArray() {
-    ensureCorrectTypeOrThrowException(StorageItemType.BYTE_ARRAY);
-    return (byte[]) value;
+  public MomentoOptional<byte[]> getByteArray() {
+    if (itemType != StorageItemType.BYTE_ARRAY) {
+      return MomentoOptional.empty(formatWrongTypeMessage(StorageItemType.BYTE_ARRAY));
+    }
+    return MomentoOptional.of((byte[]) value);
   }
 
   /**
    * Get the value as a string.
    *
-   * @return the value as a string. If the value is not a string, an exception will be thrown.
+   * @return the value as an optional string. If the value is not a string, an empty optional will
+   *     be returned. Call {@link MomentoOptional#orElseThrow()} to short circuit the operation and
+   *     throw an exception.
    */
-  public String getString() {
-    ensureCorrectTypeOrThrowException(StorageItemType.STRING);
-    return (String) value;
+  public MomentoOptional<String> getString() {
+    if (itemType != StorageItemType.STRING) {
+      return MomentoOptional.empty(formatWrongTypeMessage(StorageItemType.STRING));
+    }
+    return MomentoOptional.of((String) value);
   }
 
   /**
    * Get the value as a long.
    *
-   * @return the value as a long. If the value is not a long, an exception will be thrown.
+   * @return the value as an optional long. If the value is not a long, an empty optional will be
+   *     returned. Call {@link MomentoOptional#orElseThrow()} to short circuit the operation and
+   *     throw an exception.
    */
-  public long getLong() {
-    ensureCorrectTypeOrThrowException(StorageItemType.LONG);
-    return (long) value;
+  public MomentoOptional<Long> getLong() {
+    if (itemType != StorageItemType.LONG) {
+      return MomentoOptional.empty(formatWrongTypeMessage(StorageItemType.LONG));
+    }
+
+    return MomentoOptional.of((long) value);
   }
 
   /**
    * Get the value as a double.
    *
-   * @return the value as a double. If the value is not a double, an exception will be thrown.
+   * @return the value as an optional double. If the value is not a double, an empty optional will
+   *     be returned. Call {@link MomentoOptional#orElseThrow()} to short circuit the operation and
+   *     throw an exception.
    */
-  public double getDouble() {
-    ensureCorrectTypeOrThrowException(StorageItemType.DOUBLE);
-    return (double) value;
+  public MomentoOptional<Double> getDouble() {
+    if (itemType != StorageItemType.DOUBLE) {
+      return MomentoOptional.empty(formatWrongTypeMessage(StorageItemType.DOUBLE));
+    }
+    return MomentoOptional.of((double) value);
   }
 
-  private void ensureCorrectTypeOrThrowException(StorageItemType requested) {
-    if (requested != itemType) {
-      // In a regular Java context, ClassCastException or IllegalStateException could be
-      // appropriate here.
-      throw new ClientSdkException(
-          String.format(
-              "Value is not a %s but was: %s".format(requested.toString(), itemType.toString())));
-    }
+  private String formatWrongTypeMessage(StorageItemType requested) {
+    return String.format(
+        "Value is not a %s but was: %s".format(requested.toString(), itemType.toString()));
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/utils/MomentoOptional.java
+++ b/momento-sdk/src/main/java/momento/sdk/utils/MomentoOptional.java
@@ -1,0 +1,118 @@
+package momento.sdk.utils;
+
+import java.util.Optional;
+import momento.sdk.exceptions.ClientSdkException;
+
+/**
+ * A wrapper around {@link Optional} that provides custom error handling for empty optionals.
+ *
+ * @param <T> the type of the optional value.
+ */
+public class MomentoOptional<T> {
+  /** The optional value. */
+  private final Optional<T> optional;
+  /** The exception message to throw when the optional is empty. */
+  private final String onEmptyExceptionMessage;
+
+  /**
+   * Constructs a new optional.
+   *
+   * @param optional the optional value.
+   */
+  private MomentoOptional(Optional<T> optional) {
+    this(optional, "");
+  }
+
+  /**
+   * Constructs a new optional.
+   *
+   * @param optional the optional value.
+   * @param onEmptyExceptionMessage the exception message to throw when the optional is empty on
+   *     access.
+   */
+  private MomentoOptional(Optional<T> optional, String onEmptyExceptionMessage) {
+    this.optional = optional;
+    this.onEmptyExceptionMessage = onEmptyExceptionMessage;
+  }
+
+  /**
+   * Creates a new optional with the given value.
+   *
+   * @param value the value.
+   * @return the optional.
+   * @param <T> the type of the value.
+   */
+  public static <T> MomentoOptional<T> of(T value) {
+    return new MomentoOptional<>(Optional.of(value));
+  }
+
+  /**
+   * Creates a new optional with the given value.
+   *
+   * @param onEmptyExceptionMessage the exception message to throw when the optional is empty on
+   * @return the optional.
+   * @param <T> the type of the value.
+   */
+  public static <T> MomentoOptional<T> empty(String onEmptyExceptionMessage) {
+    return new MomentoOptional<>(Optional.empty(), onEmptyExceptionMessage);
+  }
+
+  /**
+   * Gets the value of the optional.
+   *
+   * @return the value.
+   */
+  public T get() {
+    return optional.get();
+  }
+
+  /**
+   * Gets the value of the optional or throws an exception if the optional is empty.
+   *
+   * @return the value.
+   */
+  public T orElseThrow() {
+    return optional.orElseThrow(() -> new ClientSdkException(onEmptyExceptionMessage));
+  }
+
+  /**
+   * Converts the optional to a standard {@link Optional}.
+   *
+   * @return the optional.
+   */
+  public Optional<T> toOptional() {
+    return optional;
+  }
+
+  /**
+   * Checks if the optional is present.
+   *
+   * @return true if the optional is present, false otherwise.
+   */
+  public boolean isPresent() {
+    return optional.isPresent();
+  }
+
+  /**
+   * Checks if the optional is empty.
+   *
+   * @return true if the optional is empty, false otherwise.
+   */
+  public boolean isEmpty() {
+    return !isPresent();
+  }
+
+  /**
+   * Returns a string representation of the optional.
+   *
+   * @return the string representation.
+   */
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("MomentoOptional{");
+    sb.append("optional=");
+    sb.append(optional);
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/utils/MomentoOptional.java
+++ b/momento-sdk/src/main/java/momento/sdk/utils/MomentoOptional.java
@@ -58,12 +58,13 @@ public class MomentoOptional<T> {
   }
 
   /**
-   * Gets the value of the optional.
+   * If the value is present, returns the value. Otherwise throws a {@link ClientSdkException} with
+   * a specific error message.
    *
    * @return the value.
    */
   public T get() {
-    return optional.get();
+    return this.orElseThrow();
   }
 
   /**

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -1,6 +1,9 @@
 package momento.sdk.responses.storage;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import io.grpc.Status;
+import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.internal.MomentoGrpcErrorDetails;
 import momento.sdk.internal.MomentoTransportErrorDetails;
@@ -10,47 +13,47 @@ public class GetResponseTest {
   @Test
   public void testGetResponseFoundWorksOnTheRightType() {
     GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
-    assert response.value().getByteArray().get().length == 4;
-    assert !response.value().getString().isPresent();
-    assert !response.value().getLong().isPresent();
-    assert !response.value().getDouble().isPresent();
+    assert response.value().getByteArray().length == 4;
+    assertThrows(ClientSdkException.class, response.value()::getString);
+    assertThrows(ClientSdkException.class, response.value()::getLong);
+    assertThrows(ClientSdkException.class, response.value()::getDouble);
 
     response = GetResponse.Found.of("string");
-    assert !response.value().getByteArray().isPresent();
-    assert response.value().getString().get().equals("string");
-    assert !response.value().getLong().isPresent();
-    assert !response.value().getDouble().isPresent();
+    assertThrows(ClientSdkException.class, response.value()::getByteArray);
+    assert response.value().getString().equals("string");
+    assertThrows(ClientSdkException.class, response.value()::getLong);
+    assertThrows(ClientSdkException.class, response.value()::getDouble);
 
     response = GetResponse.Found.of(42L);
-    assert !response.value().getByteArray().isPresent();
-    assert !response.value().getString().isPresent();
-    assert response.value().getLong().get() == 42L;
-    assert !response.value().getDouble().isPresent();
+    assertThrows(ClientSdkException.class, response.value()::getByteArray);
+    assertThrows(ClientSdkException.class, response.value()::getString);
+    assert response.value().getLong() == 42L;
+    assertThrows(ClientSdkException.class, response.value()::getDouble);
 
     response = GetResponse.Found.of(3.14);
-    assert !response.value().getByteArray().isPresent();
-    assert !response.value().getString().isPresent();
-    assert !response.value().getLong().isPresent();
-    assert response.value().getDouble().get() == 3.14;
+    assertThrows(ClientSdkException.class, response.value()::getByteArray);
+    assertThrows(ClientSdkException.class, response.value()::getString);
+    assertThrows(ClientSdkException.class, response.value()::getLong);
+    assert response.value().getDouble() == 3.14;
   }
 
   @Test
   public void testConvenienceMethodsOnGetResponse() {
     GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
     assert response.found().isPresent();
-    assert response.found().get().value().getByteArray().get().length == 4;
+    assert response.found().get().value().getByteArray().length == 4;
 
     response = GetResponse.Found.of("string");
     assert response.found().isPresent();
-    assert response.found().get().value().getString().get() == "string";
+    assert response.found().get().value().getString() == "string";
 
     response = GetResponse.Found.of(42L);
     assert response.found().isPresent();
-    assert response.found().get().value().getLong().get() == 42L;
+    assert response.found().get().value().getLong() == 42L;
 
     response = GetResponse.Found.of(3.14);
     assert response.found().isPresent();
-    assert response.found().get().value().getDouble().get() == 3.14;
+    assert response.found().get().value().getDouble() == 3.14;
 
     GetResponse.Error error =
         new GetResponse.Error(

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -40,20 +40,20 @@ public class GetResponseTest {
   @Test
   public void testConvenienceMethodsOnGetResponse() {
     GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
-    assert response.found().isPresent();
-    assert response.found().get().value().getByteArray().get().length == 4;
+    assert response.valueWhenFound().isPresent();
+    assert response.valueWhenFound().get().getByteArray().get().length == 4;
 
     response = GetResponse.Found.of("string");
-    assert response.found().isPresent();
-    assert response.found().get().value().getString().get() == "string";
+    assert response.valueWhenFound().isPresent();
+    assert response.valueWhenFound().get().getString().get() == "string";
 
     response = GetResponse.Found.of(42L);
-    assert response.found().isPresent();
-    assert response.found().get().value().getLong().get() == 42L;
+    assert response.valueWhenFound().isPresent();
+    assert response.valueWhenFound().get().getLong().get() == 42L;
 
     response = GetResponse.Found.of(3.14);
-    assert response.found().isPresent();
-    assert response.found().get().value().getDouble().get() == 3.14;
+    assert response.valueWhenFound().isPresent();
+    assert response.valueWhenFound().get().getDouble().get() == 3.14;
 
     GetResponse.Error error =
         new GetResponse.Error(
@@ -61,7 +61,7 @@ public class GetResponseTest {
                 new Exception(),
                 new MomentoTransportErrorDetails(
                     new MomentoGrpcErrorDetails(Status.Code.NOT_FOUND, "not found"))));
-    assert error.found().isEmpty();
-    assertThrows(ClientSdkException.class, error.found()::orElseThrow);
+    assert error.valueWhenFound().isEmpty();
+    assertThrows(ClientSdkException.class, error.valueWhenFound()::orElseThrow);
   }
 }

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -8,57 +8,56 @@ import org.junit.jupiter.api.Test;
 
 public class GetResponseTest {
   @Test
-  public void testGetResponseSuccessWorksOnTheRightType() {
-    GetResponse.Success response = GetResponse.Success.of(new byte[] {0, 1, 2, 3});
-    assert response.value().get().getByteArray().get().length == 4;
-    assert !response.value().get().getString().isPresent();
-    assert !response.value().get().getLong().isPresent();
-    assert !response.value().get().getDouble().isPresent();
+  public void testGetResponseFoundWorksOnTheRightType() {
+    GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
+    assert response.value().getByteArray().get().length == 4;
+    assert !response.value().getString().isPresent();
+    assert !response.value().getLong().isPresent();
+    assert !response.value().getDouble().isPresent();
 
-    response = GetResponse.Success.of("string");
-    assert !response.value().get().getByteArray().isPresent();
-    assert response.value().get().getString().get().equals("string");
-    assert !response.value().get().getLong().isPresent();
-    assert !response.value().get().getDouble().isPresent();
+    response = GetResponse.Found.of("string");
+    assert !response.value().getByteArray().isPresent();
+    assert response.value().getString().get().equals("string");
+    assert !response.value().getLong().isPresent();
+    assert !response.value().getDouble().isPresent();
 
-    response = GetResponse.Success.of(42L);
-    assert !response.value().get().getByteArray().isPresent();
-    assert !response.value().get().getString().isPresent();
-    assert response.value().get().getLong().get() == 42L;
-    assert !response.value().get().getDouble().isPresent();
+    response = GetResponse.Found.of(42L);
+    assert !response.value().getByteArray().isPresent();
+    assert !response.value().getString().isPresent();
+    assert response.value().getLong().get() == 42L;
+    assert !response.value().getDouble().isPresent();
 
-    response = GetResponse.Success.of(3.14);
-    assert !response.value().get().getByteArray().isPresent();
-    assert !response.value().get().getString().isPresent();
-    assert !response.value().get().getLong().isPresent();
-    assert response.value().get().getDouble().get() == 3.14;
+    response = GetResponse.Found.of(3.14);
+    assert !response.value().getByteArray().isPresent();
+    assert !response.value().getString().isPresent();
+    assert !response.value().getLong().isPresent();
+    assert response.value().getDouble().get() == 3.14;
   }
 
   @Test
   public void testConvenienceMethodsOnGetResponse() {
-    GetResponse.Success response = GetResponse.Success.of(new byte[] {0, 1, 2, 3});
-    assert response.success().isPresent();
-    assert response.success().get().value().get().getByteArray().get().length == 4;
+    GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
+    assert response.found().isPresent();
+    assert response.found().get().value().getByteArray().get().length == 4;
 
-    response = GetResponse.Success.of("string");
-    assert response.success().isPresent();
-    assert response.success().get().value().get().getString().get() == "string";
+    response = GetResponse.Found.of("string");
+    assert response.found().isPresent();
+    assert response.found().get().value().getString().get() == "string";
 
-    response = GetResponse.Success.of(42L);
-    assert response.success().isPresent();
-    assert response.success().get().value().get().getLong().get() == 42L;
+    response = GetResponse.Found.of(42L);
+    assert response.found().isPresent();
+    assert response.found().get().value().getLong().get() == 42L;
 
-    response = GetResponse.Success.of(3.14);
-    assert response.success().isPresent();
-    assert response.success().get().value().get().getDouble().get() == 3.14;
+    response = GetResponse.Found.of(3.14);
+    assert response.found().isPresent();
+    assert response.found().get().value().getDouble().get() == 3.14;
 
-    // TODO distinguish store not found from key not found
     GetResponse.Error error =
         new GetResponse.Error(
             new StoreNotFoundException(
                 new Exception(),
                 new MomentoTransportErrorDetails(
                     new MomentoGrpcErrorDetails(Status.Code.NOT_FOUND, "not found"))));
-    assert !error.success().isPresent();
+    assert !error.found().isPresent();
   }
 }

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -13,47 +13,47 @@ public class GetResponseTest {
   @Test
   public void testGetResponseFoundWorksOnTheRightType() {
     GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
-    assert response.value().getByteArray().length == 4;
-    assertThrows(ClientSdkException.class, response.value()::getString);
-    assertThrows(ClientSdkException.class, response.value()::getLong);
-    assertThrows(ClientSdkException.class, response.value()::getDouble);
+    assert response.value().getByteArray().get().length == 4;
+    assertThrows(ClientSdkException.class, response.value().getString()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.value().getLong()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.value().getDouble()::orElseThrow);
 
     response = GetResponse.Found.of("string");
-    assertThrows(ClientSdkException.class, response.value()::getByteArray);
-    assert response.value().getString().equals("string");
-    assertThrows(ClientSdkException.class, response.value()::getLong);
-    assertThrows(ClientSdkException.class, response.value()::getDouble);
+    assertThrows(ClientSdkException.class, response.value().getByteArray()::orElseThrow);
+    assert response.value().getString().get().equals("string");
+    assertThrows(ClientSdkException.class, response.value().getLong()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.value().getDouble()::orElseThrow);
 
     response = GetResponse.Found.of(42L);
-    assertThrows(ClientSdkException.class, response.value()::getByteArray);
-    assertThrows(ClientSdkException.class, response.value()::getString);
-    assert response.value().getLong() == 42L;
-    assertThrows(ClientSdkException.class, response.value()::getDouble);
+    assertThrows(ClientSdkException.class, response.value().getByteArray()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.value().getString()::orElseThrow);
+    assert response.value().getLong().get() == 42L;
+    assertThrows(ClientSdkException.class, response.value().getDouble()::orElseThrow);
 
     response = GetResponse.Found.of(3.14);
-    assertThrows(ClientSdkException.class, response.value()::getByteArray);
-    assertThrows(ClientSdkException.class, response.value()::getString);
-    assertThrows(ClientSdkException.class, response.value()::getLong);
-    assert response.value().getDouble() == 3.14;
+    assertThrows(ClientSdkException.class, response.value().getByteArray()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.value().getString()::orElseThrow);
+    assertThrows(ClientSdkException.class, response.value().getLong()::orElseThrow);
+    assert response.value().getDouble().get() == 3.14;
   }
 
   @Test
   public void testConvenienceMethodsOnGetResponse() {
     GetResponse.Found response = GetResponse.Found.of(new byte[] {0, 1, 2, 3});
     assert response.found().isPresent();
-    assert response.found().get().value().getByteArray().length == 4;
+    assert response.found().get().value().getByteArray().get().length == 4;
 
     response = GetResponse.Found.of("string");
     assert response.found().isPresent();
-    assert response.found().get().value().getString() == "string";
+    assert response.found().get().value().getString().get() == "string";
 
     response = GetResponse.Found.of(42L);
     assert response.found().isPresent();
-    assert response.found().get().value().getLong() == 42L;
+    assert response.found().get().value().getLong().get() == 42L;
 
     response = GetResponse.Found.of(3.14);
     assert response.found().isPresent();
-    assert response.found().get().value().getDouble() == 3.14;
+    assert response.found().get().value().getDouble().get() == 3.14;
 
     GetResponse.Error error =
         new GetResponse.Error(

--- a/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/responses/storage/GetResponseTest.java
@@ -61,6 +61,7 @@ public class GetResponseTest {
                 new Exception(),
                 new MomentoTransportErrorDetails(
                     new MomentoGrpcErrorDetails(Status.Code.NOT_FOUND, "not found"))));
-    assert !error.found().isPresent();
+    assert error.found().isEmpty();
+    assertThrows(ClientSdkException.class, error.found()::orElseThrow);
   }
 }


### PR DESCRIPTION
1. Split `GetResponse.Success` into `GetResponse.Found` and, in the event the item isn't found, `GetResponse.NotFound`. This sheds the optional on `value`.
2. Add a `valueWhenFound` shortcut accessor on the interface that returns a `MomentoOptional<StorageValue>`.
3. ~~Throw exceptions when `StorageValue::get*` are called on the wrong type. This sheds the `Optional` on those responses.~~ Return a `MomentoOptional` which allows for both optional behavior and custom error messages. A careful user can still switch on `StorageValue::getType` for exhaustiveness checks.
4. ~~Add `GetResponse::asFound` which returns `GetResponseFound` in the event of a `GetResponse.Found` otherwise throws an exception.~~ Will add this on demand per user feedback in order to keep the API slim.
5. Introduce `MomentoOptional` for the convenience of a parameter-less `orElseThrow` method. The `orElseThrow` method will throw a `ClientSdkException` when the optional is empty with an informative error message. This makes using `GetResponse::found` slightly less long winded.