### PR TITLE
refactor: java cache and topics integration tests should use random cache names

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
@@ -25,12 +25,13 @@ import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
 import momento.sdk.responses.cache.control.CacheCreateResponse;
 import momento.sdk.responses.cache.control.CacheDeleteResponse;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AuthClientCacheTests extends BaseTestClass {
-  private AuthClient authClient;
-  private CacheClient cacheClient;
+  private static AuthClient authClient;
+  private static CacheClient cacheClient;
 
   private String cacheName;
 
@@ -38,13 +39,13 @@ public class AuthClientCacheTests extends BaseTestClass {
   String value = "test-value";
   private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
 
-  @BeforeEach
-  void setup() {
+  @BeforeAll
+  static void setup() {
     authClient = AuthClient.builder(credentialProvider).build();
     cacheClient =
         CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
             .build();
-    cacheName = System.getenv("TEST_CACHE_NAME");
+    cacheName = testCacheName();
   }
 
   private CompletableFuture<CacheClient> getClientForTokenScope(DisposableTokenScope scope) {

--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
@@ -25,13 +25,11 @@ import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
 import momento.sdk.responses.cache.control.CacheCreateResponse;
 import momento.sdk.responses.cache.control.CacheDeleteResponse;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class AuthClientCacheTests extends BaseTestClass {
   private static AuthClient authClient;
-  private static String cacheName;
 
   String key = "test-key";
   String value = "test-value";
@@ -39,13 +37,6 @@ public class AuthClientCacheTests extends BaseTestClass {
   @BeforeAll
   static void setup() {
     authClient = AuthClient.builder(credentialProvider).build();
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void tearDown() {
-    cleanupTestCache(cacheName);
   }
 
   private CompletableFuture<CacheClient> getClientForTokenScope(DisposableTokenScope scope) {

--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
@@ -25,27 +25,27 @@ import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
 import momento.sdk.responses.cache.control.CacheCreateResponse;
 import momento.sdk.responses.cache.control.CacheDeleteResponse;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AuthClientCacheTests extends BaseTestClass {
   private static AuthClient authClient;
-  private static CacheClient cacheClient;
-
-  private String cacheName;
+  private static String cacheName;
 
   String key = "test-key";
   String value = "test-value";
-  private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
 
   @BeforeAll
   static void setup() {
     authClient = AuthClient.builder(credentialProvider).build();
-    cacheClient =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-            .build();
     cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    cleanupTestCache(cacheName);
   }
 
   private CompletableFuture<CacheClient> getClientForTokenScope(DisposableTokenScope scope) {
@@ -231,26 +231,31 @@ public class AuthClientCacheTests extends BaseTestClass {
   @Test
   void generateDisposableCacheAuthTokenReadWriteHappyPath()
       throws ExecutionException, InterruptedException {
-    CacheClient readwriteCacheClient =
+    CacheClient readWriteCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheReadWrite(cacheName)).get();
+    try {
+      SetResponse setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
 
-    SetResponse setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+      GetResponse getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
 
-    GetResponse getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      readWriteCacheClient.close();
+      readWriteCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheReadWrite("someothercache")).get();
 
-    readwriteCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheReadWrite("someothercache")).get();
-    setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
 
-    getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    } finally {
+      readWriteCacheClient.close();
+    }
   }
 
   @Test
@@ -258,24 +263,28 @@ public class AuthClientCacheTests extends BaseTestClass {
       throws ExecutionException, InterruptedException {
     CacheClient readWriteCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheReadWrite(cacheName)).get();
-
     CacheClient readOnlyCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheReadOnly(cacheName)).get();
 
-    SetResponse setResponse = readOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+    try {
+      SetResponse setResponse = readOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
 
-    SetResponse setResponseForVerifyingGetResponse =
-        readWriteCacheClient.set(cacheName, key, value).get();
-    assertTrue(
-        setResponseForVerifyingGetResponse instanceof SetResponse.Success,
-        "Unexpected response: " + setResponseForVerifyingGetResponse);
+      SetResponse setResponseForVerifyingGetResponse =
+          readWriteCacheClient.set(cacheName, key, value).get();
+      assertTrue(
+          setResponseForVerifyingGetResponse instanceof SetResponse.Success,
+          "Unexpected response: " + setResponseForVerifyingGetResponse);
 
-    GetResponse getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      GetResponse getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
+    } finally {
+      readWriteCacheClient.close();
+      readOnlyCacheClient.close();
+    }
   }
 
   @Test
@@ -283,28 +292,33 @@ public class AuthClientCacheTests extends BaseTestClass {
       throws ExecutionException, InterruptedException {
     CacheClient readWriteCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheReadWrite(cacheName)).get();
-
     CacheClient writeOnlyCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheWriteOnly(cacheName)).get();
 
-    SetResponse setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+    try {
+      SetResponse setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
 
-    GetResponse getResponse = writeOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      GetResponse getResponse = writeOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    getResponse = readWriteCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
 
-    writeOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheWriteOnly("someothercache")).get();
+      writeOnlyCacheClient.close();
+      writeOnlyCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheWriteOnly("someothercache")).get();
 
-    setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+    } finally {
+      readWriteCacheClient.close();
+      writeOnlyCacheClient.close();
+    }
   }
 
   @Test
@@ -529,36 +543,42 @@ public class AuthClientCacheTests extends BaseTestClass {
   @Test
   void generateDisposableCacheKeyAuthTokenReadWriteHappyPath()
       throws ExecutionException, InterruptedException {
-    CacheClient readwriteCacheClient =
+    CacheClient readWriteCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, key)).get();
 
-    SetResponse setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+    try {
+      SetResponse setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
 
-    GetResponse getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      GetResponse getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
 
-    readwriteCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite("someothercache", key))
-            .get();
-    setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readWriteCacheClient.close();
+      readWriteCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite("someothercache", key))
+              .get();
+      setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    readwriteCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, "someotherkey"))
-            .get();
-    setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readWriteCacheClient.close();
+      readWriteCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, "someotherkey"))
+              .get();
+      setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    } finally {
+      readWriteCacheClient.close();
+    }
   }
 
   @Test
@@ -567,31 +587,38 @@ public class AuthClientCacheTests extends BaseTestClass {
     CacheClient readOnlyCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheKeyReadOnly(cacheName, key)).get();
 
-    SetResponse setResponse = readOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+    try {
+      SetResponse setResponse = readOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
 
-    CacheClient readWriteCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, key)).get();
-    readWriteCacheClient.set(cacheName, key, value).get();
+      CacheClient readWriteCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, key)).get();
+      readWriteCacheClient.set(cacheName, key, value).get();
 
-    GetResponse getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      GetResponse getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
 
-    readOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyReadOnly("someothercache", key)).get();
-    getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readOnlyCacheClient.close();
+      readOnlyCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyReadOnly("someothercache", key))
+              .get();
+      getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    readOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, "someotherkey"))
-            .get();
-    getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readOnlyCacheClient.close();
+      readOnlyCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyReadWrite(cacheName, "someotherkey"))
+              .get();
+      getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    } finally {
+      readOnlyCacheClient.close();
+    }
   }
 
   @Test
@@ -600,25 +627,31 @@ public class AuthClientCacheTests extends BaseTestClass {
     CacheClient writeOnlyCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheKeyWriteOnly(cacheName, key)).get();
 
-    SetResponse setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
-    GetResponse getResponse = writeOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    try {
+      SetResponse setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+      GetResponse getResponse = writeOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    writeOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyWriteOnly("someothercache", key))
-            .get();
-    setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      writeOnlyCacheClient.close();
+      writeOnlyCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyWriteOnly("someothercache", key))
+              .get();
+      setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
 
-    writeOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyWriteOnly(cacheName, "someotherkey"))
-            .get();
-    setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      writeOnlyCacheClient.close();
+      writeOnlyCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyWriteOnly(cacheName, "someotherkey"))
+              .get();
+      setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+    } finally {
+      writeOnlyCacheClient.close();
+    }
   }
 
   @Test
@@ -855,37 +888,44 @@ public class AuthClientCacheTests extends BaseTestClass {
   @Test
   void generateDisposableCacheKeyPrefixAuthTokenReadWriteHappyPath()
       throws ExecutionException, InterruptedException {
-    CacheClient readwriteCacheClient =
+    CacheClient readWriteCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixReadWrite(cacheName, key)).get();
 
-    SetResponse setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+    try {
+      SetResponse setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
 
-    GetResponse getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      GetResponse getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
 
-    readwriteCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixReadWrite("someothercache", key))
-            .get();
-    setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readWriteCacheClient.close();
+      readWriteCacheClient =
+          getClientForTokenScope(
+                  DisposableTokenScopes.cacheKeyPrefixReadWrite("someothercache", key))
+              .get();
+      setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    readwriteCacheClient =
-        getClientForTokenScope(
-                DisposableTokenScopes.cacheKeyPrefixReadWrite(cacheName, "someotherkey"))
-            .get();
-    setResponse = readwriteCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = readwriteCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readWriteCacheClient.close();
+      readWriteCacheClient =
+          getClientForTokenScope(
+                  DisposableTokenScopes.cacheKeyPrefixReadWrite(cacheName, "someotherkey"))
+              .get();
+      setResponse = readWriteCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = readWriteCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    } finally {
+      readWriteCacheClient.close();
+    }
   }
 
   @Test
@@ -894,33 +934,41 @@ public class AuthClientCacheTests extends BaseTestClass {
     CacheClient readOnlyCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixReadOnly(cacheName, key)).get();
 
-    SetResponse setResponse = readOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+    try {
+      SetResponse setResponse = readOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
 
-    CacheClient readWriteCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixReadWrite(cacheName, key)).get();
-    readWriteCacheClient.set(cacheName, key, value).get();
+      CacheClient readWriteCacheClient =
+          getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixReadWrite(cacheName, key))
+              .get();
+      readWriteCacheClient.set(cacheName, key, value).get();
 
-    GetResponse getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals(value, hit.valueString());
+      GetResponse getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals(value, hit.valueString());
 
-    readOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixReadOnly("someothercache", key))
-            .get();
-    getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readOnlyCacheClient.close();
+      readOnlyCacheClient =
+          getClientForTokenScope(
+                  DisposableTokenScopes.cacheKeyPrefixReadOnly("someothercache", key))
+              .get();
+      getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    readOnlyCacheClient =
-        getClientForTokenScope(
-                DisposableTokenScopes.cacheKeyPrefixReadOnly(cacheName, "someotherkey"))
-            .get();
-    getResponse = readOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      readOnlyCacheClient.close();
+      readOnlyCacheClient =
+          getClientForTokenScope(
+                  DisposableTokenScopes.cacheKeyPrefixReadOnly(cacheName, "someotherkey"))
+              .get();
+      getResponse = readOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    } finally {
+      readOnlyCacheClient.close();
+    }
   }
 
   @Test
@@ -929,26 +977,33 @@ public class AuthClientCacheTests extends BaseTestClass {
     CacheClient writeOnlyCacheClient =
         getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixWriteOnly(cacheName, key)).get();
 
-    SetResponse setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
-    GetResponse getResponse = writeOnlyCacheClient.get(cacheName, key).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    try {
+      SetResponse setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+      GetResponse getResponse = writeOnlyCacheClient.get(cacheName, key).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    writeOnlyCacheClient =
-        getClientForTokenScope(DisposableTokenScopes.cacheKeyPrefixWriteOnly("someothercache", key))
-            .get();
-    setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      writeOnlyCacheClient.close();
+      writeOnlyCacheClient =
+          getClientForTokenScope(
+                  DisposableTokenScopes.cacheKeyPrefixWriteOnly("someothercache", key))
+              .get();
+      setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
 
-    writeOnlyCacheClient =
-        getClientForTokenScope(
-                DisposableTokenScopes.cacheKeyPrefixWriteOnly(cacheName, "someotherkey"))
-            .get();
-    setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      writeOnlyCacheClient.close();
+      writeOnlyCacheClient =
+          getClientForTokenScope(
+                  DisposableTokenScopes.cacheKeyPrefixWriteOnly(cacheName, "someotherkey"))
+              .get();
+      setResponse = writeOnlyCacheClient.set(cacheName, key, value).get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+    } finally {
+      writeOnlyCacheClient.close();
+    }
   }
 
   // Tests using DisposableTokenScopes composed of multiple permissions
@@ -970,78 +1025,84 @@ public class AuthClientCacheTests extends BaseTestClass {
 
     CacheClient client = getClientForTokenScope(scope).get();
 
-    // Test read/write on specified key and key prefix
-    SetResponse setResponse = client.set(cacheName, "cow", "moo").get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
-    GetResponse getResponse = client.get(cacheName, "cow").get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit = (GetResponse.Hit) getResponse;
-    assertEquals("moo", hit.valueString());
+    try {
+      // Test read/write on specified key and key prefix
+      SetResponse setResponse = client.set(cacheName, "cow", "moo").get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+      GetResponse getResponse = client.get(cacheName, "cow").get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
+      assertEquals("moo", hit.valueString());
 
-    setResponse = client.set(cacheName, "pet-cat", "meow").get();
-    assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
-    getResponse = client.get(cacheName, "pet-cat").get();
-    assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
-    GetResponse.Hit hit2 = (GetResponse.Hit) getResponse;
-    assertEquals("meow", hit2.valueString());
+      setResponse = client.set(cacheName, "pet-cat", "meow").get();
+      assertTrue(setResponse instanceof SetResponse.Success, "Unexpected response: " + setResponse);
+      getResponse = client.get(cacheName, "pet-cat").get();
+      assertTrue(getResponse instanceof GetResponse.Hit, "Unexpected response: " + getResponse);
+      GetResponse.Hit hit2 = (GetResponse.Hit) getResponse;
+      assertEquals("meow", hit2.valueString());
 
-    // Test read/write on a different cache or unspecified key/prefix
-    setResponse = client.set(cacheName, "giraffe", "noidea").get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = client.get(cacheName, "giraffe").get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      // Test read/write on a different cache or unspecified key/prefix
+      setResponse = client.set(cacheName, "giraffe", "noidea").get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = client.get(cacheName, "giraffe").get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    // Test read/write on specified key and key prefix to a different cache
-    permissions = new ArrayList<>();
-    permissions.add(
-        new DisposableToken.CacheItemPermission(
-            CacheRole.ReadWrite,
-            CacheSelector.ByName("a-totally-different-cache"),
-            CacheItemSelector.ByKey("cow")));
-    permissions.add(
-        new DisposableToken.CacheItemPermission(
-            CacheRole.ReadWrite,
-            CacheSelector.ByName("a-totally-different-cache"),
-            CacheItemSelector.ByKeyPrefix("pet")));
-    scope = new DisposableTokenScope(permissions);
+      // Test read/write on specified key and key prefix to a different cache
+      permissions = new ArrayList<>();
+      permissions.add(
+          new DisposableToken.CacheItemPermission(
+              CacheRole.ReadWrite,
+              CacheSelector.ByName("a-totally-different-cache"),
+              CacheItemSelector.ByKey("cow")));
+      permissions.add(
+          new DisposableToken.CacheItemPermission(
+              CacheRole.ReadWrite,
+              CacheSelector.ByName("a-totally-different-cache"),
+              CacheItemSelector.ByKeyPrefix("pet")));
+      scope = new DisposableTokenScope(permissions);
 
-    client = getClientForTokenScope(scope).get();
+      client.close();
+      client = getClientForTokenScope(scope).get();
 
-    setResponse = client.set(cacheName, "cow", "moo").get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = client.get(cacheName, "cow").get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      setResponse = client.set(cacheName, "cow", "moo").get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = client.get(cacheName, "cow").get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
 
-    setResponse = client.set(cacheName, "pet-cat", "meow").get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
-    getResponse = client.get(cacheName, "pet-cat").get();
-    assertEquals(
-        MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+      setResponse = client.set(cacheName, "pet-cat", "meow").get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((SetResponse.Error) setResponse).getErrorCode());
+      getResponse = client.get(cacheName, "pet-cat").get();
+      assertEquals(
+          MomentoErrorCode.PERMISSION_ERROR, ((GetResponse.Error) getResponse).getErrorCode());
+    } finally {
+      client.close();
+    }
   }
 
   @Test
   void generateDisposableMultiPermissionReadOnlyWithSelectorsAllCaches() {
     String cache2Name = cacheName + "-2";
+
+    List<DisposableTokenPermission> permissions = new ArrayList<>();
+    permissions.add(
+        new DisposableToken.CacheItemPermission(
+            CacheRole.ReadOnly, CacheSelector.AllCaches, CacheItemSelector.ByKey("cow")));
+    permissions.add(
+        new DisposableToken.CacheItemPermission(
+            CacheRole.ReadOnly, CacheSelector.AllCaches, CacheItemSelector.ByKeyPrefix("pet")));
+    DisposableTokenScope scope = new DisposableTokenScope(permissions);
+    CacheClient client = getClientForTokenScope(scope).join();
+
     try {
       CacheCreateResponse createCacheResponse = cacheClient.createCache(cache2Name).get();
       assertTrue(
           createCacheResponse instanceof CacheCreateResponse.Success,
           "Unexpected response: " + createCacheResponse);
-
-      List<DisposableTokenPermission> permissions = new ArrayList<>();
-      permissions.add(
-          new DisposableToken.CacheItemPermission(
-              CacheRole.ReadOnly, CacheSelector.AllCaches, CacheItemSelector.ByKey("cow")));
-      permissions.add(
-          new DisposableToken.CacheItemPermission(
-              CacheRole.ReadOnly, CacheSelector.AllCaches, CacheItemSelector.ByKeyPrefix("pet")));
-      DisposableTokenScope scope = new DisposableTokenScope(permissions);
-      CacheClient client = getClientForTokenScope(scope).get();
 
       // sets should fail for both caches
       SetResponse setResponse = client.set(cacheName, "cow", "moo").get();
@@ -1092,31 +1153,31 @@ public class AuthClientCacheTests extends BaseTestClass {
       CacheDeleteResponse response = cacheClient.deleteCache(cache2Name).join();
       assertTrue(
           response instanceof CacheDeleteResponse.Success, "Unexpected response: " + response);
+      client.close();
     }
   }
 
   @Test
   void generateDisposableMultiPermissionReadOnlyWriteOnly() {
     String cache2Name = cacheName + "-2";
+
+    List<DisposableTokenPermission> permissions = new ArrayList<>();
+    permissions.add(
+        new DisposableToken.CacheItemPermission(
+            CacheRole.WriteOnly, CacheSelector.ByName(cacheName), CacheItemSelector.ByKey("cow")));
+    permissions.add(
+        new DisposableToken.CacheItemPermission(
+            CacheRole.ReadOnly,
+            CacheSelector.ByName(cache2Name),
+            CacheItemSelector.ByKeyPrefix("pet")));
+    DisposableTokenScope scope = new DisposableTokenScope(permissions);
+    CacheClient client = getClientForTokenScope(scope).join();
+
     try {
       CacheCreateResponse createCacheResponse = cacheClient.createCache(cache2Name).get();
       assertTrue(
           createCacheResponse instanceof CacheCreateResponse.Success,
           "Unexpected response: " + createCacheResponse);
-
-      List<DisposableTokenPermission> permissions = new ArrayList<>();
-      permissions.add(
-          new DisposableToken.CacheItemPermission(
-              CacheRole.WriteOnly,
-              CacheSelector.ByName(cacheName),
-              CacheItemSelector.ByKey("cow")));
-      permissions.add(
-          new DisposableToken.CacheItemPermission(
-              CacheRole.ReadOnly,
-              CacheSelector.ByName(cache2Name),
-              CacheItemSelector.ByKeyPrefix("pet")));
-      DisposableTokenScope scope = new DisposableTokenScope(permissions);
-      CacheClient client = getClientForTokenScope(scope).get();
 
       // we can write to only one key and not read in test cache
       SetResponse setResponse = client.set(cacheName, "cow", "moo").get();
@@ -1157,6 +1218,7 @@ public class AuthClientCacheTests extends BaseTestClass {
       CacheDeleteResponse response = cacheClient.deleteCache(cache2Name).join();
       assertTrue(
           response instanceof CacheDeleteResponse.Success, "Unexpected response: " + response);
+      client.close();
     }
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientTopicTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientTopicTests.java
@@ -10,18 +10,18 @@ import momento.sdk.auth.accessControl.ExpiresIn;
 import momento.sdk.auth.accessControl.TopicSelector;
 import momento.sdk.exceptions.MomentoErrorCode;
 import momento.sdk.responses.auth.GenerateDisposableTokenResponse;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class AuthClientTopicTests extends BaseTestClass {
-  private AuthClient authClient;
-  private String cacheName;
-  private String topicName = "topic";
+  private static AuthClient authClient;
+  private static String cacheName;
+  private static String topicName = "topic";
 
-  @BeforeEach
-  void setup() {
+  @BeforeAll
+  static void setup() {
     authClient = AuthClient.builder(credentialProvider).build();
-    cacheName = System.getenv("TEST_CACHE_NAME");
+    cacheName = testCacheName();
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientTopicTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientTopicTests.java
@@ -15,13 +15,11 @@ import org.junit.jupiter.api.Test;
 
 public class AuthClientTopicTests extends BaseTestClass {
   private static AuthClient authClient;
-  private static String cacheName;
   private static String topicName = "topic";
 
   @BeforeAll
   static void setup() {
     authClient = AuthClient.builder(credentialProvider).build();
-    cacheName = testCacheName();
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/BaseTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/BaseTestClass.java
@@ -1,12 +1,15 @@
 package momento.sdk;
 
 import java.time.Duration;
+import java.util.UUID;
+
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configurations;
 import org.junit.jupiter.api.BeforeAll;
 
 public class BaseTestClass {
   public static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
+  public static final Duration TEN_SECONDS = Duration.ofSeconds(10);
 
   public static final CredentialProvider credentialProvider =
       CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
@@ -17,19 +20,31 @@ public class BaseTestClass {
       throw new IllegalArgumentException(
           "Integration tests require TEST_AUTH_TOKEN env var; see README for more details.");
     }
-    if (System.getenv("TEST_CACHE_NAME") == null) {
-      throw new IllegalArgumentException(
-          "Integration tests require TEST_CACHE_NAME env var; see README for more details.");
-    }
-    ensureTestCacheExists();
   }
 
-  private static void ensureTestCacheExists() {
+  private static void ensureTestCacheExists(String cacheName) {
     try (CacheClient client =
         CacheClient.builder(
-                credentialProvider, Configurations.Laptop.latest(), Duration.ofSeconds(10))
+                credentialProvider, Configurations.Laptop.latest(), TEN_SECONDS)
             .build()) {
-      client.createCache(System.getenv("TEST_CACHE_NAME")).join();
+      client.createCache(cacheName).join();
     }
+  }
+
+  public static void cleanupTestCache(String cacheName) {
+    try (CacheClient client =
+        CacheClient.builder(
+                credentialProvider, Configurations.Laptop.latest(), TEN_SECONDS)
+            .build()) {
+      client.deleteCache(cacheName).join();
+    }
+  }
+
+  public static String testCacheName() {
+    return "java-integration-test-default-" + UUID.randomUUID().toString();
+  }
+
+  public static String testStoreName() {
+    return "java-integration-test-default-" + UUID.randomUUID().toString();
   }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/BaseTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/BaseTestClass.java
@@ -12,11 +12,10 @@ import org.junit.jupiter.api.BeforeAll;
 public class BaseTestClass {
   protected static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
   protected static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
-  protected static final Duration TEN_SECONDS = Duration.ofSeconds(10);
-
   protected static CredentialProvider credentialProvider;
 
   protected static CacheClient cacheClient;
+  protected static String cacheName;
 
   @BeforeAll
   static void beforeAll() {
@@ -24,10 +23,13 @@ public class BaseTestClass {
     cacheClient =
         CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
             .build();
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
   @AfterAll
   static void afterAll() {
+    cleanupTestCache(cacheName);
     cacheClient.close();
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
@@ -1,5 +1,6 @@
 package momento.sdk;
 
+import static momento.sdk.TestUtils.randomBytes;
 import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -29,18 +30,13 @@ import momento.sdk.responses.cache.control.CacheFlushResponse;
 import momento.sdk.responses.cache.ttl.ItemGetTtlResponse;
 import momento.sdk.responses.cache.ttl.UpdateTtlResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Just includes a happy test path that interacts with both control and data plane clients. */
 final class CacheClientTest extends BaseTestClass {
-
-  private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
-
-  private CacheClient target;
-
-  private String cacheName;
+  private static String cacheName;
 
   private static final String JWT_HEADER_BASE64 = "eyJhbGciOiJIUzUxMiJ9";
   private static final String JWT_INVALID_SIGNATURE_BASE64 =
@@ -75,19 +71,15 @@ final class CacheClientTest extends BaseTestClass {
   private static final CredentialProvider BAD_DATA_PLANE_PROVIDER =
       new StringCredentialProvider(BAD_DATA_PLANE_JWT);
 
-  @BeforeEach
-  void setup() {
-    target =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-            .build();
-    cacheName = System.getenv("TEST_CACHE_NAME");
-    target.createCache(cacheName).join();
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
-  @AfterEach
-  void teardown() {
-    target.deleteCache(cacheName).join();
-    target.close();
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
   }
 
   @Test
@@ -96,56 +88,59 @@ final class CacheClientTest extends BaseTestClass {
     final String key = randomString("key");
     final String value = randomString("value");
 
-    target.createCache(alternateCacheName).join();
+    cacheClient.createCache(alternateCacheName).join();
     try {
-      target.set(cacheName, key, value).join();
+      cacheClient.set(cacheName, key, value).join();
 
-      final GetResponse getResponse = target.get(cacheName, key).join();
+      final GetResponse getResponse = cacheClient.get(cacheName, key).join();
       assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
       assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(value);
 
-      final DeleteResponse deleteResponse = target.delete(cacheName, key).join();
+      final DeleteResponse deleteResponse = cacheClient.delete(cacheName, key).join();
       assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
 
-      final GetResponse getAfterDeleteResponse = target.get(cacheName, key).join();
+      final GetResponse getAfterDeleteResponse = cacheClient.get(cacheName, key).join();
       assertThat(getAfterDeleteResponse).isInstanceOf(GetResponse.Miss.class);
 
-      final GetResponse getForKeyInSomeOtherCache = target.get(alternateCacheName, key).join();
+      final GetResponse getForKeyInSomeOtherCache = cacheClient.get(alternateCacheName, key).join();
       assertThat(getForKeyInSomeOtherCache).isInstanceOf(GetResponse.Miss.class);
     } finally {
-      target.deleteCache(alternateCacheName).join();
+      cacheClient.deleteCache(alternateCacheName).join();
     }
   }
 
   @Test
   public void shouldFlushCacheContents() {
-    final String key = randomString("key");
-    final String value = randomString("value");
+    final String cacheToFlush = randomString("cacheToFlush");
+    final String key = randomString();
+    final String value = randomString();
     final Duration ttl1Hour = Duration.ofHours(1);
 
     try {
-      assertThat(target.set(cacheName, key, value, ttl1Hour))
+      CacheCreateResponse response = cacheClient.createCache(cacheToFlush).join();
+      assertThat(response).isInstanceOf(CacheCreateResponse.Success.class);
+      assertThat(cacheClient.set(cacheName, key, value, ttl1Hour))
           .succeedsWithin(FIVE_SECONDS)
           .asInstanceOf(InstanceOfAssertFactories.type(SetResponse.Success.class))
           .satisfies(success -> assertThat(success.value()).isEqualTo(value));
 
       // Execute Flush
-      assertThat(target.flushCache(cacheName))
+      assertThat(cacheClient.flushCache(cacheName))
           .succeedsWithin(FIVE_SECONDS)
           .isInstanceOf(CacheFlushResponse.Success.class);
 
       // Verify that previously set key is now a MISS
-      assertThat(target.get(cacheName, key))
+      assertThat(cacheClient.get(cacheName, key))
           .succeedsWithin(FIVE_SECONDS)
           .isInstanceOf(GetResponse.Miss.class);
     } finally {
-      target.deleteCache(cacheName).join();
+      cacheClient.deleteCache(cacheToFlush).join();
     }
   }
 
   @Test
   public void shouldReturnNotFoundWhenCacheToFlushDoesNotExist() {
-    assertThat(target.flushCache(randomString("name")))
+    assertThat(cacheClient.flushCache(randomString("name")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheFlushResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
@@ -153,7 +148,7 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void shouldReturnIllegalArgWhenCacheNameToFlushIsInvalid() {
-    assertThat(target.flushCache(null))
+    assertThat(cacheClient.flushCache(null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheFlushResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -230,14 +225,14 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void shouldUpdateTTLAndGetItWithStringKey() {
-    final String key = "updateTTlGetTTLTestString";
+    final String key = randomString();
 
     // set a key with default ttl
-    SetResponse setResponse = target.set(cacheName, key, "value", DEFAULT_TTL_SECONDS).join();
+    SetResponse setResponse = cacheClient.set(cacheName, key, "value", DEFAULT_TTL_SECONDS).join();
 
     assertThat(setResponse).isInstanceOf(SetResponse.Success.class);
 
-    ItemGetTtlResponse itemGetTtlResponse = target.itemGetTtl(cacheName, key).join();
+    ItemGetTtlResponse itemGetTtlResponse = cacheClient.itemGetTtl(cacheName, key).join();
 
     // retrieved ttl should work and less than default ttl
     assertThat(itemGetTtlResponse).isInstanceOf(ItemGetTtlResponse.Hit.class);
@@ -246,11 +241,11 @@ final class CacheClientTest extends BaseTestClass {
 
     // update ttl to 300 seconds
     Duration updatedTTL = Duration.of(300, ChronoUnit.SECONDS);
-    UpdateTtlResponse updateTtlResponse = target.updateTtl(cacheName, key, updatedTTL).join();
+    UpdateTtlResponse updateTtlResponse = cacheClient.updateTtl(cacheName, key, updatedTTL).join();
 
     assertThat(updateTtlResponse).isInstanceOf(UpdateTtlResponse.Set.class);
 
-    itemGetTtlResponse = target.itemGetTtl(cacheName, key).join();
+    itemGetTtlResponse = cacheClient.itemGetTtl(cacheName, key).join();
 
     // assert that the updated ttl is less than 300 seconds but more than 300 - epsilon (taken as 60
     // to reduce flakiness)
@@ -263,15 +258,15 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void shouldUpdateTTLAndGetItWithByteArrayKey() {
-    final byte[] key = "updateTTlGetTTLTestByteArray".getBytes();
+    final byte[] key = randomBytes();
 
     // set a key with default ttl
     SetResponse setResponse =
-        target.set(cacheName, key, "value".getBytes(), DEFAULT_TTL_SECONDS).join();
+        cacheClient.set(cacheName, key, "value".getBytes(), DEFAULT_TTL_SECONDS).join();
 
     assertThat(setResponse).isInstanceOf(SetResponse.Success.class);
 
-    ItemGetTtlResponse itemGetTtlResponse = target.itemGetTtl(cacheName, key).join();
+    ItemGetTtlResponse itemGetTtlResponse = cacheClient.itemGetTtl(cacheName, key).join();
 
     // retrieved ttl should work and less than default ttl
     assertThat(itemGetTtlResponse).isInstanceOf(ItemGetTtlResponse.Hit.class);
@@ -280,11 +275,11 @@ final class CacheClientTest extends BaseTestClass {
 
     // update ttl to 300 seconds
     Duration updatedTTL = Duration.of(300, ChronoUnit.SECONDS);
-    UpdateTtlResponse updateTtlResponse = target.updateTtl(cacheName, key, updatedTTL).join();
+    UpdateTtlResponse updateTtlResponse = cacheClient.updateTtl(cacheName, key, updatedTTL).join();
 
     assertThat(updateTtlResponse).isInstanceOf(UpdateTtlResponse.Set.class);
 
-    itemGetTtlResponse = target.itemGetTtl(cacheName, key).join();
+    itemGetTtlResponse = cacheClient.itemGetTtl(cacheName, key).join();
 
     // assert that the updated ttl is less than 300 seconds but more than 300 - epsilon (taken as 60
     // to reduce flakiness)
@@ -297,10 +292,10 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void throwsOnUpdateTTLWhenNegative() {
-    final byte[] key = "updateTTlGetTTLTestByteArray".getBytes();
+    final byte[] key = randomBytes();
 
     UpdateTtlResponse updateTtlResponse =
-        target.updateTtl(cacheName, key, Duration.of(-1, ChronoUnit.SECONDS)).join();
+        cacheClient.updateTtl(cacheName, key, Duration.of(-1, ChronoUnit.SECONDS)).join();
     assertThat(updateTtlResponse).isInstanceOf(UpdateTtlResponse.Error.class);
     assertThat(((UpdateTtlResponse.Error) updateTtlResponse).getMessage())
         .contains("Cache item TTL cannot be negative");
@@ -308,166 +303,166 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void shouldReturnCacheIncrementedValuesWithStringField() {
-    final String field = "field";
+    final String field = randomString();
 
     IncrementResponse incrementResponse =
-        target.increment(cacheName, field, 1, DEFAULT_TTL_SECONDS).join();
+        cacheClient.increment(cacheName, field, 1, DEFAULT_TTL_SECONDS).join();
 
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Success.class);
     assertThat(((IncrementResponse.Success) incrementResponse).valueNumber()).isEqualTo(1);
 
     // increment with ttl specified
-    incrementResponse = target.increment(cacheName, field, 50, DEFAULT_TTL_SECONDS).join();
+    incrementResponse = cacheClient.increment(cacheName, field, 50, DEFAULT_TTL_SECONDS).join();
 
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Success.class);
     assertThat(((IncrementResponse.Success) incrementResponse).valueNumber()).isEqualTo(51);
 
     // increment without ttl specified
-    incrementResponse = target.increment(cacheName, field, -1051).join();
+    incrementResponse = cacheClient.increment(cacheName, field, -1051).join();
 
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Success.class);
     assertThat(((IncrementResponse.Success) incrementResponse).valueNumber()).isEqualTo(-1000);
 
-    GetResponse getResp = target.get(cacheName, field).join();
+    GetResponse getResp = cacheClient.get(cacheName, field).join();
     assertThat(getResp).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResp).valueString()).isEqualTo("-1000");
   }
 
   @Test
   public void shouldReturnCacheIncrementedValuesWithByteArrayField() {
-    final byte[] field = "field".getBytes();
+    final byte[] field = randomBytes();
 
     IncrementResponse incrementResponse =
-        target.increment(cacheName, field, 1, DEFAULT_TTL_SECONDS).join();
+        cacheClient.increment(cacheName, field, 1, DEFAULT_TTL_SECONDS).join();
 
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Success.class);
     assertThat(((IncrementResponse.Success) incrementResponse).valueNumber()).isEqualTo(1);
 
     // increment with ttl specified
-    incrementResponse = target.increment(cacheName, field, 50, DEFAULT_TTL_SECONDS).join();
+    incrementResponse = cacheClient.increment(cacheName, field, 50, DEFAULT_TTL_SECONDS).join();
 
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Success.class);
     assertThat(((IncrementResponse.Success) incrementResponse).valueNumber()).isEqualTo(51);
 
     // increment without ttl specified
-    incrementResponse = target.increment(cacheName, field, -1051).join();
+    incrementResponse = cacheClient.increment(cacheName, field, -1051).join();
 
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Success.class);
     assertThat(((IncrementResponse.Success) incrementResponse).valueNumber()).isEqualTo(-1000);
 
-    GetResponse getResp = target.get(cacheName, field).join();
+    GetResponse getResp = cacheClient.get(cacheName, field).join();
     assertThat(getResp).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResp).valueString()).isEqualTo("-1000");
   }
 
   @Test
   public void shouldFailCacheIncrementedValuesWhenNullCacheName() {
-    final String field = "field";
+    final String field = randomString();
 
     // With ttl specified
     IncrementResponse incrementResponse =
-        target.increment(null, field, 1, DEFAULT_TTL_SECONDS).join();
+        cacheClient.increment(null, field, 1, DEFAULT_TTL_SECONDS).join();
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Error.class);
 
     // Without ttl specified
-    incrementResponse = target.increment(null, field, 1).join();
+    incrementResponse = cacheClient.increment(null, field, 1).join();
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Error.class);
   }
 
   @Test
   public void shouldFailCacheIncrementedValuesWhenCacheNotExist() {
-    final String cacheName = "fake-cache";
-    final String field = "field";
+    final String cacheName = randomString("fake-cache");
+    final String field = randomString();
 
     // With ttl specified
     IncrementResponse incrementResponse =
-        target.increment(cacheName, field, 1, DEFAULT_TTL_SECONDS).join();
+        cacheClient.increment(cacheName, field, 1, DEFAULT_TTL_SECONDS).join();
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Error.class);
 
     // Without ttl specified
-    incrementResponse = target.increment(cacheName, field, 1).join();
+    incrementResponse = cacheClient.increment(cacheName, field, 1).join();
     assertThat(incrementResponse).isInstanceOf(IncrementResponse.Error.class);
   }
 
   @Test
   public void shouldSetStringValueToStringKeyWhenKeyNotExistsWithTtl() {
-    final String key = randomString("test-key");
-    final String value = randomString("test-value");
+    final String key = randomString();
+    final String value = randomString();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyString()).isEqualTo(key);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueString())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetStringValueToStringKeyWhenKeyNotExistsWithoutTtl() {
-    final String key = randomString("test-key");
-    final String value = randomString("test-value");
+    final String key = randomString();
+    final String value = randomString();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value).join();
+        cacheClient.setIfNotExists(cacheName, key, value).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyString()).isEqualTo(key);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueString())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetByteArrayValueToStringKeyWhenKeyNotExistsWithTtl() {
-    final String key = randomString("test-key");
-    final byte[] value = "test-value".getBytes();
+    final String key = randomString();
+    final byte[] value = randomBytes();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyString()).isEqualTo(key);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueByteArray())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueByteArray()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetByteArrayValueToStringKeyWhenKeyNotExistsWithoutTtl() {
-    final String key = randomString("test-key");
-    final byte[] value = "test-value".getBytes();
+    final String key = randomString();
+    final byte[] value = randomBytes();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value).join();
+        cacheClient.setIfNotExists(cacheName, key, value).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyString()).isEqualTo(key);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueByteArray())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueByteArray()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetStringValueToByteArrayKeyWhenKeyNotExistsWithTtl() {
-    final byte[] key = "test-key".getBytes();
-    final String value = "test-value";
+    final byte[] key = randomBytes();
+    final String value = randomString();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyByteArray())
@@ -475,18 +470,18 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueString())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetStringValueToByteArrayKeyWhenKeyNotExistsWithoutTtl() {
-    final byte[] key = "test-key".getBytes();
-    final String value = "test-value";
+    final byte[] key = randomBytes();
+    final String value = randomString();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value).join();
+        cacheClient.setIfNotExists(cacheName, key, value).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyByteArray())
@@ -494,18 +489,18 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueString())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetByteArrayValueToByteArrayKeyWhenKeyNotExistsWithttl() {
-    final byte[] key = "test-key".getBytes();
-    final byte[] value = "test-value".getBytes();
+    final byte[] key = randomBytes();
+    final byte[] value = randomBytes();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyByteArray())
@@ -513,18 +508,18 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueByteArray())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueByteArray()).isEqualTo(value);
   }
 
   @Test
   public void shouldSetByteArrayValueToByteArrayKeyWhenKeyNotExistsWithoutTtl() {
-    final byte[] key = "test-key".getBytes();
-    final byte[] value = "test-value".getBytes();
+    final byte[] key = randomBytes();
+    final byte[] value = randomBytes();
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value).join();
+        cacheClient.setIfNotExists(cacheName, key, value).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyByteArray())
@@ -532,19 +527,19 @@ final class CacheClientTest extends BaseTestClass {
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).valueByteArray())
         .isEqualTo(value);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueByteArray()).isEqualTo(value);
   }
 
   @Test
   public void shouldNotSetValueToKeyWhenKeyExists() {
-    final String key = "test-key";
+    final String key = randomString();
     final String oldValue = "old-test-value";
     final String newValue = "new-test-value";
 
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, oldValue, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, oldValue, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Stored.class);
     assertThat(((SetIfNotExistsResponse.Stored) setIfNotExistsResponse).keyString()).isEqualTo(key);
@@ -553,20 +548,20 @@ final class CacheClientTest extends BaseTestClass {
 
     // When ttl is specified
     setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, newValue, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, newValue, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.NotStored.class);
 
-    GetResponse getResponse = target.get(cacheName, key).join();
+    GetResponse getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(oldValue);
 
     // When ttl is not specified
-    setIfNotExistsResponse = target.setIfNotExists(cacheName, key, newValue).join();
+    setIfNotExistsResponse = cacheClient.setIfNotExists(cacheName, key, newValue).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.NotStored.class);
 
-    getResponse = target.get(cacheName, key).join();
+    getResponse = cacheClient.get(cacheName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Hit.class);
     assertThat(((GetResponse.Hit) getResponse).valueString()).isEqualTo(oldValue);
   }
@@ -574,34 +569,34 @@ final class CacheClientTest extends BaseTestClass {
   @Test
   public void shouldFailSetValueToKeyWhenCacheNotExist() {
     final String cacheName = "fake-cache";
-    final String key = "test-key";
+    final String key = randomString();
     final String value = "old-test-value";
 
     // With ttl specified
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(cacheName, key, value, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Error.class);
 
     // Without ttl specified
-    setIfNotExistsResponse = target.setIfNotExists(cacheName, key, value).join();
+    setIfNotExistsResponse = cacheClient.setIfNotExists(cacheName, key, value).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Error.class);
   }
 
   @Test
   public void shouldFailSetValueToKeyWhenNullCacheName() {
-    final String key = "test-key";
+    final String key = randomString();
     final String value = "old-test-value";
 
     // With ttl specified
     SetIfNotExistsResponse setIfNotExistsResponse =
-        target.setIfNotExists(null, key, value, DEFAULT_TTL_SECONDS).join();
+        cacheClient.setIfNotExists(null, key, value, DEFAULT_TTL_SECONDS).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Error.class);
 
     // Without ttl specified
-    setIfNotExistsResponse = target.setIfNotExists(null, key, value).join();
+    setIfNotExistsResponse = cacheClient.setIfNotExists(null, key, value).join();
 
     assertThat(setIfNotExistsResponse).isInstanceOf(SetIfNotExistsResponse.Error.class);
   }
@@ -613,14 +608,15 @@ final class CacheClientTest extends BaseTestClass {
     items.put("key2", "val2");
     items.put("key3", "val3");
     final SetBatchResponse setBatchResponse =
-        target.setBatch(cacheName, items, Duration.ofMinutes(1)).join();
+        cacheClient.setBatch(cacheName, items, Duration.ofMinutes(1)).join();
     assertThat(setBatchResponse).isInstanceOf(SetBatchResponse.Success.class);
     for (SetResponse setResponse :
         ((SetBatchResponse.Success) setBatchResponse).results().values()) {
       assertThat(setResponse).isInstanceOf(SetResponse.Success.class);
     }
 
-    final GetBatchResponse getBatchResponse = target.getBatch(cacheName, items.keySet()).join();
+    final GetBatchResponse getBatchResponse =
+        cacheClient.getBatch(cacheName, items.keySet()).join();
 
     assertThat(getBatchResponse).isInstanceOf(GetBatchResponse.Success.class);
     assertThat(((GetBatchResponse.Success) getBatchResponse).valueMapStringString())
@@ -629,7 +625,7 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void getBatchFailsWithNullCacheName() {
-    assertThat(target.getBatch(null, new ArrayList<>()))
+    assertThat(cacheClient.getBatch(null, new ArrayList<>()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(GetBatchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -640,7 +636,7 @@ final class CacheClientTest extends BaseTestClass {
     final List<String> items = new ArrayList<>();
     items.add("key1");
 
-    assertThat(target.getBatch(randomString("cache"), items))
+    assertThat(cacheClient.getBatch(randomString("cache"), items))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(GetBatchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
@@ -648,7 +644,7 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void setBatchFailsWithNullCacheName() {
-    assertThat(target.setBatch(null, new HashMap<>()))
+    assertThat(cacheClient.setBatch(null, new HashMap<>()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetBatchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -659,7 +655,7 @@ final class CacheClientTest extends BaseTestClass {
     final Map<String, String> items = new HashMap<>();
     items.put("key1", "val1");
 
-    assertThat(target.setBatch(randomString("cache"), items))
+    assertThat(cacheClient.setBatch(randomString("cache"), items))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetBatchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
@@ -672,14 +668,15 @@ final class CacheClientTest extends BaseTestClass {
     items.put("key2", "val2".getBytes());
     items.put("key3", "val3".getBytes());
     final SetBatchResponse setBatchResponse =
-        target.setBatchStringBytes(cacheName, items, Duration.ofMinutes(1)).join();
+        cacheClient.setBatchStringBytes(cacheName, items, Duration.ofMinutes(1)).join();
     assertThat(setBatchResponse).isInstanceOf(SetBatchResponse.Success.class);
     for (SetResponse setResponse :
         ((SetBatchResponse.Success) setBatchResponse).results().values()) {
       assertThat(setResponse).isInstanceOf(SetResponse.Success.class);
     }
 
-    final GetBatchResponse getBatchResponse = target.getBatch(cacheName, items.keySet()).join();
+    final GetBatchResponse getBatchResponse =
+        cacheClient.getBatch(cacheName, items.keySet()).join();
 
     assertThat(getBatchResponse).isInstanceOf(GetBatchResponse.Success.class);
     assertThat(((GetBatchResponse.Success) getBatchResponse).valueMapStringByteArray())
@@ -688,7 +685,7 @@ final class CacheClientTest extends BaseTestClass {
 
   @Test
   public void setBatchStringBytesFailsWithNullCacheName() {
-    assertThat(target.setBatchStringBytes(null, new HashMap<>()))
+    assertThat(cacheClient.setBatchStringBytes(null, new HashMap<>()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetBatchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -699,7 +696,7 @@ final class CacheClientTest extends BaseTestClass {
     final Map<String, byte[]> items = new HashMap<>();
     items.put("key1", "val1".getBytes());
 
-    assertThat(target.setBatchStringBytes(randomString("cache"), items))
+    assertThat(cacheClient.setBatchStringBytes(randomString("cache"), items))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetBatchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
@@ -30,14 +30,10 @@ import momento.sdk.responses.cache.control.CacheFlushResponse;
 import momento.sdk.responses.cache.ttl.ItemGetTtlResponse;
 import momento.sdk.responses.cache.ttl.UpdateTtlResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Just includes a happy test path that interacts with both control and data plane clients. */
 final class CacheClientTest extends BaseTestClass {
-  private static String cacheName;
-
   private static final String JWT_HEADER_BASE64 = "eyJhbGciOiJIUzUxMiJ9";
   private static final String JWT_INVALID_SIGNATURE_BASE64 =
       "gdghdjjfjyehhdkkkskskmmls76573jnajhjjjhjdhnndy";
@@ -70,17 +66,6 @@ final class CacheClientTest extends BaseTestClass {
           + JWT_INVALID_SIGNATURE_BASE64;
   private static final CredentialProvider BAD_DATA_PLANE_PROVIDER =
       new StringCredentialProvider(BAD_DATA_PLANE_JWT);
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
 
   @Test
   public void createCacheGetSetDeleteValuesAndDeleteCache() {

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -50,13 +50,22 @@ final class CacheControlPlaneTest extends BaseTestClass {
 
   @Test
   public void throwsAlreadyExistsWhenCreatingExistingCache() {
-    final String existingCache = System.getenv("TEST_CACHE_NAME");
+    final String cacheName = randomString();
+    CacheCreateResponse response = cacheClient.createCache(cacheName).join();
+    assertThat(response).isInstanceOf(CacheCreateResponse.Success.class);
 
-    assertThat(cacheClient.createCache(existingCache))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
-        .satisfies(
-            error -> assertThat(error).hasCauseInstanceOf(CacheAlreadyExistsException.class));
+    try {
+      assertThat(cacheClient.createCache(cacheName))
+          .succeedsWithin(FIVE_SECONDS)
+          .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
+          .satisfies(
+              error -> assertThat(error).hasCauseInstanceOf(CacheAlreadyExistsException.class));
+    } finally {
+      // cleanup
+      assertThat(cacheClient.deleteCache(cacheName))
+          .succeedsWithin(FIVE_SECONDS)
+          .isInstanceOf(CacheDeleteResponse.Success.class);
+    }
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -19,47 +19,28 @@ import momento.sdk.responses.cache.signing.SigningKeyCreateResponse;
 import momento.sdk.responses.cache.signing.SigningKeyListResponse;
 import momento.sdk.responses.cache.signing.SigningKeyRevokeResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 final class CacheControlPlaneTest extends BaseTestClass {
-
-  private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
-
-  private CacheClient target;
-
-  @BeforeEach
-  void setup() {
-    target =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-            .build();
-  }
-
-  @AfterEach
-  void tearDown() {
-    target.close();
-  }
-
   @Test
   public void createListRevokeSigningKeyWorks() {
     final SigningKeyCreateResponse signingKeyCreateResponse =
-        target.createSigningKey(Duration.ofMinutes(30)).join();
+        cacheClient.createSigningKey(Duration.ofMinutes(30)).join();
     assertThat(signingKeyCreateResponse).isInstanceOf(SigningKeyCreateResponse.Success.class);
     final String keyId = ((SigningKeyCreateResponse.Success) signingKeyCreateResponse).getKeyId();
 
-    assertThat(target.listSigningKeys())
+    assertThat(cacheClient.listSigningKeys())
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SigningKeyListResponse.Success.class))
         .satisfies(
             success ->
                 assertThat(success.signingKeys()).anyMatch(sk -> sk.getKeyId().equals(keyId)));
 
-    assertThat(target.revokeSigningKey(keyId))
+    assertThat(cacheClient.revokeSigningKey(keyId))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SigningKeyRevokeResponse.Success.class);
 
-    assertThat(target.listSigningKeys())
+    assertThat(cacheClient.listSigningKeys())
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SigningKeyListResponse.Success.class))
         .satisfies(
@@ -71,7 +52,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
   public void throwsAlreadyExistsWhenCreatingExistingCache() {
     final String existingCache = System.getenv("TEST_CACHE_NAME");
 
-    assertThat(target.createCache(existingCache))
+    assertThat(cacheClient.createCache(existingCache))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
         .satisfies(
@@ -80,7 +61,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
 
   @Test
   public void returnsNotFoundWhenDeletingUnknownCache() {
-    assertThat(target.deleteCache(randomString("name")))
+    assertThat(cacheClient.deleteCache(randomString("name")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDeleteResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
@@ -90,12 +71,12 @@ final class CacheControlPlaneTest extends BaseTestClass {
   public void listsCachesHappyPath() {
     final String cacheName = randomString("name");
 
-    assertThat(target.createCache(cacheName))
+    assertThat(cacheClient.createCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheCreateResponse.Success.class);
 
     try {
-      assertThat(target.listCaches())
+      assertThat(cacheClient.listCaches())
           .succeedsWithin(FIVE_SECONDS)
           .asInstanceOf(InstanceOfAssertFactories.type(CacheListResponse.Success.class))
           .satisfies(
@@ -103,7 +84,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
                   assertThat(success.getCaches()).anyMatch(ci -> ci.name().equals(cacheName)));
     } finally {
       // cleanup
-      assertThat(target.deleteCache(cacheName))
+      assertThat(cacheClient.deleteCache(cacheName))
           .succeedsWithin(FIVE_SECONDS)
           .isInstanceOf(CacheDeleteResponse.Success.class);
     }
@@ -111,7 +92,7 @@ final class CacheControlPlaneTest extends BaseTestClass {
 
   @Test
   public void returnsBadRequestForEmptyCacheName() {
-    assertThat(target.createCache("      "))
+    assertThat(cacheClient.createCache("      "))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(BadRequestException.class));
@@ -119,12 +100,12 @@ final class CacheControlPlaneTest extends BaseTestClass {
 
   @Test
   public void throwsValidationExceptionForNullCacheName() {
-    assertThat(target.createCache(null))
+    assertThat(cacheClient.createCache(null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(target.deleteCache(null))
+    assertThat(cacheClient.deleteCache(null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDeleteResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -134,21 +115,21 @@ final class CacheControlPlaneTest extends BaseTestClass {
   public void deleteSucceeds() {
     final String cacheName = randomString("name");
 
-    assertThat(target.createCache(cacheName))
+    assertThat(cacheClient.createCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheCreateResponse.Success.class);
 
-    assertThat(target.createCache(cacheName))
+    assertThat(cacheClient.createCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheCreateResponse.Error.class))
         .satisfies(
             error -> assertThat(error).hasCauseInstanceOf(CacheAlreadyExistsException.class));
 
-    assertThat(target.deleteCache(cacheName))
+    assertThat(cacheClient.deleteCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(CacheDeleteResponse.Success.class);
 
-    assertThat(target.deleteCache(cacheName))
+    assertThat(cacheClient.deleteCache(cacheName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(CacheDeleteResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
@@ -7,25 +7,10 @@ import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Tests client side exceptions */
 final class CacheDataPlaneClientSideTest extends BaseTestClass {
-  private static String cacheName;
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
-
   @Test
   public void nullKeyGetReturnsError() {
     final GetResponse stringResponse = cacheClient.get(cacheName, (String) null).join();

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
@@ -3,56 +3,49 @@ package momento.sdk;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Tests client side exceptions */
 final class CacheDataPlaneClientSideTest extends BaseTestClass {
+  private static String cacheName;
 
-  private static final Duration DEFAULT_ITEM_TTL_SECONDS = Duration.ofSeconds(60);
-
-  private final String cacheName = System.getenv("TEST_CACHE_NAME");
-  private CacheClient client;
-
-  @BeforeEach
-  void setup() {
-    client =
-        CacheClient.builder(
-                credentialProvider, Configurations.Laptop.latest(), DEFAULT_ITEM_TTL_SECONDS)
-            .build();
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
-  @AfterEach
-  void teardown() {
-    client.close();
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
   }
 
   @Test
   public void nullKeyGetReturnsError() {
-    final GetResponse stringResponse = client.get(cacheName, (String) null).join();
+    final GetResponse stringResponse = cacheClient.get(cacheName, (String) null).join();
     assertThat(stringResponse).isInstanceOf(GetResponse.Error.class);
     assertThat((GetResponse.Error) stringResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    final GetResponse byteResponse = client.get(cacheName, (byte[]) null).join();
+    final GetResponse byteResponse = cacheClient.get(cacheName, (byte[]) null).join();
     assertThat(byteResponse).isInstanceOf(GetResponse.Error.class);
     assertThat((GetResponse.Error) byteResponse).hasCauseInstanceOf(InvalidArgumentException.class);
   }
 
   @Test
   public void nullKeyDeleteReturnsError() {
-    final DeleteResponse stringKeyResponse = client.delete(cacheName, (String) null).join();
+    final DeleteResponse stringKeyResponse = cacheClient.delete(cacheName, (String) null).join();
     assertThat(stringKeyResponse).isInstanceOf(DeleteResponse.Error.class);
     assertThat((DeleteResponse.Error) stringKeyResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    final DeleteResponse byteKeyResponse = client.delete(cacheName, (byte[]) null).join();
+    final DeleteResponse byteKeyResponse = cacheClient.delete(cacheName, (byte[]) null).join();
     assertThat(byteKeyResponse).isInstanceOf(DeleteResponse.Error.class);
     assertThat((DeleteResponse.Error) byteKeyResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
@@ -61,13 +54,13 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
   @Test
   public void nullKeySetReturnsError() {
     final SetResponse stringSetResponse =
-        client.set(cacheName, null, "hello", Duration.ofSeconds(10)).join();
+        cacheClient.set(cacheName, null, "hello", Duration.ofSeconds(10)).join();
     assertThat(stringSetResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) stringSetResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
     final SetResponse byteKeySetResponse =
-        client.set(cacheName, null, new byte[] {0x00}, Duration.ofSeconds(10)).join();
+        cacheClient.set(cacheName, null, new byte[] {0x00}, Duration.ofSeconds(10)).join();
     assertThat(byteKeySetResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) byteKeySetResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
@@ -76,13 +69,13 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
   @Test
   public void nullValueSetReturnsError() {
     final SetResponse stringResponse =
-        client.set(cacheName, "hello", null, Duration.ofSeconds(10)).join();
+        cacheClient.set(cacheName, "hello", null, Duration.ofSeconds(10)).join();
     assertThat(stringResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) stringResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
     final SetResponse byteArrayResponse =
-        client.set(cacheName, new byte[] {}, null, Duration.ofSeconds(10)).join();
+        cacheClient.set(cacheName, new byte[] {}, null, Duration.ofSeconds(10)).join();
     assertThat(byteArrayResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) byteArrayResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
@@ -91,13 +84,13 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
   @Test
   public void ttlMustNotBeNegativeReturnsError() {
     final SetResponse stringSetResponse =
-        client.set(cacheName, "hello", "", Duration.ofSeconds(-1)).join();
+        cacheClient.set(cacheName, "hello", "", Duration.ofSeconds(-1)).join();
     assertThat(stringSetResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) stringSetResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
     final SetResponse byteArraySetResponse =
-        client.set(cacheName, new byte[] {}, new byte[] {}, Duration.ofSeconds(-1)).join();
+        cacheClient.set(cacheName, new byte[] {}, new byte[] {}, Duration.ofSeconds(-1)).join();
     assertThat(byteArraySetResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) byteArraySetResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
@@ -105,16 +98,16 @@ final class CacheDataPlaneClientSideTest extends BaseTestClass {
 
   @Test
   public void nullCacheNameReturnsError() {
-    final GetResponse getResponse = client.get(null, "").join();
+    final GetResponse getResponse = cacheClient.get(null, "").join();
     assertThat(getResponse).isInstanceOf(GetResponse.Error.class);
     assertThat((GetResponse.Error) getResponse).hasCauseInstanceOf(InvalidArgumentException.class);
 
-    final DeleteResponse deleteResponse = client.delete(null, "").join();
+    final DeleteResponse deleteResponse = cacheClient.delete(null, "").join();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Error.class);
     assertThat((DeleteResponse.Error) deleteResponse)
         .hasCauseInstanceOf(InvalidArgumentException.class);
 
-    final SetResponse setResponse = client.set(null, "", "", Duration.ofSeconds(10)).join();
+    final SetResponse setResponse = cacheClient.set(null, "", "", Duration.ofSeconds(10)).join();
     assertThat(setResponse).isInstanceOf(SetResponse.Error.class);
     assertThat((SetResponse.Error) setResponse).hasCauseInstanceOf(InvalidArgumentException.class);
   }

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneEagerConnectionTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneEagerConnectionTest.java
@@ -8,32 +8,16 @@ import java.time.Duration;
 import momento.sdk.config.Configurations;
 import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CacheDataPlaneEagerConnectionTest extends BaseTestClass {
-  private static final Duration DEFAULT_ITEM_TTL_SECONDS = Duration.ofSeconds(60);
-  private static String cacheName;
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
-
   @Test
   void getReturnsHitAfterSet() {
     CacheClient client =
         CacheClient.create(
             credentialProvider,
             Configurations.Laptop.latest(),
-            DEFAULT_ITEM_TTL_SECONDS,
+            DEFAULT_TTL_SECONDS,
             Duration.ofSeconds(10));
     final String key = randomString("key");
     final String value = randomString("value");

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneEagerConnectionTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneEagerConnectionTest.java
@@ -8,11 +8,24 @@ import java.time.Duration;
 import momento.sdk.config.Configurations;
 import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CacheDataPlaneEagerConnectionTest extends BaseTestClass {
   private static final Duration DEFAULT_ITEM_TTL_SECONDS = Duration.ofSeconds(60);
-  private final String cacheName = System.getenv("TEST_CACHE_NAME");
+  private static String cacheName;
+
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
+  }
+
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
+  }
 
   @Test
   void getReturnsHitAfterSet() {

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
@@ -13,25 +13,10 @@ import momento.sdk.exceptions.TimeoutException;
 import momento.sdk.responses.cache.DeleteResponse;
 import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Tests with Async APIs. */
 final class CacheDataPlaneTest extends BaseTestClass {
-  private static String cacheName;
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
-
   @Test
   void getReturnsHitAfterSet() {
     final String key = randomString("key");

--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -21,27 +21,13 @@ import momento.sdk.responses.cache.dictionary.DictionaryRemoveFieldsResponse;
 import momento.sdk.responses.cache.dictionary.DictionarySetFieldResponse;
 import momento.sdk.responses.cache.dictionary.DictionarySetFieldsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class DictionaryTest extends BaseTestClass {
-  private static String cacheName;
   Map<String, String> stringStringMap = new HashMap<>();
   Map<String, byte[]> stringBytesMap = new HashMap<>();
   Map<byte[], String> bytesStringMap = new HashMap<>();
   Map<byte[], byte[]> bytesBytesMap = new HashMap<>();
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
 
   @Test
   public void dictionarySetFieldAndDictionaryFetchAndHappyPath() {

--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -1,14 +1,13 @@
 package momento.sdk;
 
+import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.BadRequestException;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.exceptions.MomentoErrorCode;
@@ -22,46 +21,40 @@ import momento.sdk.responses.cache.dictionary.DictionaryRemoveFieldsResponse;
 import momento.sdk.responses.cache.dictionary.DictionarySetFieldResponse;
 import momento.sdk.responses.cache.dictionary.DictionarySetFieldsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class DictionaryTest extends BaseTestClass {
-  private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
-  private CacheClient target;
-
-  private final String cacheName = System.getenv("TEST_CACHE_NAME");
-  private final String dictionaryName = "test-dictionary";
-
+  private static String cacheName;
   Map<String, String> stringStringMap = new HashMap<>();
   Map<String, byte[]> stringBytesMap = new HashMap<>();
   Map<byte[], String> bytesStringMap = new HashMap<>();
   Map<byte[], byte[]> bytesBytesMap = new HashMap<>();
 
-  @BeforeEach
-  void setup() {
-    target =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-            .build();
-    target.createCache(cacheName).join();
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
-  @AfterEach
-  void teardown() {
-    target.deleteCache(cacheName).join();
-    target.close();
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
   }
 
   @Test
   public void dictionarySetFieldAndDictionaryFetchAndHappyPath() {
+    final String dictionaryName = randomString();
+
     // Set String key, String Value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -69,12 +62,12 @@ public class DictionaryTest extends BaseTestClass {
 
     // Set String key, ByteArray Value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "c", "d".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -86,23 +79,25 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionarySetFieldAndDictionaryFetchAndHappyPathWithNoTtl() {
+    final String dictionaryName = randomString();
+
     // Set String key, String Value
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "a", "b"))
+    assertThat(cacheClient.dictionarySetField(cacheName, dictionaryName, "a", "b"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
             hit -> assertThat(hit.valueMapStringString()).hasSize(1).containsEntry("a", "b"));
 
     // Set String key, ByteArray Value
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "c", "d".getBytes()))
+    assertThat(cacheClient.dictionarySetField(cacheName, dictionaryName, "c", "d".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -115,16 +110,19 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionarySetFieldReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     // String Key and String value
     assertThat(
-            target.dictionarySetField(null, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
+            cacheClient.dictionarySetField(
+                null, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 null, dictionaryName, "a", "b".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
@@ -135,14 +133,15 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionarySetFieldReturnsErrorWithNullDictionaryName() {
     // String Key and String value
-    assertThat(target.dictionarySetField(cacheName, null, "a", "b", CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.dictionarySetField(cacheName, null, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, null, "a", "b".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
@@ -152,9 +151,11 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionarySetFieldReturnsErrorWithNullField() {
+    final String dictionaryName = randomString();
+
     // String Key and String value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, null, "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
@@ -162,7 +163,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, null, "b".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
@@ -172,9 +173,11 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionarySetFieldReturnsErrorWithNullValue() {
+    final String dictionaryName = randomString();
+
     // String Key and String value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", (String) null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
@@ -182,7 +185,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", (byte[]) null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldResponse.Error.class))
@@ -192,7 +195,9 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryFetchReturnsErrorWithNullCacheName() {
-    assertThat(target.dictionaryFetch(null, dictionaryName))
+    final String dictionaryName = randomString();
+
+    assertThat(cacheClient.dictionaryFetch(null, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -201,7 +206,7 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryFetchReturnsErrorWithNullDictionaryName() {
-    assertThat(target.dictionaryFetch(cacheName, null))
+    assertThat(cacheClient.dictionaryFetch(cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -209,23 +214,27 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryFetchReturnsMissWhenDictionaryNotExists() {
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    final String dictionaryName = randomString();
+
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryFetchResponse.Miss.class);
   }
 
   @Test
   public void dictionarySetFieldsAndDictionaryFetchAndHappyPath() {
+    final String dictionaryName = randomString();
+
     populateTestMaps();
 
     // Set String key, String value
     assertThat(
-            target.dictionarySetFields(
+            cacheClient.dictionarySetFields(
                 cacheName, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldsResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -237,12 +246,12 @@ public class DictionaryTest extends BaseTestClass {
 
     // Set String key, byte array value
     assertThat(
-            target.dictionarySetFieldsStringBytes(
+            cacheClient.dictionarySetFieldsStringBytes(
                 cacheName, dictionaryName, stringBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldsResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -255,14 +264,16 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionarySetFieldsAndDictionaryFetchAndHappyPathWithNoTtl() {
+    final String dictionaryName = randomString();
+
     populateTestMaps();
 
     // Set String key, String value
-    assertThat(target.dictionarySetFields(cacheName, dictionaryName, stringStringMap))
+    assertThat(cacheClient.dictionarySetFields(cacheName, dictionaryName, stringStringMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldsResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -273,11 +284,12 @@ public class DictionaryTest extends BaseTestClass {
             });
 
     // Set String key, byte array value
-    assertThat(target.dictionarySetFieldsStringBytes(cacheName, dictionaryName, stringBytesMap))
+    assertThat(
+            cacheClient.dictionarySetFieldsStringBytes(cacheName, dictionaryName, stringBytesMap))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldsResponse.Success.class);
 
-    assertThat(target.dictionaryFetch(cacheName, dictionaryName))
+    assertThat(cacheClient.dictionaryFetch(cacheName, dictionaryName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryFetchResponse.Hit.class))
         .satisfies(
@@ -291,11 +303,13 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionarySetFieldsReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     populateTestMaps();
 
     // String Key and String value
     assertThat(
-            target.dictionarySetFields(
+            cacheClient.dictionarySetFields(
                 null, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldsResponse.Error.class))
@@ -303,7 +317,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetFieldsStringBytes(
+            cacheClient.dictionarySetFieldsStringBytes(
                 null, dictionaryName, stringBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldsResponse.Error.class))
@@ -317,7 +331,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and String value
     assertThat(
-            target.dictionarySetFields(
+            cacheClient.dictionarySetFields(
                 cacheName, null, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldsResponse.Error.class))
@@ -325,7 +339,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetFieldsStringBytes(
+            cacheClient.dictionarySetFieldsStringBytes(
                 cacheName, null, stringBytesMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldsResponse.Error.class))
@@ -335,9 +349,11 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionarySetFieldsReturnsErrorWithNullItem() {
+    final String dictionaryName = randomString();
+
     // String Key and String value
     assertThat(
-            target.dictionarySetFields(
+            cacheClient.dictionarySetFields(
                 cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldsResponse.Error.class))
@@ -345,7 +361,7 @@ public class DictionaryTest extends BaseTestClass {
 
     // String Key and Byte value
     assertThat(
-            target.dictionarySetFieldsStringBytes(
+            cacheClient.dictionarySetFieldsStringBytes(
                 cacheName, dictionaryName, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionarySetFieldsResponse.Error.class))
@@ -354,14 +370,16 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryGetFieldHappyPath() {
+    final String dictionaryName = randomString();
+
     // Get the value as a string
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Hit.class))
         .satisfies(
@@ -372,12 +390,12 @@ public class DictionaryTest extends BaseTestClass {
 
     // Get the value as a byte array
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "c", "d".getBytes(), CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "c"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "c"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Hit.class))
         .satisfies(
@@ -390,8 +408,10 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryGetFieldReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryGetField(null, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryGetField(null, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -401,7 +421,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryGetFieldReturnsErrorWithNullDictionaryName() {
     // String field
-    assertThat(target.dictionaryGetField(cacheName, null, "a"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, null, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -410,8 +430,10 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryGetFieldReturnsErrorWithNullField() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, null))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -419,48 +441,56 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryGetFieldReturnsMissWhenFieldNotExists() {
+    final String dictionaryName = randomString();
+
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     // String field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "c"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "c"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldResponse.Miss.class);
   }
 
   @Test
   public void dictionaryGetFieldReturnsMissWhenDictionaryNotExists() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldResponse.Miss.class);
   }
 
   @Test
   public void dictionaryGetFieldsStringHappyPath() {
+    final String dictionaryName = randomString();
+
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "c", "d", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "e", "f", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     // Gets a map of string keys and string values
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "c", "e")))
+    assertThat(
+            cacheClient.dictionaryGetFields(
+                cacheName, dictionaryName, Arrays.asList("a", "c", "e")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Hit.class))
         .satisfies(
@@ -471,7 +501,9 @@ public class DictionaryTest extends BaseTestClass {
             });
 
     // Gets a map of string keys and byte array values
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "c", "e")))
+    assertThat(
+            cacheClient.dictionaryGetFields(
+                cacheName, dictionaryName, Arrays.asList("a", "c", "e")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Hit.class))
         .satisfies(
@@ -486,8 +518,10 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryGetFieldsReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     // String fields
-    assertThat(target.dictionaryGetFields(null, dictionaryName, Arrays.asList("a", "c", "e")))
+    assertThat(cacheClient.dictionaryGetFields(null, dictionaryName, Arrays.asList("a", "c", "e")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -497,7 +531,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryGetFieldsReturnsErrorWithNullDictionaryName() {
     // String fields
-    assertThat(target.dictionaryGetFields(cacheName, null, Arrays.asList("a", "c", "e")))
+    assertThat(cacheClient.dictionaryGetFields(cacheName, null, Arrays.asList("a", "c", "e")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -506,8 +540,10 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryGetFieldsReturnsErrorWithNullFields() {
+    final String dictionaryName = randomString();
+
     // String fields
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, null))
+    assertThat(cacheClient.dictionaryGetFields(cacheName, dictionaryName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -515,7 +551,7 @@ public class DictionaryTest extends BaseTestClass {
     List<String> stringListWithAtleastOneNullField = Arrays.asList("a", null);
 
     assertThat(
-            target.dictionaryGetFields(
+            cacheClient.dictionaryGetFields(
                 cacheName, dictionaryName, stringListWithAtleastOneNullField))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Error.class))
@@ -524,21 +560,25 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryGetFieldsReturnsMissOrHitWhenFieldsNotExistsOrExistsRespectively() {
+    final String dictionaryName = randomString();
+
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "c", "d", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     // get raw responses and validate Hit/Miss
     DictionaryGetFieldsResponse response =
-        target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "c", "r")).join();
+        cacheClient
+            .dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "c", "r"))
+            .join();
 
     assertThat(response).isInstanceOf(DictionaryGetFieldsResponse.Hit.class);
 
@@ -569,23 +609,28 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryGetFieldsReturnsMissWhenDictionaryNotExists() {
+    final String dictionaryName = randomString();
+
     // String field
     assertThat(
-            target.dictionaryGetFields(cacheName, dictionaryName, Collections.singletonList("a")))
+            cacheClient.dictionaryGetFields(
+                cacheName, dictionaryName, Collections.singletonList("a")))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldsResponse.Miss.class);
   }
 
   @Test
   public void dictionaryIncrementStringFieldHappyPath() {
+    final String dictionaryName = randomString();
+
     // Increment with ttl
-    assertThat(target.dictionaryIncrement(cacheName, dictionaryName, "a", 1))
+    assertThat(cacheClient.dictionaryIncrement(cacheName, dictionaryName, "a", 1))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Success.class))
         .satisfies(success -> assertThat(success.value()).isEqualTo(1));
 
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, "a", 41, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Success.class))
@@ -593,13 +638,13 @@ public class DictionaryTest extends BaseTestClass {
 
     // Increment without ttl
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, "a", -1042, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Success.class))
         .satisfies(success -> assertThat(success.value()).isEqualTo(-1000));
 
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Hit.class))
         .satisfies(
@@ -611,32 +656,34 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryIncrementSetAndResetHappyPath() {
+    final String dictionaryName = randomString();
+
     // Set field
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "a", "10"))
+    assertThat(cacheClient.dictionarySetField(cacheName, dictionaryName, "a", "10"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, "a", 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Success.class))
         .satisfies(success -> assertThat(success.value()).isEqualTo(10));
 
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, "a", 90, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Success.class))
         .satisfies(success -> assertThat(success.value()).isEqualTo(100));
 
     // Reset field
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "a", "0"))
+    assertThat(cacheClient.dictionarySetField(cacheName, dictionaryName, "a", "0"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, "a", 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Success.class))
@@ -646,9 +693,12 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryIncrementReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     // String field
     assertThat(
-            target.dictionaryIncrement(null, dictionaryName, "a", 1, CollectionTtl.fromCacheTtl()))
+            cacheClient.dictionaryIncrement(
+                null, dictionaryName, "a", 1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -658,7 +708,8 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryIncrementReturnsErrorWithNullDictionaryName() {
     // String field
-    assertThat(target.dictionaryIncrement(cacheName, null, "a", 1, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.dictionaryIncrement(cacheName, null, "a", 1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -667,9 +718,11 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryIncrementReturnsErrorWithNullField() {
+    final String dictionaryName = randomString();
+
     // String field
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, null, 1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Error.class))
@@ -678,12 +731,14 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryIncrementReturnsBadRequestError() {
-    assertThat(target.dictionarySetField(cacheName, dictionaryName, "a", "xyz"))
+    final String dictionaryName = randomString();
+
+    assertThat(cacheClient.dictionarySetField(cacheName, dictionaryName, "a", "xyz"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
     assertThat(
-            target.dictionaryIncrement(
+            cacheClient.dictionaryIncrement(
                 cacheName, dictionaryName, "a", 1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryIncrementResponse.Error.class))
@@ -696,17 +751,19 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryRemoveFieldStringHappyPath() {
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
+    final String dictionaryName = randomString();
+
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldResponse.Miss.class);
 
     assertThat(
-            target.dictionarySetField(
+            cacheClient.dictionarySetField(
                 cacheName, dictionaryName, "a", "b", CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldResponse.Success.class);
 
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldResponse.Hit.class))
         .satisfies(
@@ -715,11 +772,11 @@ public class DictionaryTest extends BaseTestClass {
               assertThat(hit.valueString()).isEqualTo("b");
             });
 
-    assertThat(target.dictionaryRemoveField(cacheName, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryRemoveField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryRemoveFieldResponse.Success.class);
 
-    assertThat(target.dictionaryGetField(cacheName, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryGetField(cacheName, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldResponse.Miss.class);
   }
@@ -727,8 +784,10 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryRemoveFieldReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryRemoveField(null, dictionaryName, "a"))
+    assertThat(cacheClient.dictionaryRemoveField(null, dictionaryName, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -738,7 +797,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryRemoveFieldReturnsErrorWithNullDictionaryName() {
     // String field
-    assertThat(target.dictionaryRemoveField(cacheName, null, "a"))
+    assertThat(cacheClient.dictionaryRemoveField(cacheName, null, "a"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -747,8 +806,10 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryRemoveFieldReturnsErrorWithNullField() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryRemoveField(cacheName, dictionaryName, null))
+    assertThat(cacheClient.dictionaryRemoveField(cacheName, dictionaryName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -756,18 +817,20 @@ public class DictionaryTest extends BaseTestClass {
 
   @Test
   public void dictionaryRemoveFieldsStringHappyPath() {
+    final String dictionaryName = randomString();
+
     populateTestMaps();
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
+    assertThat(cacheClient.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldsResponse.Miss.class);
 
     assertThat(
-            target.dictionarySetFields(
+            cacheClient.dictionarySetFields(
                 cacheName, dictionaryName, stringStringMap, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionarySetFieldsResponse.Success.class);
 
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
+    assertThat(cacheClient.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryGetFieldsResponse.Hit.class))
         .satisfies(
@@ -777,11 +840,12 @@ public class DictionaryTest extends BaseTestClass {
               assertThat(stringStringMap.values()).contains("b", "bb");
             });
 
-    assertThat(target.dictionaryRemoveFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
+    assertThat(
+            cacheClient.dictionaryRemoveFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryRemoveFieldsResponse.Success.class);
 
-    assertThat(target.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
+    assertThat(cacheClient.dictionaryGetFields(cacheName, dictionaryName, Arrays.asList("a", "aa")))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(DictionaryGetFieldsResponse.Miss.class);
   }
@@ -789,8 +853,12 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryRemoveFieldsReturnsErrorWithNullCacheName() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryRemoveFields(null, dictionaryName, Collections.singletonList("a")))
+    assertThat(
+            cacheClient.dictionaryRemoveFields(
+                null, dictionaryName, Collections.singletonList("a")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -800,7 +868,7 @@ public class DictionaryTest extends BaseTestClass {
   @Test
   public void dictionaryRemoveFieldsReturnsErrorWithNullDictionaryName() {
     // String field
-    assertThat(target.dictionaryRemoveFields(cacheName, null, Collections.singletonList("a")))
+    assertThat(cacheClient.dictionaryRemoveFields(cacheName, null, Collections.singletonList("a")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -809,13 +877,16 @@ public class DictionaryTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void dictionaryRemoveFieldsReturnsErrorWithNullField() {
+    final String dictionaryName = randomString();
+
     // String field
-    assertThat(target.dictionaryRemoveFields(cacheName, dictionaryName, null))
+    assertThat(cacheClient.dictionaryRemoveFields(cacheName, dictionaryName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(target.dictionaryRemoveFields(cacheName, dictionaryName, Arrays.asList("a", null)))
+    assertThat(
+            cacheClient.dictionaryRemoveFields(cacheName, dictionaryName, Arrays.asList("a", null)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(DictionaryRemoveFieldsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -20,24 +20,10 @@ import momento.sdk.responses.cache.list.ListPushFrontResponse;
 import momento.sdk.responses.cache.list.ListRemoveValueResponse;
 import momento.sdk.responses.cache.list.ListRetainResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ListTest extends BaseTestClass {
-  private static String cacheName;
   private final List<String> values = Arrays.asList("val1", "val2", "val3", "val4");
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
 
   @Test
   public void listConcatenateBackStringHappyPath() {

--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -1,13 +1,12 @@
 package momento.sdk;
 
+import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Iterables;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.requests.CollectionTtl;
 import momento.sdk.responses.cache.list.ListConcatenateBackResponse;
@@ -21,63 +20,54 @@ import momento.sdk.responses.cache.list.ListPushFrontResponse;
 import momento.sdk.responses.cache.list.ListRemoveValueResponse;
 import momento.sdk.responses.cache.list.ListRetainResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ListTest extends BaseTestClass {
-  private static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
-
-  private CacheClient target;
-
-  private final String cacheName = System.getenv("TEST_CACHE_NAME");
-
+  private static String cacheName;
   private final List<String> values = Arrays.asList("val1", "val2", "val3", "val4");
 
-  private final String listName = "listName";
-
-  @BeforeEach
-  void setup() {
-    target =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL_SECONDS)
-            .build();
-    target.createCache(cacheName).join();
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
-  @AfterEach
-  void teardown() {
-    target.deleteCache(cacheName).join();
-    target.close();
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
   }
 
   @Test
   public void listConcatenateBackStringHappyPath() {
+    final String listName = randomString();
     final List<String> oldValues = Arrays.asList("val1", "val2", "val3");
     final List<String> newValues = Arrays.asList("val4", "val5", "val6");
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBack(
+            cacheClient.listConcatenateBack(
                 cacheName, listName, oldValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
             hit ->
                 assertThat(hit.valueListString()).hasSize(3).containsExactlyElementsOf(oldValues));
 
-    assertThat(target.listConcatenateBack(cacheName, listName, newValues))
+    assertThat(cacheClient.listConcatenateBack(cacheName, listName, newValues))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
     final Iterable<String> expectedList = Iterables.concat(oldValues, newValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -87,12 +77,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add the original values again and truncate the list to 6 items
-    assertThat(target.listConcatenateBack(cacheName, listName, oldValues, 6))
+    assertThat(cacheClient.listConcatenateBack(cacheName, listName, oldValues, 6))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
     final Iterable<String> newExpectedList = Iterables.concat(newValues, oldValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -104,22 +94,23 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listConcatenateBackByteArrayHappyPath() {
+    final String listName = randomString();
     final List<byte[]> oldValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
     final List<byte[]> newValues =
         Arrays.asList("val4".getBytes(), "val5".getBytes(), "val6".getBytes());
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBackByteArray(
+            cacheClient.listConcatenateBackByteArray(
                 cacheName, listName, oldValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -128,12 +119,12 @@ public class ListTest extends BaseTestClass {
                     .hasSize(3)
                     .containsExactlyElementsOf(oldValues));
 
-    assertThat(target.listConcatenateBackByteArray(cacheName, listName, newValues))
+    assertThat(cacheClient.listConcatenateBackByteArray(cacheName, listName, newValues))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
     final Iterable<byte[]> expectedList = Iterables.concat(oldValues, newValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -143,12 +134,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add the original values again and truncate the list to 6 items
-    assertThat(target.listConcatenateBackByteArray(cacheName, listName, oldValues, 6))
+    assertThat(cacheClient.listConcatenateBackByteArray(cacheName, listName, oldValues, 6))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
     final Iterable<byte[]> newExpectedList = Iterables.concat(newValues, oldValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -161,46 +152,47 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListConcatenateBackWhenNullCacheName() {
+    final String listName = randomString();
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3");
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBack(
+            cacheClient.listConcatenateBack(
                 null, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBack(null, listName, stringValues, null))
+    assertThat(cacheClient.listConcatenateBack(null, listName, stringValues, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl or truncate specified in method signature
-    assertThat(target.listConcatenateBack(null, listName, stringValues))
+    assertThat(cacheClient.listConcatenateBack(null, listName, stringValues))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBackByteArray(
+            cacheClient.listConcatenateBackByteArray(
                 null, listName, byteArrayValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackByteArray(null, listName, byteArrayValues, null))
+    assertThat(cacheClient.listConcatenateBackByteArray(null, listName, byteArrayValues, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl or truncate specified in method signature
-    assertThat(target.listConcatenateBackByteArray(null, listName, byteArrayValues, null))
+    assertThat(cacheClient.listConcatenateBackByteArray(null, listName, byteArrayValues, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -215,40 +207,40 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBack(
+            cacheClient.listConcatenateBack(
                 cacheName, null, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBack(cacheName, null, stringValues, null))
+    assertThat(cacheClient.listConcatenateBack(cacheName, null, stringValues, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl or truncate specified in method signature
-    assertThat(target.listConcatenateBack(cacheName, null, stringValues))
+    assertThat(cacheClient.listConcatenateBack(cacheName, null, stringValues))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBackByteArray(
+            cacheClient.listConcatenateBackByteArray(
                 cacheName, null, byteArrayValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackByteArray(cacheName, null, byteArrayValues, null))
+    assertThat(cacheClient.listConcatenateBackByteArray(cacheName, null, byteArrayValues, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl or truncate specified in method signature
-    assertThat(target.listConcatenateBackByteArray(cacheName, null, byteArrayValues))
+    assertThat(cacheClient.listConcatenateBackByteArray(cacheName, null, byteArrayValues))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -257,42 +249,43 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListConcatenateBackWhenNullElement() {
+    final String listName = randomString();
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBack(
+            cacheClient.listConcatenateBack(
                 cacheName, listName, null, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBack(cacheName, listName, null, null))
+    assertThat(cacheClient.listConcatenateBack(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl or truncate specified in method signature
-    assertThat(target.listConcatenateBack(cacheName, listName, null))
+    assertThat(cacheClient.listConcatenateBack(cacheName, listName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateBackByteArray(
+            cacheClient.listConcatenateBackByteArray(
                 cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateBackByteArray(cacheName, listName, null, null))
+    assertThat(cacheClient.listConcatenateBackByteArray(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl or truncate specified in method signature
-    assertThat(target.listConcatenateBackByteArray(cacheName, listName, null))
+    assertThat(cacheClient.listConcatenateBackByteArray(cacheName, listName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -300,13 +293,13 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFetchAllValuesWhenListFetchWithPositiveStartEndIndices() {
-    final String listName = "listName";
-    target
+    final String listName = randomString();
+    cacheClient
         .listConcatenateBack(
             cacheName, listName, values, null, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
-    ListFetchResponse listFetchResponse = target.listFetch(cacheName, listName, 1, 3).join();
+    ListFetchResponse listFetchResponse = cacheClient.listFetch(cacheName, listName, 1, 3).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Hit.class);
 
@@ -317,13 +310,13 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFetchAllValuesWhenListFetchWithNegativeStartEndIndices() {
-    final String listName = "listName";
-    target
+    final String listName = randomString();
+    cacheClient
         .listConcatenateBack(
             cacheName, listName, values, null, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
-    ListFetchResponse listFetchResponse = target.listFetch(cacheName, listName, -3, -1).join();
+    ListFetchResponse listFetchResponse = cacheClient.listFetch(cacheName, listName, -3, -1).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Hit.class);
 
@@ -334,14 +327,15 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFetchAllValuesWhenListFetchWithNullStartIndex() {
-    final String listName = "listName";
-    target
+    final String listName = randomString();
+    cacheClient
         .listConcatenateBack(
             cacheName, listName, values, null, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // valid case for null startIndex and positive endIndex
-    ListFetchResponse listFetchResponse = target.listFetch(cacheName, listName, null, 1).join();
+    ListFetchResponse listFetchResponse =
+        cacheClient.listFetch(cacheName, listName, null, 1).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Hit.class);
 
@@ -350,7 +344,7 @@ public class ListTest extends BaseTestClass {
         .isEqualTo(expectedResult);
 
     // valid case for null startIndex and negative endIndex
-    listFetchResponse = target.listFetch(cacheName, listName, null, -3).join();
+    listFetchResponse = cacheClient.listFetch(cacheName, listName, null, -3).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Hit.class);
 
@@ -361,14 +355,15 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFetchAllValuesWhenListFetchWithNullEndIndex() {
-    final String listName = "listName";
-    target
+    final String listName = randomString();
+    cacheClient
         .listConcatenateBack(
             cacheName, listName, values, null, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // valid case for positive startIndex and null endIndex
-    ListFetchResponse listFetchResponse = target.listFetch(cacheName, listName, 2, null).join();
+    ListFetchResponse listFetchResponse =
+        cacheClient.listFetch(cacheName, listName, 2, null).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Hit.class);
 
@@ -377,7 +372,7 @@ public class ListTest extends BaseTestClass {
         .isEqualTo(expectedResult);
 
     // valid case for negative startIndex and null endIndex
-    listFetchResponse = target.listFetch(cacheName, listName, -3, null).join();
+    listFetchResponse = cacheClient.listFetch(cacheName, listName, -3, null).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Hit.class);
 
@@ -388,55 +383,56 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldFetchAllValuesWhenListFetchWithInvalidIndices() {
-    final String listName = "listName";
-    target
+    final String listName = randomString();
+    cacheClient
         .listConcatenateBack(cacheName, listName, values, 0, CollectionTtl.of(DEFAULT_TTL_SECONDS))
         .join();
 
     // the positive startIndex is larger than the positive endIndex
-    ListFetchResponse listFetchResponse = target.listFetch(cacheName, listName, 3, 1).join();
+    ListFetchResponse listFetchResponse = cacheClient.listFetch(cacheName, listName, 3, 1).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Error.class);
 
     // the positive startIndex is the same value as the positive endIndex
-    listFetchResponse = target.listFetch(cacheName, listName, 3, 3).join();
+    listFetchResponse = cacheClient.listFetch(cacheName, listName, 3, 3).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Error.class);
 
     // the negative startIndex is larger than the negative endIndex
-    listFetchResponse = target.listFetch(cacheName, listName, -2, -3).join();
+    listFetchResponse = cacheClient.listFetch(cacheName, listName, -2, -3).join();
 
     assertThat(listFetchResponse).isInstanceOf(ListFetchResponse.Error.class);
   }
 
   @Test
   public void listConcatenateFrontStringHappyPath() {
+    final String listName = randomString();
     final List<String> oldValues = Arrays.asList("val1", "val2", "val3");
     final List<String> newValues = Arrays.asList("val4", "val5", "val6");
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, oldValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
             hit ->
                 assertThat(hit.valueListString()).hasSize(3).containsExactlyElementsOf(oldValues));
 
-    assertThat(target.listConcatenateFront(cacheName, listName, newValues))
+    assertThat(cacheClient.listConcatenateFront(cacheName, listName, newValues))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
     final Iterable<String> expectedList = Iterables.concat(newValues, oldValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -446,12 +442,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add the original values again and truncate the list to 6 items
-    assertThat(target.listConcatenateFront(cacheName, listName, oldValues, 6))
+    assertThat(cacheClient.listConcatenateFront(cacheName, listName, oldValues, 6))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
     final Iterable<String> newExpectedList = Iterables.concat(oldValues, newValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -463,22 +459,23 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listConcatenateFrontByteArrayHappyPath() {
+    final String listName = randomString();
     final List<byte[]> oldValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
     final List<byte[]> newValues =
         Arrays.asList("val4".getBytes(), "val5".getBytes(), "val6".getBytes());
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFrontByteArray(
                 cacheName, listName, oldValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -487,12 +484,12 @@ public class ListTest extends BaseTestClass {
                     .hasSize(3)
                     .containsExactlyElementsOf(oldValues));
 
-    assertThat(target.listConcatenateFrontByteArray(cacheName, listName, newValues))
+    assertThat(cacheClient.listConcatenateFrontByteArray(cacheName, listName, newValues))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
     final Iterable<byte[]> expectedList = Iterables.concat(newValues, oldValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -502,12 +499,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add the original values again and truncate the list to 6 items
-    assertThat(target.listConcatenateFrontByteArray(cacheName, listName, oldValues, 6))
+    assertThat(cacheClient.listConcatenateFrontByteArray(cacheName, listName, oldValues, 6))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
     final Iterable<byte[]> newExpectedList = Iterables.concat(oldValues, newValues);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -520,27 +517,28 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListConcatenateFrontWhenNullCacheName() {
+    final String listName = randomString();
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3");
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 null, listName, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFront(null, listName, stringValues, 0))
+    assertThat(cacheClient.listConcatenateFront(null, listName, stringValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFrontByteArray(
                 null, listName, byteArrayValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
@@ -548,7 +546,7 @@ public class ListTest extends BaseTestClass {
 
     // Without ttl specified in method signature
     assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFrontByteArray(
                 null, listName, byteArrayValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
@@ -564,28 +562,28 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, null, stringValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFront(cacheName, null, stringValues, 0))
+    assertThat(cacheClient.listConcatenateFront(cacheName, null, stringValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFrontByteArray(
                 cacheName, null, byteArrayValues, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFrontByteArray(cacheName, null, byteArrayValues, 0))
+    assertThat(cacheClient.listConcatenateFrontByteArray(cacheName, null, byteArrayValues, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -594,29 +592,31 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListConcatenateFrontWhenNullElement() {
+    final String listName = randomString();
     // With ttl specified in method signature
     assertThat(
-            target.listConcatenateFront(cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // Without ttl specified in method signature
-    assertThat(target.listConcatenateFront(cacheName, listName, null, 0))
-        .succeedsWithin(FIVE_SECONDS)
-        .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
-        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
-
-    // With ttl specified in method signature
-    assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listConcatenateFrontByteArray(cacheName, listName, null, 0))
+    assertThat(cacheClient.listConcatenateFront(cacheName, listName, null, 0))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // With ttl specified in method signature
+    assertThat(
+            cacheClient.listConcatenateFrontByteArray(
+                cacheName, listName, null, 0, CollectionTtl.fromCacheTtl()))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    // Without ttl specified in method signature
+    assertThat(cacheClient.listConcatenateFrontByteArray(cacheName, listName, null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListConcatenateFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -624,34 +624,35 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listLengthHappyPath() {
+    final String listName = randomString();
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3");
     final List<byte[]> byteArrayValues =
         Arrays.asList("val1".getBytes(), "val2".getBytes(), "val3".getBytes());
 
-    assertThat(target.listLength(cacheName, listName))
+    assertThat(cacheClient.listLength(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListLengthResponse.Miss.class);
 
     // add string values to list
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listLength(cacheName, listName))
+    assertThat(cacheClient.listLength(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListLengthResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.getListLength()).isEqualTo(stringValues.size()));
 
     // add byte array values to list
     assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFrontByteArray(
                 cacheName, listName, byteArrayValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listLength(cacheName, listName))
+    assertThat(cacheClient.listLength(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListLengthResponse.Hit.class))
         .satisfies(
@@ -663,7 +664,8 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListLengthWhenNullCacheName() {
-    assertThat(target.listLength(null, listName))
+    final String listName = randomString();
+    assertThat(cacheClient.listLength(null, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListLengthResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -672,7 +674,7 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListLengthWhenNullListName() {
-    assertThat(target.listLength(cacheName, null))
+    assertThat(cacheClient.listLength(cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListLengthResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -680,26 +682,27 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listPopBackHappyPath() {
+    final String listName = randomString();
     List<String> values = Arrays.asList("val1", "val2", "val3");
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBack(
+            cacheClient.listConcatenateBack(
                 cacheName, listName, values, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
     // Pop the value as string from back of the list
-    assertThat(target.listPopBack(cacheName, listName))
+    assertThat(cacheClient.listPopBack(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopBackResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueString()).isEqualTo("val3"));
 
     // Pop the value as byte array from the back of the new list
-    assertThat(target.listPopBack(cacheName, listName))
+    assertThat(cacheClient.listPopBack(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopBackResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueByteArray()).isEqualTo("val2".getBytes()));
@@ -708,7 +711,8 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPopBackWhenNullCacheName() {
-    assertThat(target.listPopBack(null, listName))
+    final String listName = randomString();
+    assertThat(cacheClient.listPopBack(null, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -717,7 +721,7 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPopBackWhenNullListName() {
-    assertThat(target.listPopBack(cacheName, null))
+    assertThat(cacheClient.listPopBack(cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -725,26 +729,27 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listPopFrontHappyPath() {
+    final String listName = randomString();
     List<String> values = Arrays.asList("val1", "val2", "val3");
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listConcatenateBack(
+            cacheClient.listConcatenateBack(
                 cacheName, listName, values, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateBackResponse.Success.class);
 
     // Pop the value as string from front of the list
-    assertThat(target.listPopFront(cacheName, listName))
+    assertThat(cacheClient.listPopFront(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopFrontResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueString()).isEqualTo("val1"));
 
     // Pop the value as byte array from the front of the new list
-    assertThat(target.listPopFront(cacheName, listName))
+    assertThat(cacheClient.listPopFront(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopFrontResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueByteArray()).isEqualTo("val2".getBytes()));
@@ -753,7 +758,8 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPopFrontWhenNullCacheName() {
-    assertThat(target.listPopFront(null, listName))
+    final String listName = randomString();
+    assertThat(cacheClient.listPopFront(null, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -762,7 +768,7 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPopFrontWhenNullListName() {
-    assertThat(target.listPopFront(cacheName, null))
+    assertThat(cacheClient.listPopFront(cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPopFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -770,30 +776,32 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listPushBackStringHappyPath() {
+    final String listName = randomString();
     final String oldValue = "val1";
     final String newValue = "val2";
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listPushBack(cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushBack(
+                cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushBackResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushBack(cacheName, listName, oldValue))
+    assertThat(cacheClient.listPushBack(cacheName, listName, oldValue))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushBackResponse.Success.class);
 
     final List<String> expectedList = Arrays.asList(oldValue, oldValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -803,12 +811,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add a new value and truncate the list to 2 items
-    assertThat(target.listPushBack(cacheName, listName, newValue, 2))
+    assertThat(cacheClient.listPushBack(cacheName, listName, newValue, 2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushBackResponse.Success.class);
 
     final List<String> newExpectedList = Arrays.asList(oldValue, newValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -820,30 +828,32 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listPushBackByteArrayHappyPath() {
+    final String listName = randomString();
     final byte[] oldValue = "val1".getBytes();
     final byte[] newValue = "val2".getBytes();
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listPushBack(cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushBack(
+                cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushBackResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListByteArray()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushBack(cacheName, listName, oldValue))
+    assertThat(cacheClient.listPushBack(cacheName, listName, oldValue))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushBackResponse.Success.class);
 
     final List<byte[]> expectedList = Arrays.asList(oldValue, oldValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -853,12 +863,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add a new value and truncate the list to 2 items
-    assertThat(target.listPushBack(cacheName, listName, newValue, 2))
+    assertThat(cacheClient.listPushBack(cacheName, listName, newValue, 2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushBackResponse.Success.class);
 
     final List<byte[]> newExpectedList = Arrays.asList(oldValue, newValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -871,29 +881,33 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPushBackWhenNullCacheName() {
+    final String listName = randomString();
     final String stringValue = "val1";
     final byte[] byteArrayValue = "val1".getBytes();
 
     // With ttl specified in method signature
-    assertThat(target.listPushBack(null, listName, stringValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.listPushBack(null, listName, stringValue, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushBack(null, listName, stringValue, 0))
+    assertThat(cacheClient.listPushBack(null, listName, stringValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
-    assertThat(target.listPushBack(null, listName, byteArrayValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.listPushBack(
+                null, listName, byteArrayValue, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushBack(null, listName, byteArrayValue, 0))
+    assertThat(cacheClient.listPushBack(null, listName, byteArrayValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -906,26 +920,28 @@ public class ListTest extends BaseTestClass {
     final byte[] byteArrayValue = "val1".getBytes();
 
     // With ttl specified in method signature
-    assertThat(target.listPushBack(cacheName, null, stringValue, 0, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.listPushBack(cacheName, null, stringValue, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushBack(cacheName, null, stringValue, 0))
+    assertThat(cacheClient.listPushBack(cacheName, null, stringValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushBack(cacheName, null, byteArrayValue, 0, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushBack(
+                cacheName, null, byteArrayValue, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushBack(cacheName, null, byteArrayValue, 0))
+    assertThat(cacheClient.listPushBack(cacheName, null, byteArrayValue, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -934,30 +950,31 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPushBackWhenNullElement() {
+    final String listName = randomString();
     // With ttl specified in method signature
     assertThat(
-            target.listPushBack(
+            cacheClient.listPushBack(
                 cacheName, listName, (String) null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushBack(cacheName, listName, (String) null, 0))
+    assertThat(cacheClient.listPushBack(cacheName, listName, (String) null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushBack(
+            cacheClient.listPushBack(
                 cacheName, listName, (byte[]) null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushBack(cacheName, listName, (byte[]) null, 0))
+    assertThat(cacheClient.listPushBack(cacheName, listName, (byte[]) null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushBackResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -965,30 +982,32 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listPushFrontStringHappyPath() {
+    final String listName = randomString();
     final String oldValue = "val1";
     final String newValue = "val2";
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listPushFront(cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushFront(
+                cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushFront(cacheName, listName, oldValue))
+    assertThat(cacheClient.listPushFront(cacheName, listName, oldValue))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushFrontResponse.Success.class);
 
     final List<String> expectedList = Arrays.asList(oldValue, oldValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -998,12 +1017,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add a new value and truncate the list to 2 items
-    assertThat(target.listPushFront(cacheName, listName, newValue, 2))
+    assertThat(cacheClient.listPushFront(cacheName, listName, newValue, 2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushFrontResponse.Success.class);
 
     final List<String> newExpectedList = Arrays.asList(newValue, oldValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -1015,30 +1034,32 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listPushFrontByteArrayHappyPath() {
+    final String listName = randomString();
     final byte[] oldValue = "val1".getBytes();
     final byte[] newValue = "val2".getBytes();
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListFetchResponse.Miss.class);
 
     assertThat(
-            target.listPushFront(cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushFront(
+                cacheName, listName, oldValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListByteArray()).hasSize(1).containsOnly(oldValue));
 
     // Add the same value
-    assertThat(target.listPushFront(cacheName, listName, oldValue))
+    assertThat(cacheClient.listPushFront(cacheName, listName, oldValue))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushFrontResponse.Success.class);
 
     final List<byte[]> expectedList = Arrays.asList(oldValue, oldValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -1048,12 +1069,12 @@ public class ListTest extends BaseTestClass {
                     .containsExactlyElementsOf(expectedList));
 
     // Add a new value and truncate the list to 2 items
-    assertThat(target.listPushFront(cacheName, listName, newValue, 2))
+    assertThat(cacheClient.listPushFront(cacheName, listName, newValue, 2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListPushFrontResponse.Success.class);
 
     final List<byte[]> newExpectedList = Arrays.asList(newValue, oldValue);
-    assertThat(target.listFetch(cacheName, listName))
+    assertThat(cacheClient.listFetch(cacheName, listName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -1066,32 +1087,34 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPushFrontWhenNullCacheName() {
+    final String listName = randomString();
     final String stringValue = "val1";
     final byte[] byteArrayValue = "val1".getBytes();
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(null, listName, stringValue, null, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushFront(
+                null, listName, stringValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(null, listName, stringValue, null))
+    assertThat(cacheClient.listPushFront(null, listName, stringValue, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(
+            cacheClient.listPushFront(
                 null, listName, byteArrayValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(null, listName, byteArrayValue, null))
+    assertThat(cacheClient.listPushFront(null, listName, byteArrayValue, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1105,27 +1128,28 @@ public class ListTest extends BaseTestClass {
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(cacheName, null, stringValue, null, CollectionTtl.fromCacheTtl()))
+            cacheClient.listPushFront(
+                cacheName, null, stringValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, null, stringValue, null))
+    assertThat(cacheClient.listPushFront(cacheName, null, stringValue, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(
+            cacheClient.listPushFront(
                 cacheName, null, byteArrayValue, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, null, byteArrayValue, null))
+    assertThat(cacheClient.listPushFront(cacheName, null, byteArrayValue, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1134,30 +1158,31 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListPushFrontWhenNullElement() {
+    final String listName = randomString();
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(
+            cacheClient.listPushFront(
                 cacheName, listName, (String) null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, listName, (String) null, 0))
+    assertThat(cacheClient.listPushFront(cacheName, listName, (String) null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // With ttl specified in method signature
     assertThat(
-            target.listPushFront(
+            cacheClient.listPushFront(
                 cacheName, listName, (byte[]) null, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // Without ttl specified in method signature
-    assertThat(target.listPushFront(cacheName, listName, (byte[]) null, 0))
+    assertThat(cacheClient.listPushFront(cacheName, listName, (byte[]) null, 0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListPushFrontResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1165,22 +1190,23 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listRemoveValueStringHappyPath() {
+    final String listName = randomString();
     List<String> values = Arrays.asList("val1", "val1", "val2", "val3", "val4");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, values, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
     // Remove value from list
     String removeValue = "val1";
-    assertThat(target.listRemoveValue(cacheName, listName, removeValue))
+    assertThat(cacheClient.listRemoveValue(cacheName, listName, removeValue))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRemoveValueResponse.Success.class);
 
     List<String> expectedList = Arrays.asList("val2", "val3", "val4");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(3).containsAll(expectedList));
@@ -1188,6 +1214,7 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void listRemoveValueByteArrayHappyPath() {
+    final String listName = randomString();
     List<byte[]> values =
         Arrays.asList(
             "val1".getBytes(),
@@ -1197,20 +1224,20 @@ public class ListTest extends BaseTestClass {
             "val4".getBytes());
 
     assertThat(
-            target.listConcatenateFrontByteArray(
+            cacheClient.listConcatenateFrontByteArray(
                 cacheName, listName, values, 0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
     // Remove value from list
     byte[] removeValue = "val1".getBytes();
-    assertThat(target.listRemoveValue(cacheName, listName, removeValue))
+    assertThat(cacheClient.listRemoveValue(cacheName, listName, removeValue))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRemoveValueResponse.Success.class);
 
     List<byte[]> expectedList =
         Arrays.asList("val2".getBytes(), "val3".getBytes(), "val4".getBytes());
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -1220,15 +1247,16 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListRemoveValueWhenNullCacheName() {
+    final String listName = randomString();
     String stringValue = "val1";
     byte[] byteArrayValue = "val1".getBytes();
 
-    assertThat(target.listRemoveValue(null, listName, stringValue))
+    assertThat(cacheClient.listRemoveValue(null, listName, stringValue))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRemoveValueResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(target.listRemoveValue(null, listName, byteArrayValue))
+    assertThat(cacheClient.listRemoveValue(null, listName, byteArrayValue))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRemoveValueResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1240,12 +1268,12 @@ public class ListTest extends BaseTestClass {
     String stringValue = "val1";
     byte[] byteArrayValue = "val1".getBytes();
 
-    assertThat(target.listRemoveValue(cacheName, null, stringValue))
+    assertThat(cacheClient.listRemoveValue(cacheName, null, stringValue))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRemoveValueResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(target.listRemoveValue(cacheName, null, byteArrayValue))
+    assertThat(cacheClient.listRemoveValue(cacheName, null, byteArrayValue))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRemoveValueResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1254,12 +1282,13 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldFailListRemoveValueWhenNullElement() {
-    assertThat(target.listRemoveValue(cacheName, listName, (String) null))
+    final String listName = randomString();
+    assertThat(cacheClient.listRemoveValue(cacheName, listName, (String) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRemoveValueResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(target.listRemoveValue(null, listName, (byte[]) null))
+    assertThat(cacheClient.listRemoveValue(null, listName, (byte[]) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRemoveValueResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1267,26 +1296,26 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldRetainAllValuesWhenListRetainWithPositiveStartEndIndices() {
-    final String listName = "listName";
+    final String listName = randomString();
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3", "val4");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(4).containsAll(stringValues));
 
-    assertThat(target.listRetain(cacheName, listName, 1, 3))
+    assertThat(cacheClient.listRetain(cacheName, listName, 1, 3))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
     List<String> expectedList = Arrays.asList("val2", "val3");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(2).containsAll(expectedList));
@@ -1294,26 +1323,26 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldRetainAllValuesWhenListRetainWithNegativeStartEndIndices() {
-    final String listName = "listName";
+    final String listName = randomString();
     final List<String> stringValues = Arrays.asList("val1", "val2", "val3", "val4");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(4).containsAll(stringValues));
 
-    assertThat(target.listRetain(cacheName, listName, -3, -1))
+    assertThat(cacheClient.listRetain(cacheName, listName, -3, -1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
     List<String> expectedList = Arrays.asList("val2", "val3");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(2).containsAll(expectedList));
@@ -1321,40 +1350,40 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldRetainAllValuesWhenListRetainWithNullStartIndex() {
-    final String listName = "listName";
+    final String listName = randomString();
     final List<String> stringValues =
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(8).containsAll(stringValues));
 
     // valid case for null startIndex and positive endIndex
-    assertThat(target.listRetain(cacheName, listName, null, 7))
+    assertThat(cacheClient.listRetain(cacheName, listName, null, 7))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
     List<String> expectedList =
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(7).containsAll(expectedList));
 
     // valid case for null startIndex and negative endIndex
-    assertThat(target.listRetain(cacheName, listName, null, -3))
+    assertThat(cacheClient.listRetain(cacheName, listName, null, -3))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
     List<String> newExpectedList = Arrays.asList("val1", "val2", "val3", "val4");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -1363,39 +1392,39 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldRetainAllValuesWhenListRetainWithNullEndIndex() {
-    final String listName = "listName";
+    final String listName = randomString();
     final List<String> stringValues =
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(8).containsAll(stringValues));
 
     // valid case for positive startIndex and null endIndex
-    assertThat(target.listRetain(cacheName, listName, 2, null))
+    assertThat(cacheClient.listRetain(cacheName, listName, 2, null))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
     List<String> expectedList = Arrays.asList("val3", "val4", "val5", "val6", "val7", "val8");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(6).containsAll(expectedList));
 
     // valid case for negative startIndex and null endIndex
-    assertThat(target.listRetain(cacheName, listName, -4, null))
+    assertThat(cacheClient.listRetain(cacheName, listName, -4, null))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
     List<String> newExpectedList = Arrays.asList("val5", "val6", "val7", "val8");
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(
@@ -1404,27 +1433,27 @@ public class ListTest extends BaseTestClass {
 
   @Test
   public void shouldRetainAllValuesWhenListRetainWithNullStartAndEndIndices() {
-    final String listName = "listName";
+    final String listName = randomString();
     final List<String> stringValues =
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(8).containsAll(stringValues));
 
     // valid case for null startIndex and null endIndex
-    assertThat(target.listRetain(cacheName, listName, null, null))
+    assertThat(cacheClient.listRetain(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListRetainResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(8).containsAll(stringValues));
@@ -1433,35 +1462,35 @@ public class ListTest extends BaseTestClass {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void shouldRetainAllValuesWhenListRetainWithInvalidIndices() {
-    final String listName = "listName";
+    final String listName = randomString();
     final List<String> stringValues =
         Arrays.asList("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8");
 
     assertThat(
-            target.listConcatenateFront(
+            cacheClient.listConcatenateFront(
                 cacheName, listName, stringValues, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(ListConcatenateFrontResponse.Success.class);
 
-    assertThat(target.listFetch(cacheName, listName, null, null))
+    assertThat(cacheClient.listFetch(cacheName, listName, null, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueListString()).hasSize(8).containsAll(stringValues));
 
     // the positive startIndex is larger than the positive endIndex
-    assertThat(target.listRetain(null, listName, 3, 1))
+    assertThat(cacheClient.listRetain(null, listName, 3, 1))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRetainResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // the positive startIndex is the same value as the positive endIndex
-    assertThat(target.listRetain(null, listName, 3, 3))
+    assertThat(cacheClient.listRetain(null, listName, 3, 3))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRetainResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     // the negative startIndex is the larger than the negative endIndex
-    assertThat(target.listRetain(null, listName, -3, -5))
+    assertThat(cacheClient.listRetain(null, listName, -3, -5))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(ListRetainResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
@@ -18,21 +18,16 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
-  private static String cacheName;
   private static MomentoBatchUtils momentoBatchUtils;
 
   @BeforeAll
   static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-
     momentoBatchUtils = MomentoBatchUtils.builder(cacheClient).build();
   }
 
   @AfterAll
   static void teardown() {
     momentoBatchUtils.close();
-    cleanupTestCache(cacheName);
   }
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
@@ -6,9 +6,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Vector;
 import momento.sdk.batchutils.MomentoBatchUtils;
 import momento.sdk.batchutils.request.BatchGetRequest;
 import momento.sdk.batchutils.response.BatchGetResponse;
@@ -147,8 +147,8 @@ public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
             .build();
 
     // test data with more keys than max concurrent requests
-    Vector<String> keys = new Vector<>();
-    Vector<String> values = new Vector<>();
+    ArrayList<String> keys = new ArrayList<>();
+    ArrayList<String> values = new ArrayList<>();
     for (int i = 0; i < numberOfKeys; i++) {
       String key = randomString("testKey" + i);
       String value = randomString("testValue" + i);

--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
@@ -1,57 +1,49 @@
 package momento.sdk;
 
+import static momento.sdk.TestUtils.randomBytes;
+import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.Vector;
 import momento.sdk.batchutils.MomentoBatchUtils;
 import momento.sdk.batchutils.request.BatchGetRequest;
 import momento.sdk.batchutils.response.BatchGetResponse;
-import momento.sdk.config.Configurations;
 import momento.sdk.responses.cache.GetResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
+  private static String cacheName;
+  private static MomentoBatchUtils momentoBatchUtils;
 
-  private CacheClient cacheClient;
-  private String cacheName;
-  private MomentoBatchUtils momentoBatchUtils;
-
-  @BeforeEach
-  void setup() {
-    cacheClient =
-        CacheClient.builder(
-                credentialProvider, Configurations.Laptop.latest(), Duration.ofSeconds(10))
-            .build();
-    cacheName = "batchTest";
-    cacheClient.createCache(cacheName).join();
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
 
     momentoBatchUtils = MomentoBatchUtils.builder(cacheClient).build();
   }
 
-  @AfterEach
-  void teardown() {
+  @AfterAll
+  static void teardown() {
     momentoBatchUtils.close();
-    cacheClient.deleteCache(cacheName).join();
-    cacheClient.close();
+    cleanupTestCache(cacheName);
   }
 
   @Test
   void testBatchGetWithStringKeys() {
     // Setup test data
-    String key1 = "testKey1";
-    String value1 = "testValue1";
+    String key1 = randomString();
+    String value1 = randomString();
     cacheClient.set(cacheName, key1, value1).join();
 
-    String key2 = "testKey2";
-    String value2 = "testValue2";
+    String key2 = randomString();
+    String value2 = randomString();
     cacheClient.set(cacheName, key2, value2).join();
 
     // Create a batch get request
@@ -103,12 +95,12 @@ public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
   @Test
   void testBatchGetWithByteArrayKeys() {
     // Setup test data
-    byte[] key1 = "testKey1".getBytes();
-    byte[] value1 = "testValue1".getBytes();
+    byte[] key1 = randomBytes();
+    byte[] value1 = randomBytes();
     cacheClient.set(cacheName, key1, value1).join();
 
-    byte[] key2 = "testKey2".getBytes();
-    byte[] value2 = "testValue2".getBytes();
+    byte[] key2 = randomBytes();
+    byte[] value2 = randomBytes();
     cacheClient.set(cacheName, key2, value2).join();
 
     // Create a batch get request
@@ -160,14 +152,17 @@ public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
             .build();
 
     // test data with more keys than max concurrent requests
+    Vector<String> keys = new Vector<>();
+    Vector<String> values = new Vector<>();
     for (int i = 0; i < numberOfKeys; i++) {
-      String key = "testKey" + i;
-      String value = "testValue" + i;
+      String key = randomString("testKey" + i);
+      String value = randomString("testValue" + i);
       cacheClient.set(cacheName, key, value).join();
+
+      keys.add(key);
+      values.add(value);
     }
 
-    List<String> keys =
-        IntStream.range(0, numberOfKeys).mapToObj(i -> "testKey" + i).collect(Collectors.toList());
     BatchGetRequest.StringKeyBatchGetRequest request =
         new BatchGetRequest.StringKeyBatchGetRequest(keys);
 
@@ -183,8 +178,8 @@ public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
 
     // Assert each response
     for (int i = 0; i < numberOfKeys; i++) {
-      String expectedKey = "testKey" + i;
-      String expectedValue = "testValue" + i;
+      String expectedKey = keys.get(i);
+      String expectedValue = values.get(i);
       boolean keyFound =
           summaries.stream()
               .anyMatch(
@@ -204,7 +199,8 @@ public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
   @Test
   void testBatchGetOrderWithStringKeys() {
     // Setup test data with a specific order
-    List<String> keys = Arrays.asList("key3", "key1", "key2");
+    List<String> keys =
+        Arrays.asList(randomString("key3"), randomString("key1"), randomString("key2"));
     List<String> values = Arrays.asList("value3", "value1", "value2");
 
     for (int i = 0; i < keys.size(); i++) {

--- a/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
@@ -15,24 +15,9 @@ import momento.sdk.responses.cache.set.SetFetchResponse;
 import momento.sdk.responses.cache.set.SetRemoveElementResponse;
 import momento.sdk.responses.cache.set.SetRemoveElementsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class SetTest extends BaseTestClass {
-  private static String cacheName;
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
-
   @Test
   public void setAddElementStringHappyPath() {
     final String setName = randomString();

--- a/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
@@ -1,13 +1,12 @@
 package momento.sdk;
 
+import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
-import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.requests.CollectionTtl;
 import momento.sdk.responses.cache.set.SetAddElementResponse;
@@ -16,66 +15,61 @@ import momento.sdk.responses.cache.set.SetFetchResponse;
 import momento.sdk.responses.cache.set.SetRemoveElementResponse;
 import momento.sdk.responses.cache.set.SetRemoveElementsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class SetTest extends BaseTestClass {
-  private static final Duration DEFAULT_TTL = Duration.ofSeconds(60);
+  private static String cacheName;
 
-  private final String cacheName = System.getenv("TEST_CACHE_NAME");
-  private CacheClient client;
-
-  private final String setName = "test-set";
-
-  @BeforeEach
-  void setup() {
-    client =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL)
-            .build();
-    client.createCache(cacheName).join();
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
-  @AfterEach
-  void teardown() {
-    client.deleteCache(cacheName).join();
-    client.close();
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
   }
 
   @Test
   public void setAddElementStringHappyPath() {
+    final String setName = randomString();
     final String element1 = "1";
     final String element2 = "2";
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
 
-    assertThat(client.setAddElement(cacheName, setName, element1))
+    assertThat(cacheClient.setAddElement(cacheName, setName, element1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
 
     // Try to add the same element again
-    assertThat(client.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
 
     // Add a different element
-    assertThat(client.setAddElement(cacheName, setName, element2, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(cacheName, setName, element2, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
@@ -84,34 +78,37 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementBytesHappyPath() {
+    final String setName = randomString();
     final byte[] element1 = "one".getBytes();
     final byte[] element2 = "two".getBytes();
 
-    assertThat(client.setAddElement(cacheName, setName, element1))
+    assertThat(cacheClient.setAddElement(cacheName, setName, element1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element1));
 
     // Try to add the same element again
-    assertThat(client.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(cacheName, setName, element1, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element1));
 
     // Add a different element
-    assertThat(client.setAddElement(cacheName, setName, element2, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(cacheName, setName, element2, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
@@ -120,15 +117,17 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementReturnsErrorWithNullCacheName() {
+    final String setName = randomString();
     final String elementString = "element";
     final byte[] elementBytes = elementString.getBytes(StandardCharsets.UTF_8);
 
-    assertThat(client.setAddElement(null, setName, elementString, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(null, setName, elementString, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setAddElement(null, setName, elementBytes, CollectionTtl.fromCacheTtl()))
+    assertThat(cacheClient.setAddElement(null, setName, elementBytes, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -139,12 +138,14 @@ public class SetTest extends BaseTestClass {
     final String elementString = "element";
     final byte[] elementBytes = elementString.getBytes(StandardCharsets.UTF_8);
 
-    assertThat(client.setAddElement(cacheName, null, elementString, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(cacheName, null, elementString, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setAddElement(cacheName, null, elementBytes, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElement(cacheName, null, elementBytes, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -152,14 +153,17 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementReturnsErrorWithNullElement() {
+    final String setName = randomString();
     assertThat(
-            client.setAddElement(cacheName, setName, (String) null, CollectionTtl.fromCacheTtl()))
+            cacheClient.setAddElement(
+                cacheName, setName, (String) null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.setAddElement(cacheName, setName, (byte[]) null, CollectionTtl.fromCacheTtl()))
+            cacheClient.setAddElement(
+                cacheName, setName, (byte[]) null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -167,34 +171,37 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementsStringHappyPath() {
+    final String setName = randomString();
     final Set<String> firstSet = Sets.newHashSet("one", "two");
     final Set<String> secondSet = Sets.newHashSet("two", "three");
 
-    assertThat(client.setAddElements(cacheName, setName, firstSet))
+    assertThat(cacheClient.setAddElements(cacheName, setName, firstSet))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(2).containsAll(firstSet));
 
     // Try to add the same elements again
-    assertThat(client.setAddElements(cacheName, setName, firstSet, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElements(cacheName, setName, firstSet, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(2).containsAll(firstSet));
 
     // Add a set with one new and one overlapping element
-    assertThat(client.setAddElements(cacheName, setName, secondSet, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElements(cacheName, setName, secondSet, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
@@ -207,38 +214,39 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementsByteArrayHappyPath() {
+    final String setName = randomString();
     final Set<byte[]> firstSet = Sets.newHashSet("one".getBytes(), "two".getBytes());
     final Set<byte[]> secondSet = Sets.newHashSet("two".getBytes(), "three".getBytes());
 
-    assertThat(client.setAddElementsByteArray(cacheName, setName, firstSet))
+    assertThat(cacheClient.setAddElementsByteArray(cacheName, setName, firstSet))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(2).containsAll(firstSet));
 
     // Try to add the same elements again
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 cacheName, setName, firstSet, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(2).containsAll(firstSet));
 
     // Add a set with one new and one overlapping element
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 cacheName, setName, secondSet, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
@@ -251,16 +259,18 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementsReturnsErrorWithNullCacheName() {
+    final String setName = randomString();
     final Set<String> stringElements = Collections.singleton("element");
     final Set<byte[]> bytesElements = Collections.singleton("bytes-element".getBytes());
 
-    assertThat(client.setAddElements(null, setName, stringElements, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElements(null, setName, stringElements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 null, setName, bytesElements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementsResponse.Error.class))
@@ -272,13 +282,15 @@ public class SetTest extends BaseTestClass {
     final Set<String> stringElements = Collections.singleton("element");
     final Set<byte[]> bytesElements = Collections.singleton("bytes-element".getBytes());
 
-    assertThat(client.setAddElements(cacheName, null, stringElements, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElements(
+                cacheName, null, stringElements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 cacheName, null, bytesElements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementsResponse.Error.class))
@@ -287,13 +299,14 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setAddElementsReturnsErrorWithNullElements() {
-    assertThat(client.setAddElements(cacheName, cacheName, null, CollectionTtl.fromCacheTtl()))
+    final String setName = randomString();
+    assertThat(cacheClient.setAddElements(cacheName, cacheName, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 cacheName, cacheName, null, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetAddElementsResponse.Error.class))
@@ -302,129 +315,133 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setRemoveElementStringHappyPath() {
+    final String setName = randomString();
     final String element1 = "one";
     final String element2 = "two";
     final Set<String> elements = Sets.newHashSet(element1, element2);
 
     // Add some elements to a set
-    assertThat(client.setAddElements(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElements(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
             hit -> assertThat(hit.valueSetString()).hasSize(2).containsOnly(element1, element2));
 
     // Remove an element
-    assertThat(client.setRemoveElement(cacheName, setName, element1))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element2));
 
     // Try to remove the same element again
-    assertThat(client.setRemoveElement(cacheName, setName, element1))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element2));
 
     // Remove the last element
-    assertThat(client.setRemoveElement(cacheName, setName, element2))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
 
     // Remove an element from the now non-existent set
-    assertThat(client.setRemoveElement(cacheName, setName, element2))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
   }
 
   @Test
   public void setRemoveElementByteArrayHappyPath() {
+    final String setName = randomString();
     final byte[] element1 = "one".getBytes();
     final byte[] element2 = "two".getBytes();
     final Set<byte[]> elements = Sets.newHashSet(element1, element2);
 
     // Add some elements to a set
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
             hit -> assertThat(hit.valueSetByteArray()).hasSize(2).containsOnly(element1, element2));
 
     // Remove an element
-    assertThat(client.setRemoveElement(cacheName, setName, element1))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element2));
 
     // Try to remove the same element again
-    assertThat(client.setRemoveElement(cacheName, setName, element1))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element1))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element2));
 
     // Remove the last element
-    assertThat(client.setRemoveElement(cacheName, setName, element2))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
 
     // Remove an element from the now non-existent set
-    assertThat(client.setRemoveElement(cacheName, setName, element2))
+    assertThat(cacheClient.setRemoveElement(cacheName, setName, element2))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
   }
 
   @Test
   public void setRemoveElementReturnsErrorWithNullCacheName() {
+    final String setName = randomString();
     final String elementString = "element";
     final byte[] elementBytes = elementString.getBytes(StandardCharsets.UTF_8);
 
-    assertThat(client.setRemoveElement(null, setName, elementString))
+    assertThat(cacheClient.setRemoveElement(null, setName, elementString))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setRemoveElement(null, setName, elementBytes))
+    assertThat(cacheClient.setRemoveElement(null, setName, elementBytes))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -435,12 +452,12 @@ public class SetTest extends BaseTestClass {
     final String elementString = "element";
     final byte[] elementBytes = elementString.getBytes(StandardCharsets.UTF_8);
 
-    assertThat(client.setRemoveElement(cacheName, null, elementString))
+    assertThat(cacheClient.setRemoveElement(cacheName, null, elementString))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setRemoveElement(cacheName, null, elementBytes))
+    assertThat(cacheClient.setRemoveElement(cacheName, null, elementBytes))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -448,12 +465,13 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setRemoveElementReturnsErrorWithNullElement() {
-    assertThat(client.setRemoveElement(cacheName, cacheName, (String) null))
+    final String setName = randomString();
+    assertThat(cacheClient.setRemoveElement(cacheName, cacheName, (String) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setRemoveElement(cacheName, cacheName, (byte[]) null))
+    assertThat(cacheClient.setRemoveElement(cacheName, cacheName, (byte[]) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -461,6 +479,7 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setRemoveElementsStringHappyPath() {
+    final String setName = randomString();
     final String element1 = "one";
     final String element2 = "two";
     final String element3 = "three";
@@ -468,11 +487,12 @@ public class SetTest extends BaseTestClass {
     final Set<String> elements = Sets.newHashSet(element1, element2, element3);
 
     // Add some elements to a set
-    assertThat(client.setAddElements(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
+    assertThat(
+            cacheClient.setAddElements(cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
@@ -483,49 +503,50 @@ public class SetTest extends BaseTestClass {
 
     // Remove some elements that are in the set and one that isn't
     assertThat(
-            client.setRemoveElements(
+            cacheClient.setRemoveElements(
                 cacheName, setName, Sets.newHashSet(element2, element3, element4)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
 
     // Try to remove an element that has already been removed
-    assertThat(client.setRemoveElements(cacheName, setName, Collections.singleton(element3)))
+    assertThat(cacheClient.setRemoveElements(cacheName, setName, Collections.singleton(element3)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetString()).hasSize(1).containsOnly(element1));
 
     // Remove everything
-    assertThat(client.setRemoveElements(cacheName, setName, elements))
+    assertThat(cacheClient.setRemoveElements(cacheName, setName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
 
     // Remove elements from the now non-existent set
     assertThat(
-            client.setRemoveElements(
+            cacheClient.setRemoveElements(
                 cacheName, setName, Sets.newHashSet(element1, element2, element3, element4)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
   }
 
   @Test
   public void setRemoveElementsByteArrayHappyPath() {
+    final String setName = randomString();
     final byte[] element1 = "one".getBytes();
     final byte[] element2 = "two".getBytes();
     final byte[] element3 = "three".getBytes();
@@ -534,12 +555,12 @@ public class SetTest extends BaseTestClass {
 
     // Add some elements to a set
     assertThat(
-            client.setAddElementsByteArray(
+            cacheClient.setAddElementsByteArray(
                 cacheName, setName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetAddElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(
@@ -550,59 +571,61 @@ public class SetTest extends BaseTestClass {
 
     // Remove some elements that are in the set and one that isn't
     assertThat(
-            client.setRemoveElementsByteArray(
+            cacheClient.setRemoveElementsByteArray(
                 cacheName, setName, Sets.newHashSet(element2, element3, element4)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element1));
 
     // Try to remove an element that has already been removed
     assertThat(
-            client.setRemoveElementsByteArray(cacheName, setName, Collections.singleton(element3)))
+            cacheClient.setRemoveElementsByteArray(
+                cacheName, setName, Collections.singleton(element3)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.valueSetByteArray()).hasSize(1).containsOnly(element1));
 
     // Remove everything
-    assertThat(client.setRemoveElementsByteArray(cacheName, setName, elements))
+    assertThat(cacheClient.setRemoveElementsByteArray(cacheName, setName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
 
     // Remove elements from the now non-existent set
     assertThat(
-            client.setRemoveElementsByteArray(
+            cacheClient.setRemoveElementsByteArray(
                 cacheName, setName, Sets.newHashSet(element1, element2, element3, element4)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetRemoveElementsResponse.Success.class);
 
-    assertThat(client.setFetch(cacheName, setName))
+    assertThat(cacheClient.setFetch(cacheName, setName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SetFetchResponse.Miss.class);
   }
 
   @Test
   public void setRemoveElementsReturnsErrorWithNullCacheName() {
+    final String setName = randomString();
     final Set<String> stringElements = Sets.newHashSet("element");
     final Set<byte[]> bytesElements = Sets.newHashSet("bytes-element".getBytes());
 
-    assertThat(client.setRemoveElements(null, setName, stringElements))
+    assertThat(cacheClient.setRemoveElements(null, setName, stringElements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setRemoveElementsByteArray(null, setName, bytesElements))
+    assertThat(cacheClient.setRemoveElementsByteArray(null, setName, bytesElements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -613,12 +636,12 @@ public class SetTest extends BaseTestClass {
     final Set<String> stringElements = Sets.newHashSet("element");
     final Set<byte[]> bytesElements = Sets.newHashSet("bytes-element".getBytes());
 
-    assertThat(client.setRemoveElements(cacheName, null, stringElements))
+    assertThat(cacheClient.setRemoveElements(cacheName, null, stringElements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setRemoveElementsByteArray(cacheName, null, bytesElements))
+    assertThat(cacheClient.setRemoveElementsByteArray(cacheName, null, bytesElements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -626,12 +649,13 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setRemoveElementsReturnsErrorWithNullElements() {
-    assertThat(client.setRemoveElements(cacheName, cacheName, null))
+    final String setName = randomString();
+    assertThat(cacheClient.setRemoveElements(cacheName, cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.setRemoveElementsByteArray(cacheName, cacheName, null))
+    assertThat(cacheClient.setRemoveElementsByteArray(cacheName, cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -639,7 +663,8 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setFetchReturnsErrorWithNullCacheName() {
-    assertThat(client.setFetch(null, "set"))
+    final String setName = randomString();
+    assertThat(cacheClient.setFetch(null, "set"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -647,7 +672,7 @@ public class SetTest extends BaseTestClass {
 
   @Test
   public void setFetchReturnsErrorWithNullSetName() {
-    assertThat(client.setFetch(cacheName, null))
+    assertThat(cacheClient.setFetch(cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -27,24 +27,9 @@ import momento.sdk.responses.cache.sortedset.SortedSetPutElementsResponse;
 import momento.sdk.responses.cache.sortedset.SortedSetRemoveElementResponse;
 import momento.sdk.responses.cache.sortedset.SortedSetRemoveElementsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class SortedSetTest extends BaseTestClass {
-  private static String cacheName;
-
-  @BeforeAll
-  static void setup() {
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
-  }
-
-  @AfterAll
-  static void teardown() {
-    cleanupTestCache(cacheName);
-  }
-
   // sortedSetPutElement
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -13,7 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import momento.sdk.config.Configurations;
 import momento.sdk.exceptions.CacheNotFoundException;
 import momento.sdk.exceptions.InvalidArgumentException;
 import momento.sdk.requests.CollectionTtl;
@@ -29,51 +27,43 @@ import momento.sdk.responses.cache.sortedset.SortedSetPutElementsResponse;
 import momento.sdk.responses.cache.sortedset.SortedSetRemoveElementResponse;
 import momento.sdk.responses.cache.sortedset.SortedSetRemoveElementsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class SortedSetTest extends BaseTestClass {
-  private static final Duration DEFAULT_TTL = Duration.ofSeconds(60);
+  private static String cacheName;
 
-  private final String cacheName = System.getenv("TEST_CACHE_NAME");
-  private CacheClient client;
-
-  private String sortedSetName;
-
-  @BeforeEach
-  void setup() {
-    client =
-        CacheClient.builder(credentialProvider, Configurations.Laptop.latest(), DEFAULT_TTL)
-            .build();
-    client.createCache(cacheName).join();
-    sortedSetName = randomString("sortedSet");
+  @BeforeAll
+  static void setup() {
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
   }
 
-  @AfterEach
-  void teardown() {
-    client.deleteCache(cacheName).join();
-    client.close();
+  @AfterAll
+  static void teardown() {
+    cleanupTestCache(cacheName);
   }
 
   // sortedSetPutElement
 
   @Test
   public void sortedSetPutElementStringHappyPath() {
+    final String sortedSetName = randomString();
     final String value = "1";
     final double score = 1.0;
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
     assertThat(
-            client.sortedSetPutElement(
+            cacheClient.sortedSetPutElement(
                 cacheName, sortedSetName, value, score, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -86,20 +76,21 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementBytesHappyPath() {
+    final String sortedSetName = randomString();
     final byte[] value = "1".getBytes();
     final double score = 1.0;
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
     assertThat(
-            client.sortedSetPutElement(
+            cacheClient.sortedSetPutElement(
                 cacheName, sortedSetName, value, score, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -114,6 +105,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementsWithScoredElementsHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
     final String three = "3";
@@ -128,13 +120,13 @@ public class SortedSetTest extends BaseTestClass {
     elements.add(new ScoredElement(five, 1.5));
 
     assertThat(
-            client.sortedSetPutElements(
+            cacheClient.sortedSetPutElements(
                 cacheName, sortedSetName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
     // Full set ascending
-    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByScore(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -150,12 +142,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetPutElement(null, sortedSetName, "element", 1.0))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetPutElement(null, sortedSetName, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetPutElement(null, sortedSetName, "element".getBytes(), 1.0))
+    assertThat(cacheClient.sortedSetPutElement(null, sortedSetName, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -163,13 +156,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetPutElement(randomString("cache"), sortedSetName, "element", 1.0))
+    final String sortedSetName = randomString();
+    assertThat(
+            cacheClient.sortedSetPutElement(randomString("cache"), sortedSetName, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetPutElement(
+            cacheClient.sortedSetPutElement(
                 randomString("cache"), sortedSetName, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
@@ -178,12 +173,12 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetPutElement(cacheName, null, "element", 1.0))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, null, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetPutElement(cacheName, null, "element".getBytes(), 1.0))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, null, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -193,22 +188,23 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementsStringHappyPath() {
+    final String sortedSetName = randomString();
     final Map<String, Double> elements = new HashMap<>();
     elements.put("1", 0.1);
     elements.put("2", 0.5);
     elements.put("3", 1.0);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
     assertThat(
-            client.sortedSetPutElements(
+            cacheClient.sortedSetPutElements(
                 cacheName, sortedSetName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -225,22 +221,23 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementsBytesHappyPath() {
+    final String sortedSetName = randomString();
     final Map<byte[], Double> elements = new HashMap<>();
     elements.put("1".getBytes(), 0.0);
     elements.put("2".getBytes(), 0.5);
     elements.put("3".getBytes(), 1.0);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
     assertThat(
-            client.sortedSetPutElementsByteArray(
+            cacheClient.sortedSetPutElementsByteArray(
                 cacheName, sortedSetName, elements, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -257,15 +254,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementsReturnsErrorWithNullCacheName() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetPutElements(
+            cacheClient.sortedSetPutElements(
                 null, sortedSetName, Collections.singletonMap("element", 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetPutElementsByteArray(
+            cacheClient.sortedSetPutElementsByteArray(
                 null, sortedSetName, Collections.singletonMap("element".getBytes(), 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
@@ -274,15 +272,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetPutElementsReturnsErrorWithNonexistentCacheName() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetPutElements(
+            cacheClient.sortedSetPutElements(
                 randomString("cache"), sortedSetName, Collections.singletonMap("element", 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetPutElementsByteArray(
+            cacheClient.sortedSetPutElementsByteArray(
                 randomString("cache"),
                 sortedSetName,
                 Collections.singletonMap("element".getBytes(), 1.0)))
@@ -294,13 +293,14 @@ public class SortedSetTest extends BaseTestClass {
   @Test
   public void sortedSetPutElementsReturnsErrorWithNullSetName() {
     assertThat(
-            client.sortedSetPutElements(cacheName, null, Collections.singletonMap("element", 1.0)))
+            cacheClient.sortedSetPutElements(
+                cacheName, null, Collections.singletonMap("element", 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetPutElementsByteArray(
+            cacheClient.sortedSetPutElementsByteArray(
                 cacheName, null, Collections.singletonMap("element".getBytes(), 1.0)))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetPutElementsResponse.Error.class))
@@ -311,6 +311,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByRankStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
     final String three = "3";
@@ -324,16 +325,17 @@ public class SortedSetTest extends BaseTestClass {
     elements.put(four, 2.0);
     elements.put(five, 1.5);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElements(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElements(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
     // Full set ascending, end index larger than set
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName, 0, 6, SortOrder.ASCENDING))
+    assertThat(
+            cacheClient.sortedSetFetchByRank(cacheName, sortedSetName, 0, 6, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -347,7 +349,8 @@ public class SortedSetTest extends BaseTestClass {
             });
 
     // Partial set descending
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName, 1, 4, SortOrder.DESCENDING))
+    assertThat(
+            cacheClient.sortedSetFetchByRank(cacheName, sortedSetName, 1, 4, SortOrder.DESCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -363,6 +366,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByRankBytesHappyPath() {
+    final String sortedSetName = randomString();
     final byte[] one = "1".getBytes();
     final byte[] two = "2".getBytes();
     final byte[] three = "3".getBytes();
@@ -376,16 +380,17 @@ public class SortedSetTest extends BaseTestClass {
     elements.put(four, 2.0);
     elements.put(five, 1.5);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElementsByteArray(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElementsByteArray(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
     // Full set ascending, end index larger than set
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName, 0, 6, SortOrder.ASCENDING))
+    assertThat(
+            cacheClient.sortedSetFetchByRank(cacheName, sortedSetName, 0, 6, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -399,7 +404,8 @@ public class SortedSetTest extends BaseTestClass {
             });
 
     // Partial set descending
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName, 1, 4, SortOrder.DESCENDING))
+    assertThat(
+            cacheClient.sortedSetFetchByRank(cacheName, sortedSetName, 1, 4, SortOrder.DESCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -415,7 +421,10 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByRankReturnsErrorWithInvalidIndexRange() {
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName, 1000, -5, SortOrder.ASCENDING))
+    final String sortedSetName = randomString();
+    assertThat(
+            cacheClient.sortedSetFetchByRank(
+                cacheName, sortedSetName, 1000, -5, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -423,7 +432,8 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByRankReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetFetchByRank(null, sortedSetName))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetFetchByRank(null, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -431,7 +441,8 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByRankReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetFetchByRank(randomString("cache"), sortedSetName))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetFetchByRank(randomString("cache"), sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
@@ -439,7 +450,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByRankReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetFetchByRank(cacheName, null))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -449,6 +460,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
     final String three = "3";
@@ -462,17 +474,18 @@ public class SortedSetTest extends BaseTestClass {
     elements.put(four, 2.0);
     elements.put(five, 1.5);
 
-    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByScore(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetFetchResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElements(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElements(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
     // Full set ascending, end index larger than set
     assertThat(
-            client.sortedSetFetchByScore(cacheName, sortedSetName, 0.0, 9.9, SortOrder.ASCENDING))
+            cacheClient.sortedSetFetchByScore(
+                cacheName, sortedSetName, 0.0, 9.9, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -490,7 +503,7 @@ public class SortedSetTest extends BaseTestClass {
 
     // Partial set descending
     assertThat(
-            client.sortedSetFetchByScore(
+            cacheClient.sortedSetFetchByScore(
                 cacheName, sortedSetName, 0.2, 1.9, SortOrder.DESCENDING, 0, 99))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
@@ -505,7 +518,7 @@ public class SortedSetTest extends BaseTestClass {
             });
 
     // Partial set limited by offset and count
-    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName, null, null, null, 1, 3))
+    assertThat(cacheClient.sortedSetFetchByScore(cacheName, sortedSetName, null, null, null, 1, 3))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -519,7 +532,7 @@ public class SortedSetTest extends BaseTestClass {
             });
 
     // Full set ascending
-    assertThat(client.sortedSetFetchByScore(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByScore(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -535,8 +548,9 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithInvalidScoreRange() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetFetchByScore(
+            cacheClient.sortedSetFetchByScore(
                 null, sortedSetName, 10.0, 0.5, SortOrder.ASCENDING, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
@@ -545,7 +559,8 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetFetchByScore(null, sortedSetName, null, null, null, 0, 100))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetFetchByScore(null, sortedSetName, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -553,8 +568,9 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNonexistentCacheName() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetFetchByScore(
+            cacheClient.sortedSetFetchByScore(
                 randomString("cache"), sortedSetName, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
@@ -563,7 +579,7 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetFetchByScoreReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetFetchByScore(cacheName, null, null, null, null, 0, 100))
+    assertThat(cacheClient.sortedSetFetchByScore(cacheName, null, null, null, null, 0, 100))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -573,34 +589,35 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetRankStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
 
-    assertThat(client.sortedSetGetRank(cacheName, sortedSetName, one, null))
+    assertThat(cacheClient.sortedSetGetRank(cacheName, sortedSetName, one, null))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetGetRankResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetRank(cacheName, sortedSetName, one, null))
+    assertThat(cacheClient.sortedSetGetRank(cacheName, sortedSetName, one, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.rank()).isEqualTo(0));
 
     // Add another element that changes the rank of the first one
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetRank(cacheName, sortedSetName, one, null))
+    assertThat(cacheClient.sortedSetGetRank(cacheName, sortedSetName, one, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.rank()).isEqualTo(1));
 
     // Check the descending rank
-    assertThat(client.sortedSetGetRank(cacheName, sortedSetName, one, SortOrder.DESCENDING))
+    assertThat(cacheClient.sortedSetGetRank(cacheName, sortedSetName, one, SortOrder.DESCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.rank()).isEqualTo(0));
@@ -608,13 +625,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetRankReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetGetRank(null, sortedSetName, "element", SortOrder.ASCENDING))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetGetRank(null, sortedSetName, "element", SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetGetRank(null, sortedSetName, "element".getBytes(), SortOrder.ASCENDING))
+            cacheClient.sortedSetGetRank(
+                null, sortedSetName, "element".getBytes(), SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -622,15 +641,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetRankReturnsErrorWithNonexistentCacheName() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetGetRank(
+            cacheClient.sortedSetGetRank(
                 randomString("cache"), sortedSetName, "element", SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetGetRank(
+            cacheClient.sortedSetGetRank(
                 randomString("cache"), sortedSetName, "element".getBytes(), SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
@@ -639,12 +659,14 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetRankReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetGetRank(cacheName, null, "element", SortOrder.ASCENDING))
+    assertThat(cacheClient.sortedSetGetRank(cacheName, null, "element", SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetGetRank(cacheName, null, "element".getBytes(), SortOrder.ASCENDING))
+    assertThat(
+            cacheClient.sortedSetGetRank(
+                cacheName, null, "element".getBytes(), SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -652,14 +674,17 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetRankReturnsErrorWithNullElement() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetGetRank(cacheName, sortedSetName, (String) null, SortOrder.ASCENDING))
+            cacheClient.sortedSetGetRank(
+                cacheName, sortedSetName, (String) null, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetGetRank(cacheName, sortedSetName, (byte[]) null, SortOrder.ASCENDING))
+            cacheClient.sortedSetGetRank(
+                cacheName, sortedSetName, (byte[]) null, SortOrder.ASCENDING))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetRankResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -669,28 +694,29 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoreStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetGetScoreResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.score()).isEqualTo(1.0));
 
     // Add another element that changes the rank of the first one
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.score()).isEqualTo(1.0));
@@ -698,28 +724,29 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoreBytesHappyPath() {
+    final String sortedSetName = randomString();
     final byte[] one = "1".getBytes();
     final byte[] two = "2".getBytes();
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetGetScoreResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.score()).isEqualTo(1.0));
 
     // Add another element that changes the rank of the first one
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Hit.class))
         .satisfies(hit -> assertThat(hit.score()).isEqualTo(1.0));
@@ -727,12 +754,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoreReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetGetScore(null, sortedSetName, "element"))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetGetScore(null, sortedSetName, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetGetScore(null, sortedSetName, "element".getBytes()))
+    assertThat(cacheClient.sortedSetGetScore(null, sortedSetName, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -740,12 +768,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoreReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetGetScore(randomString("cache"), sortedSetName, "element"))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetGetScore(randomString("cache"), sortedSetName, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
-    assertThat(client.sortedSetGetScore(randomString("cache"), sortedSetName, "element".getBytes()))
+    assertThat(
+            cacheClient.sortedSetGetScore(
+                randomString("cache"), sortedSetName, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
@@ -753,12 +784,12 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoreReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetGetScore(cacheName, null, "element"))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, null, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetGetScore(cacheName, null, "element".getBytes()))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, null, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -766,12 +797,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoreReturnsErrorWithNullElement() {
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, (String) null))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, (String) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetGetScore(cacheName, sortedSetName, (byte[]) null))
+    assertThat(cacheClient.sortedSetGetScore(cacheName, sortedSetName, (byte[]) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -781,22 +813,23 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoresStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
     final Set<String> elements = new HashSet<>();
     elements.add(one);
     elements.add(two);
 
-    assertThat(client.sortedSetGetScores(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetGetScores(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetGetScoresResponse.Miss.class);
 
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, one, 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
     // One element in the set, one not in the set
-    assertThat(client.sortedSetGetScores(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetGetScores(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Hit.class))
         .satisfies(
@@ -809,11 +842,11 @@ public class SortedSetTest extends BaseTestClass {
             });
 
     // Add the other element
-    assertThat(client.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
+    assertThat(cacheClient.sortedSetPutElement(cacheName, sortedSetName, two, 0.5))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementResponse.Success.class);
 
-    assertThat(client.sortedSetGetScores(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetGetScores(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Hit.class))
         .satisfies(
@@ -828,13 +861,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoresReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetGetScores(null, sortedSetName, Collections.singleton("element")))
+    final String sortedSetName = randomString();
+    assertThat(
+            cacheClient.sortedSetGetScores(null, sortedSetName, Collections.singleton("element")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetGetScoresByteArray(
+            cacheClient.sortedSetGetScoresByteArray(
                 null, sortedSetName, Collections.singleton("element".getBytes())))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
@@ -843,15 +878,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoresReturnsErrorWithNonexistentCacheName() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetGetScores(
+            cacheClient.sortedSetGetScores(
                 randomString("cache"), sortedSetName, Collections.singleton("element")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetGetScoresByteArray(
+            cacheClient.sortedSetGetScoresByteArray(
                 randomString("cache"), sortedSetName, Collections.singleton("element".getBytes())))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
@@ -860,13 +896,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoresReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetGetScores(cacheName, null, Collections.singleton("element")))
+    assertThat(cacheClient.sortedSetGetScores(cacheName, null, Collections.singleton("element")))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetGetScoresByteArray(
+            cacheClient.sortedSetGetScoresByteArray(
                 cacheName, null, Collections.singleton("element".getBytes())))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
@@ -875,12 +911,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetGetScoresReturnsErrorWithNullElements() {
-    assertThat(client.sortedSetGetScores(cacheName, sortedSetName, null))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetGetScores(cacheName, sortedSetName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetGetScoresByteArray(cacheName, sortedSetName, null))
+    assertThat(cacheClient.sortedSetGetScoresByteArray(cacheName, sortedSetName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetGetScoresResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -890,14 +927,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetIncrementScoreStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
 
-    assertThat(client.sortedSetIncrementScore(cacheName, sortedSetName, one, 1.0))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, sortedSetName, one, 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Success.class))
         .satisfies(success -> assertThat(success.score()).isEqualTo(1.0));
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -907,12 +945,12 @@ public class SortedSetTest extends BaseTestClass {
                     .map(ScoredElement::getScore)
                     .containsOnly(1.0));
 
-    assertThat(client.sortedSetIncrementScore(cacheName, sortedSetName, one, 14.5))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, sortedSetName, one, 14.5))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Success.class))
         .satisfies(success -> assertThat(success.score()).isEqualTo(15.5));
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -922,7 +960,7 @@ public class SortedSetTest extends BaseTestClass {
                     .map(ScoredElement::getScore)
                     .containsOnly(15.5));
 
-    assertThat(client.sortedSetIncrementScore(cacheName, sortedSetName, one, -115.5))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, sortedSetName, one, -115.5))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Success.class))
         .satisfies(success -> assertThat(success.score()).isEqualTo(-100));
@@ -930,14 +968,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetIncrementScoreBytesHappyPath() {
+    final String sortedSetName = randomString();
     final byte[] one = "1".getBytes();
 
-    assertThat(client.sortedSetIncrementScore(cacheName, sortedSetName, one, 1.0))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, sortedSetName, one, 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Success.class))
         .satisfies(success -> assertThat(success.score()).isEqualTo(1.0));
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -947,12 +986,12 @@ public class SortedSetTest extends BaseTestClass {
                     .map(ScoredElement::getScore)
                     .containsOnly(1.0));
 
-    assertThat(client.sortedSetIncrementScore(cacheName, sortedSetName, one, 14.5))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, sortedSetName, one, 14.5))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Success.class))
         .satisfies(success -> assertThat(success.score()).isEqualTo(15.5));
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -962,7 +1001,7 @@ public class SortedSetTest extends BaseTestClass {
                     .map(ScoredElement::getScore)
                     .containsOnly(15.5));
 
-    assertThat(client.sortedSetIncrementScore(cacheName, sortedSetName, one, -115.5))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, sortedSetName, one, -115.5))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Success.class))
         .satisfies(success -> assertThat(success.score()).isEqualTo(-100));
@@ -970,12 +1009,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetIncrementScoreReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetIncrementScore(null, sortedSetName, "element", 1.0))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetIncrementScore(null, sortedSetName, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetIncrementScore(null, sortedSetName, "element".getBytes(), 1.0))
+    assertThat(cacheClient.sortedSetIncrementScore(null, sortedSetName, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -983,13 +1023,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetIncrementScoreReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetIncrementScore(randomString("cache"), sortedSetName, "element", 1.0))
+    final String sortedSetName = randomString();
+    assertThat(
+            cacheClient.sortedSetIncrementScore(
+                randomString("cache"), sortedSetName, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetIncrementScore(
+            cacheClient.sortedSetIncrementScore(
                 randomString("cache"), sortedSetName, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
@@ -998,12 +1041,12 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetIncrementScoreReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetIncrementScore(cacheName, null, "element", 1.0))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, null, "element", 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetIncrementScore(cacheName, null, "element".getBytes(), 1.0))
+    assertThat(cacheClient.sortedSetIncrementScore(cacheName, null, "element".getBytes(), 1.0))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1011,15 +1054,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetIncrementScoreReturnsErrorWithNullElement() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetIncrementScore(
+            cacheClient.sortedSetIncrementScore(
                 cacheName, sortedSetName, (String) null, 1.0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
     assertThat(
-            client.sortedSetIncrementScore(
+            cacheClient.sortedSetIncrementScore(
                 cacheName, sortedSetName, (byte[]) null, 1.0, CollectionTtl.fromCacheTtl()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetIncrementScoreResponse.Error.class))
@@ -1030,24 +1074,25 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
     final String three = "3";
     final Map<String, Double> elements = ImmutableMap.of(one, 1.0, two, 2.0, three, 3.0);
 
-    assertThat(client.sortedSetRemoveElement(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementResponse.Success.class);
 
-    assertThat(client.sortedSetPutElements(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElements(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
-    assertThat(client.sortedSetRemoveElement(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -1060,24 +1105,25 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementBytesHappyPath() {
+    final String sortedSetName = randomString();
     final byte[] one = "1".getBytes();
     final byte[] two = "2".getBytes();
     final byte[] three = "3".getBytes();
     final Map<byte[], Double> elements = ImmutableMap.of(one, 1.0, two, 2.0, three, 3.0);
 
-    assertThat(client.sortedSetRemoveElement(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementResponse.Success.class);
 
-    assertThat(client.sortedSetPutElementsByteArray(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElementsByteArray(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
-    assertThat(client.sortedSetRemoveElement(cacheName, sortedSetName, one))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, sortedSetName, one))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -1090,12 +1136,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetRemoveElement(null, sortedSetName, "element"))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetRemoveElement(null, sortedSetName, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetRemoveElement(null, sortedSetName, "element".getBytes()))
+    assertThat(cacheClient.sortedSetRemoveElement(null, sortedSetName, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1103,13 +1150,14 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementReturnsErrorWithNonexistentCacheName() {
-    assertThat(client.sortedSetRemoveElement(randomString("cache"), sortedSetName, "element"))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetRemoveElement(randomString("cache"), sortedSetName, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetRemoveElement(
+            cacheClient.sortedSetRemoveElement(
                 randomString("cache"), sortedSetName, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
@@ -1118,12 +1166,12 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetRemoveElement(cacheName, null, "element"))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, null, "element"))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetRemoveElement(cacheName, null, "element".getBytes()))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, null, "element".getBytes()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1131,12 +1179,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementReturnsErrorWithNullElement() {
-    assertThat(client.sortedSetRemoveElement(cacheName, sortedSetName, (String) null))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, sortedSetName, (String) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetRemoveElement(cacheName, sortedSetName, (byte[]) null))
+    assertThat(cacheClient.sortedSetRemoveElement(cacheName, sortedSetName, (byte[]) null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1146,24 +1195,27 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementsStringHappyPath() {
+    final String sortedSetName = randomString();
     final String one = "1";
     final String two = "2";
     final String three = "3";
     final Map<String, Double> elements = ImmutableMap.of(one, 1.0, two, 2.0, three, 3.0);
 
-    assertThat(client.sortedSetRemoveElements(cacheName, sortedSetName, elements.keySet()))
+    assertThat(cacheClient.sortedSetRemoveElements(cacheName, sortedSetName, elements.keySet()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementsResponse.Success.class);
 
-    assertThat(client.sortedSetPutElements(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElements(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
-    assertThat(client.sortedSetRemoveElements(cacheName, sortedSetName, Sets.newHashSet(one, two)))
+    assertThat(
+            cacheClient.sortedSetRemoveElements(
+                cacheName, sortedSetName, Sets.newHashSet(one, two)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementsResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -1176,26 +1228,29 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementsBytesHappyPath() {
+    final String sortedSetName = randomString();
     final byte[] one = "1".getBytes();
     final byte[] two = "2".getBytes();
     final byte[] three = "3".getBytes();
     final Map<byte[], Double> elements = ImmutableMap.of(one, 1.0, two, 2.0, three, 3.0);
 
-    assertThat(client.sortedSetRemoveElementsByteArray(cacheName, sortedSetName, elements.keySet()))
+    assertThat(
+            cacheClient.sortedSetRemoveElementsByteArray(
+                cacheName, sortedSetName, elements.keySet()))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementsResponse.Success.class);
 
-    assertThat(client.sortedSetPutElementsByteArray(cacheName, sortedSetName, elements))
+    assertThat(cacheClient.sortedSetPutElementsByteArray(cacheName, sortedSetName, elements))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetPutElementsResponse.Success.class);
 
     assertThat(
-            client.sortedSetRemoveElementsByteArray(
+            cacheClient.sortedSetRemoveElementsByteArray(
                 cacheName, sortedSetName, Sets.newHashSet(one, two)))
         .succeedsWithin(FIVE_SECONDS)
         .isInstanceOf(SortedSetRemoveElementsResponse.Success.class);
 
-    assertThat(client.sortedSetFetchByRank(cacheName, sortedSetName))
+    assertThat(cacheClient.sortedSetFetchByRank(cacheName, sortedSetName))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetFetchResponse.Hit.class))
         .satisfies(
@@ -1208,12 +1263,15 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementsReturnsErrorWithNullCacheName() {
-    assertThat(client.sortedSetRemoveElements(null, sortedSetName, Collections.emptySet()))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetRemoveElements(null, sortedSetName, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetRemoveElementsByteArray(null, sortedSetName, Collections.emptySet()))
+    assertThat(
+            cacheClient.sortedSetRemoveElementsByteArray(
+                null, sortedSetName, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1221,15 +1279,16 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementsReturnsErrorWithNonexistentCacheName() {
+    final String sortedSetName = randomString();
     assertThat(
-            client.sortedSetRemoveElements(
+            cacheClient.sortedSetRemoveElements(
                 randomString("cache"), sortedSetName, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
 
     assertThat(
-            client.sortedSetRemoveElementsByteArray(
+            cacheClient.sortedSetRemoveElementsByteArray(
                 randomString("cache"), sortedSetName, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
@@ -1238,12 +1297,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementsReturnsErrorWithNullSetName() {
-    assertThat(client.sortedSetRemoveElements(cacheName, null, Collections.emptySet()))
+    assertThat(cacheClient.sortedSetRemoveElements(cacheName, null, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetRemoveElementsByteArray(cacheName, null, Collections.emptySet()))
+    assertThat(
+            cacheClient.sortedSetRemoveElementsByteArray(cacheName, null, Collections.emptySet()))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
@@ -1251,12 +1311,13 @@ public class SortedSetTest extends BaseTestClass {
 
   @Test
   public void sortedSetRemoveElementsReturnsErrorWithNullElements() {
-    assertThat(client.sortedSetRemoveElements(cacheName, sortedSetName, null))
+    final String sortedSetName = randomString();
+    assertThat(cacheClient.sortedSetRemoveElements(cacheName, sortedSetName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
 
-    assertThat(client.sortedSetRemoveElementsByteArray(cacheName, sortedSetName, null))
+    assertThat(cacheClient.sortedSetRemoveElementsByteArray(cacheName, sortedSetName, null))
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(SortedSetRemoveElementsResponse.Error.class))
         .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));

--- a/momento-sdk/src/intTest/java/momento/sdk/TestUtils.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/TestUtils.java
@@ -7,4 +7,12 @@ public class TestUtils {
   public static String randomString(String prefix) {
     return prefix + "-" + UUID.randomUUID();
   }
+
+  public static String randomString() {
+    return UUID.randomUUID().toString();
+  }
+
+  public static byte[] randomBytes() {
+    return UUID.randomUUID().toString().getBytes();
+  }
 }

--- a/momento-sdk/src/intTest/java/momento/sdk/TopicClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/TopicClientTest.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TopicClientTest extends BaseTestClass {
-  private static String cacheName;
   private static TopicClient topicClient;
 
   private final String topicName = "test-topic";
@@ -32,14 +31,11 @@ public class TopicClientTest extends BaseTestClass {
   static void setupAll() {
     topicClient =
         TopicClient.builder(credentialProvider, TopicConfigurations.Laptop.latest()).build();
-    cacheName = testCacheName();
-    ensureTestCacheExists(cacheName);
   }
 
   @AfterAll
   static void teardownAll() {
     topicClient.close();
-    cleanupTestCache(cacheName);
   }
 
   private ISubscriptionCallbacks callbacks(CountDownLatch latch) {


### PR DESCRIPTION
Refactors the cache and topics integration tests to use a random cache
name instead of reading from the environment. This follows the
JavaScript SDK pattern.

We have re-written the tests to use a base test class that sets up the
client, assigns a random cache name, creates the cache, and tears it
down at the end of tests.

Because a test class now re-uses the same cache, we have refactored
the tests to use random keys in each test case. These two changes have
fixed race conditions that have caused consistent test failures when
running locally.

Lastly the auth tests were not closing clients in the tests. Because
of this, warning messages appeared in the logs consistently. We have
fixed these problems by closing clients between reuse.