### PR TITLE
refactor: storage tests should use a single test store and base

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/BaseStorageTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/BaseStorageTestClass.java
@@ -1,0 +1,55 @@
+package momento.sdk;
+
+import java.time.Duration;
+import java.util.UUID;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.StorageConfigurations;
+import momento.sdk.responses.storage.CreateStoreResponse;
+import momento.sdk.responses.storage.DeleteStoreResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class BaseStorageTestClass {
+  protected static final Duration TEN_SECONDS = Duration.ofSeconds(10);
+  protected static CredentialProvider credentialProvider;
+  protected static PreviewStorageClient storageClient;
+  protected static String storeName;
+
+  @BeforeAll
+  static void beforeAll() {
+    credentialProvider = CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
+    storageClient =
+        new PreviewStorageClientBuilder()
+            .withCredentialProvider(credentialProvider)
+            .withConfiguration(StorageConfigurations.Laptop.latest())
+            .build();
+    storeName = testStoreName();
+    ensureTestStoreExists(storeName);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    cleanupTestStore(storeName);
+    storageClient.close();
+  }
+
+  protected static void ensureTestStoreExists(String storeName) {
+    CreateStoreResponse response = storageClient.createStore(storeName).join();
+    if (response instanceof CreateStoreResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test create store: " + ((CreateStoreResponse.Error) response).getMessage());
+    }
+  }
+
+  public static void cleanupTestStore(String storeName) {
+    DeleteStoreResponse response = storageClient.deleteStore(storeName).join();
+    if (response instanceof DeleteStoreResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test delete store: " + ((DeleteStoreResponse.Error) response).getMessage());
+    }
+  }
+
+  public static String testStoreName() {
+    return "java-integration-test-default-" + UUID.randomUUID();
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
@@ -20,9 +20,7 @@ import org.junit.jupiter.api.Test;
 public class ControlTests extends BaseStorageTestClass {
   @Test
   public void returnsAlreadyExistsWhenCreatingExistingStore() {
-    // TODO externalize this
-    // TODO rename env var to something broader like TEST_RESOURCE_NAME
-    final String existingStore = System.getenv("TEST_CACHE_NAME");
+    final String existingStore = storeName;
 
     assertThat(storageClient.createStore(existingStore))
         .succeedsWithin(TEN_SECONDS)

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -4,52 +4,26 @@ import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import momento.sdk.BaseTestClass;
-import momento.sdk.PreviewStorageClient;
-import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.StorageConfigurations;
+import momento.sdk.BaseStorageTestClass;
 import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.responses.storage.DeleteResponse;
 import momento.sdk.responses.storage.GetResponse;
 import momento.sdk.responses.storage.PutResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class DataTests extends BaseTestClass {
-  private static PreviewStorageClient client;
-
-  // TODO can set to the same value as the cache tests
-  // TODO rename env var for clarity to TEST_RESOURCE_NAME or similar
-  private final String storeName = System.getenv("TEST_CACHE_NAME");
-
-  @BeforeAll
-  static void setup() {
-    client =
-        new PreviewStorageClient(
-            CredentialProvider.fromEnvVar("MOMENTO_API_KEY"),
-            StorageConfigurations.Laptop.latest());
-
-    client.createStore(System.getenv("TEST_CACHE_NAME")).join();
-  }
-
-  @AfterAll
-  static void tearDown() {
-    client.close();
-  }
-
+public class DataTests extends BaseStorageTestClass {
   @Test
   void getReturnsValueAsStringAfterPut() {
     final String key = randomString("key");
     final String value = randomString("value");
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getString().get()).isEqualTo(value);
   }
@@ -60,11 +34,11 @@ public class DataTests extends BaseTestClass {
     final String value = randomString("value");
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value.getBytes()).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value.getBytes()).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getByteArray().get()).isEqualTo(value.getBytes());
   }
@@ -75,11 +49,11 @@ public class DataTests extends BaseTestClass {
     final long value = 42L;
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getLong().get()).isEqualTo(value);
   }
@@ -90,11 +64,11 @@ public class DataTests extends BaseTestClass {
     final double value = 3.14;
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getDouble().get()).isEqualTo(value);
   }
@@ -102,7 +76,7 @@ public class DataTests extends BaseTestClass {
   @Test
   void storeKeyNotFound() {
     // Get key that was not set
-    final GetResponse response = client.get(storeName, randomString("key")).join();
+    final GetResponse response = storageClient.get(storeName, randomString("key")).join();
     assertThat(response).isInstanceOf(GetResponse.NotFound.class);
     assert response.valueWhenFound().isEmpty();
     assert response instanceof GetResponse.NotFound;
@@ -113,11 +87,11 @@ public class DataTests extends BaseTestClass {
   public void badStoreNameReturnsError() {
     final String storeName = randomString("name");
 
-    final GetResponse getResponse = client.get(storeName, "").join();
+    final GetResponse getResponse = storageClient.get(storeName, "").join();
     assertThat(getResponse).isInstanceOf(GetResponse.Error.class);
     assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(StoreNotFoundException.class);
 
-    final PutResponse putResponse = client.put(storeName, "", "").join();
+    final PutResponse putResponse = storageClient.put(storeName, "", "").join();
     assertThat(putResponse).isInstanceOf(PutResponse.Error.class);
     assertThat(((PutResponse.Error) putResponse)).hasCauseInstanceOf(StoreNotFoundException.class);
   }
@@ -126,8 +100,8 @@ public class DataTests extends BaseTestClass {
   public void allowEmptyKeyValuesOnGet() throws Exception {
     final String emptyKey = "";
     final String emptyValue = "";
-    client.put(storeName, emptyKey, emptyValue).get();
-    final GetResponse response = client.get(storeName, emptyKey).get();
+    storageClient.put(storeName, emptyKey, emptyValue).get();
+    final GetResponse response = storageClient.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
     assert response.valueWhenFound().get().getString().get().isEmpty();
   }
@@ -137,15 +111,15 @@ public class DataTests extends BaseTestClass {
     final String key = "key";
     final String value = "value";
 
-    client.put(storeName, key, value).get();
-    final GetResponse getResponse = client.get(storeName, key).get();
+    storageClient.put(storeName, key, value).get();
+    final GetResponse getResponse = storageClient.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getString().get()).isEqualTo(value);
 
-    final DeleteResponse deleteResponse = client.delete(storeName, key).get();
+    final DeleteResponse deleteResponse = storageClient.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
 
-    final GetResponse getAfterDeleteResponse = client.get(storeName, key).get();
+    final GetResponse getAfterDeleteResponse = storageClient.get(storeName, key).get();
     assert getAfterDeleteResponse.valueWhenFound().isEmpty();
     assert getAfterDeleteResponse instanceof GetResponse.NotFound;
   }
@@ -154,7 +128,7 @@ public class DataTests extends BaseTestClass {
   public void deleteNonExistentKey() throws Exception {
     final String key = randomString("key");
 
-    final DeleteResponse deleteResponse = client.delete(storeName, key).get();
+    final DeleteResponse deleteResponse = storageClient.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/PreviewStorageClientBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/PreviewStorageClientBuilder.java
@@ -49,7 +49,7 @@ public final class PreviewStorageClientBuilder {
    *
    * @return the client.
    */
-  public IPreviewStorageClient build() {
+  public PreviewStorageClient build() {
     if (credentialProvider == null) {
       credentialProvider = new EnvVarCredentialProvider("MOMENTO_API_KEY");
     }


### PR DESCRIPTION
Refactors the storage tests to use a base class similar to the one
just introduced for cache. Handles store set up and tear down uniformly.
