### PR TITLE
refactor: rename cache test base

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientCacheTests.java
@@ -28,7 +28,7 @@ import momento.sdk.responses.cache.control.CacheDeleteResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class AuthClientCacheTests extends BaseTestClass {
+public class AuthClientCacheTests extends BaseCacheTestClass {
   private static AuthClient authClient;
 
   String key = "test-key";

--- a/momento-sdk/src/intTest/java/momento/sdk/AuthClientTopicTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/AuthClientTopicTests.java
@@ -13,7 +13,7 @@ import momento.sdk.responses.auth.GenerateDisposableTokenResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class AuthClientTopicTests extends BaseTestClass {
+public class AuthClientTopicTests extends BaseCacheTestClass {
   private static AuthClient authClient;
   private static String topicName = "topic";
 

--- a/momento-sdk/src/intTest/java/momento/sdk/BaseCacheTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/BaseCacheTestClass.java
@@ -9,7 +9,7 @@ import momento.sdk.responses.cache.control.CacheDeleteResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class BaseTestClass {
+public class BaseCacheTestClass {
   protected static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
   protected static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
   protected static CredentialProvider credentialProvider;

--- a/momento-sdk/src/intTest/java/momento/sdk/BaseStorageTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/BaseStorageTestClass.java
@@ -1,0 +1,55 @@
+package momento.sdk;
+
+import java.time.Duration;
+import java.util.UUID;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.StorageConfigurations;
+import momento.sdk.responses.storage.CreateStoreResponse;
+import momento.sdk.responses.storage.DeleteStoreResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class BaseStorageTestClass {
+  protected static final Duration TEN_SECONDS = Duration.ofSeconds(10);
+  protected static CredentialProvider credentialProvider;
+  protected static PreviewStorageClient storageClient;
+  protected static String storeName;
+
+  @BeforeAll
+  static void beforeAll() {
+    credentialProvider = CredentialProvider.fromEnvVar("TEST_AUTH_TOKEN");
+    storageClient =
+        new PreviewStorageClientBuilder()
+            .withCredentialProvider(credentialProvider)
+            .withConfiguration(StorageConfigurations.Laptop.latest())
+            .build();
+    storeName = testStoreName();
+    ensureTestStoreExists(storeName);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    cleanupTestStore(storeName);
+    storageClient.close();
+  }
+
+  protected static void ensureTestStoreExists(String storeName) {
+    CreateStoreResponse response = storageClient.createStore(storeName).join();
+    if (response instanceof CreateStoreResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test create store: " + ((CreateStoreResponse.Error) response).getMessage());
+    }
+  }
+
+  public static void cleanupTestStore(String storeName) {
+    DeleteStoreResponse response = storageClient.deleteStore(storeName).join();
+    if (response instanceof DeleteStoreResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test delete store: " + ((DeleteStoreResponse.Error) response).getMessage());
+    }
+  }
+
+  public static String testStoreName() {
+    return "java-integration-test-default-" + UUID.randomUUID();
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheClientTest.java
@@ -33,7 +33,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 /** Just includes a happy test path that interacts with both control and data plane clients. */
-final class CacheClientTest extends BaseTestClass {
+final class CacheClientTest extends BaseCacheTestClass {
   private static final String JWT_HEADER_BASE64 = "eyJhbGciOiJIUzUxMiJ9";
   private static final String JWT_INVALID_SIGNATURE_BASE64 =
       "gdghdjjfjyehhdkkkskskmmls76573jnajhjjjhjdhnndy";

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheControlPlaneTest.java
@@ -21,7 +21,7 @@ import momento.sdk.responses.cache.signing.SigningKeyRevokeResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-final class CacheControlPlaneTest extends BaseTestClass {
+final class CacheControlPlaneTest extends BaseCacheTestClass {
   @Test
   public void createListRevokeSigningKeyWorks() {
     final SigningKeyCreateResponse signingKeyCreateResponse =

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneClientSideTest.java
@@ -10,7 +10,7 @@ import momento.sdk.responses.cache.SetResponse;
 import org.junit.jupiter.api.Test;
 
 /** Tests client side exceptions */
-final class CacheDataPlaneClientSideTest extends BaseTestClass {
+final class CacheDataPlaneClientSideTest extends BaseCacheTestClass {
   @Test
   public void nullKeyGetReturnsError() {
     final GetResponse stringResponse = cacheClient.get(cacheName, (String) null).join();

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneEagerConnectionTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneEagerConnectionTest.java
@@ -1,6 +1,5 @@
 package momento.sdk;
 
-import static momento.sdk.BaseTestClass.credentialProvider;
 import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +9,7 @@ import momento.sdk.responses.cache.GetResponse;
 import momento.sdk.responses.cache.SetResponse;
 import org.junit.jupiter.api.Test;
 
-public class CacheDataPlaneEagerConnectionTest extends BaseTestClass {
+public class CacheDataPlaneEagerConnectionTest extends BaseCacheTestClass {
   @Test
   void getReturnsHitAfterSet() {
     CacheClient client =

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheDataPlaneTest.java
@@ -16,7 +16,7 @@ import momento.sdk.responses.cache.SetResponse;
 import org.junit.jupiter.api.Test;
 
 /** Tests with Async APIs. */
-final class CacheDataPlaneTest extends BaseTestClass {
+final class CacheDataPlaneTest extends BaseCacheTestClass {
   @Test
   void getReturnsHitAfterSet() {
     final String key = randomString("key");

--- a/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/DictionaryTest.java
@@ -23,7 +23,7 @@ import momento.sdk.responses.cache.dictionary.DictionarySetFieldsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-public class DictionaryTest extends BaseTestClass {
+public class DictionaryTest extends BaseCacheTestClass {
   Map<String, String> stringStringMap = new HashMap<>();
   Map<String, byte[]> stringBytesMap = new HashMap<>();
   Map<byte[], String> bytesStringMap = new HashMap<>();

--- a/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/ListTest.java
@@ -22,7 +22,7 @@ import momento.sdk.responses.cache.list.ListRetainResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-public class ListTest extends BaseTestClass {
+public class ListTest extends BaseCacheTestClass {
   private final List<String> values = Arrays.asList("val1", "val2", "val3", "val4");
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/MomentoBatchUtilsIntegrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class MomentoBatchUtilsIntegrationTest extends BaseTestClass {
+public class MomentoBatchUtilsIntegrationTest extends BaseCacheTestClass {
   private static MomentoBatchUtils momentoBatchUtils;
 
   @BeforeAll

--- a/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SetTest.java
@@ -17,7 +17,7 @@ import momento.sdk.responses.cache.set.SetRemoveElementsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-public class SetTest extends BaseTestClass {
+public class SetTest extends BaseCacheTestClass {
   @Test
   public void setAddElementStringHappyPath() {
     final String setName = randomString();

--- a/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/SortedSetTest.java
@@ -29,7 +29,7 @@ import momento.sdk.responses.cache.sortedset.SortedSetRemoveElementsResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
-public class SortedSetTest extends BaseTestClass {
+public class SortedSetTest extends BaseCacheTestClass {
   // sortedSetPutElement
 
   @Test

--- a/momento-sdk/src/intTest/java/momento/sdk/TopicClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/TopicClientTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TopicClientTest extends BaseTestClass {
+public class TopicClientTest extends BaseCacheTestClass {
   private static TopicClient topicClient;
 
   private final String topicName = "test-topic";

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/ControlTests.java
@@ -20,9 +20,7 @@ import org.junit.jupiter.api.Test;
 public class ControlTests extends BaseStorageTestClass {
   @Test
   public void returnsAlreadyExistsWhenCreatingExistingStore() {
-    // TODO externalize this
-    // TODO rename env var to something broader like TEST_RESOURCE_NAME
-    final String existingStore = System.getenv("TEST_CACHE_NAME");
+    final String existingStore = storeName;
 
     assertThat(storageClient.createStore(existingStore))
         .succeedsWithin(TEN_SECONDS)

--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -4,52 +4,26 @@ import static momento.sdk.TestUtils.randomString;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import momento.sdk.BaseTestClass;
-import momento.sdk.PreviewStorageClient;
-import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.StorageConfigurations;
+import momento.sdk.BaseStorageTestClass;
 import momento.sdk.exceptions.ClientSdkException;
 import momento.sdk.exceptions.StoreNotFoundException;
 import momento.sdk.responses.storage.DeleteResponse;
 import momento.sdk.responses.storage.GetResponse;
 import momento.sdk.responses.storage.PutResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class DataTests extends BaseTestClass {
-  private static PreviewStorageClient client;
-
-  // TODO can set to the same value as the cache tests
-  // TODO rename env var for clarity to TEST_RESOURCE_NAME or similar
-  private final String storeName = System.getenv("TEST_CACHE_NAME");
-
-  @BeforeAll
-  static void setup() {
-    client =
-        new PreviewStorageClient(
-            CredentialProvider.fromEnvVar("MOMENTO_API_KEY"),
-            StorageConfigurations.Laptop.latest());
-
-    client.createStore(System.getenv("TEST_CACHE_NAME")).join();
-  }
-
-  @AfterAll
-  static void tearDown() {
-    client.close();
-  }
-
+public class DataTests extends BaseStorageTestClass {
   @Test
   void getReturnsValueAsStringAfterPut() {
     final String key = randomString("key");
     final String value = randomString("value");
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getString().get()).isEqualTo(value);
   }
@@ -60,11 +34,11 @@ public class DataTests extends BaseTestClass {
     final String value = randomString("value");
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value.getBytes()).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value.getBytes()).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getByteArray().get()).isEqualTo(value.getBytes());
   }
@@ -75,11 +49,11 @@ public class DataTests extends BaseTestClass {
     final long value = 42L;
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getLong().get()).isEqualTo(value);
   }
@@ -90,11 +64,11 @@ public class DataTests extends BaseTestClass {
     final double value = 3.14;
 
     // Successful Set
-    final PutResponse putResponse = client.put(storeName, key, value).join();
+    final PutResponse putResponse = storageClient.put(storeName, key, value).join();
     assertThat(putResponse).isInstanceOf(PutResponse.Success.class);
 
     // Successful Get
-    final GetResponse getResponse = client.get(storeName, key).join();
+    final GetResponse getResponse = storageClient.get(storeName, key).join();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getDouble().get()).isEqualTo(value);
   }
@@ -102,7 +76,7 @@ public class DataTests extends BaseTestClass {
   @Test
   void storeKeyNotFound() {
     // Get key that was not set
-    final GetResponse response = client.get(storeName, randomString("key")).join();
+    final GetResponse response = storageClient.get(storeName, randomString("key")).join();
     assertThat(response).isInstanceOf(GetResponse.NotFound.class);
     assert response.valueWhenFound().isEmpty();
     assert response instanceof GetResponse.NotFound;
@@ -113,11 +87,11 @@ public class DataTests extends BaseTestClass {
   public void badStoreNameReturnsError() {
     final String storeName = randomString("name");
 
-    final GetResponse getResponse = client.get(storeName, "").join();
+    final GetResponse getResponse = storageClient.get(storeName, "").join();
     assertThat(getResponse).isInstanceOf(GetResponse.Error.class);
     assertThat(((GetResponse.Error) getResponse)).hasCauseInstanceOf(StoreNotFoundException.class);
 
-    final PutResponse putResponse = client.put(storeName, "", "").join();
+    final PutResponse putResponse = storageClient.put(storeName, "", "").join();
     assertThat(putResponse).isInstanceOf(PutResponse.Error.class);
     assertThat(((PutResponse.Error) putResponse)).hasCauseInstanceOf(StoreNotFoundException.class);
   }
@@ -126,8 +100,8 @@ public class DataTests extends BaseTestClass {
   public void allowEmptyKeyValuesOnGet() throws Exception {
     final String emptyKey = "";
     final String emptyValue = "";
-    client.put(storeName, emptyKey, emptyValue).get();
-    final GetResponse response = client.get(storeName, emptyKey).get();
+    storageClient.put(storeName, emptyKey, emptyValue).get();
+    final GetResponse response = storageClient.get(storeName, emptyKey).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
     assert response.valueWhenFound().get().getString().get().isEmpty();
   }
@@ -137,15 +111,15 @@ public class DataTests extends BaseTestClass {
     final String key = "key";
     final String value = "value";
 
-    client.put(storeName, key, value).get();
-    final GetResponse getResponse = client.get(storeName, key).get();
+    storageClient.put(storeName, key, value).get();
+    final GetResponse getResponse = storageClient.get(storeName, key).get();
     assertThat(getResponse).isInstanceOf(GetResponse.Found.class);
     assertThat(getResponse.valueWhenFound().get().getString().get()).isEqualTo(value);
 
-    final DeleteResponse deleteResponse = client.delete(storeName, key).get();
+    final DeleteResponse deleteResponse = storageClient.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
 
-    final GetResponse getAfterDeleteResponse = client.get(storeName, key).get();
+    final GetResponse getAfterDeleteResponse = storageClient.get(storeName, key).get();
     assert getAfterDeleteResponse.valueWhenFound().isEmpty();
     assert getAfterDeleteResponse instanceof GetResponse.NotFound;
   }
@@ -154,7 +128,7 @@ public class DataTests extends BaseTestClass {
   public void deleteNonExistentKey() throws Exception {
     final String key = randomString("key");
 
-    final DeleteResponse deleteResponse = client.delete(storeName, key).get();
+    final DeleteResponse deleteResponse = storageClient.delete(storeName, key).get();
     assertThat(deleteResponse).isInstanceOf(DeleteResponse.Success.class);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/PreviewStorageClientBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/PreviewStorageClientBuilder.java
@@ -49,7 +49,7 @@ public final class PreviewStorageClientBuilder {
    *
    * @return the client.
    */
-  public IPreviewStorageClient build() {
+  public PreviewStorageClient build() {
     if (credentialProvider == null) {
       credentialProvider = new EnvVarCredentialProvider("MOMENTO_API_KEY");
     }


### PR DESCRIPTION
Renames the cache `BaseTestClass` to `BaseCacheTestClass` for clarity.
