### PR TITLE
feat: Prototype for concurrent operations limiting

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
@@ -1,6 +1,7 @@
 package momento.sdk.config;
 
 import java.time.Duration;
+import java.util.Optional;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.config.transport.TransportStrategy;
 import momento.sdk.retry.RetryStrategy;
@@ -11,6 +12,8 @@ public class Configuration {
   private final TransportStrategy transportStrategy;
   private final RetryStrategy retryStrategy;
 
+  private final Integer concurrencyLimit;
+
   /**
    * Creates a new configuration object.
    *
@@ -20,6 +23,14 @@ public class Configuration {
   public Configuration(TransportStrategy transportStrategy, RetryStrategy retryStrategy) {
     this.transportStrategy = transportStrategy;
     this.retryStrategy = retryStrategy;
+    this.concurrencyLimit = null;
+  }
+
+  public Configuration(
+      TransportStrategy transportStrategy, RetryStrategy retryStrategy, int concurrencyLimit) {
+    this.transportStrategy = transportStrategy;
+    this.retryStrategy = retryStrategy;
+    this.concurrencyLimit = concurrencyLimit;
   }
 
   /**
@@ -61,5 +72,9 @@ public class Configuration {
 
   public Configuration withRetryStrategy(final RetryStrategy retryStrategy) {
     return new Configuration(this.transportStrategy, retryStrategy);
+  }
+
+  public Optional<Integer> getConcurrencyLimit() {
+    return Optional.ofNullable(concurrencyLimit);
   }
 }


### PR DESCRIPTION
Modify cache Get and Get to add optional concurrent operations limiting. It works by creating an executor with a max number of threads equal to the limit. Get and Set calls are given to the executor and wait on the executor's internal queue until there is a thread free to take them, implicitly limiting the number of concurrent requests. The load generator limits concurrent requests in the same way.

Add a general ScsFutureStub method that takes a gRPC call, a gRPC to Momento response converter, and an error handler. Something like this should let us cut a lot of boilerplate out of the data client. It won't work for the batch call, since that uses a different type of stub.