### PR TITLE
chore: add missing topic examples for injection in CodeBlocks

### DIFF
--- a/examples/topic/src/main/java/momento/client/doc_examples/DocExamplesJavaAPIs.java
+++ b/examples/topic/src/main/java/momento/client/doc_examples/DocExamplesJavaAPIs.java
@@ -1,0 +1,79 @@
+package momento.client.doc_examples;
+
+import momento.sdk.ISubscriptionCallbacks;
+import momento.sdk.TopicClient;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.TopicConfigurations;
+import momento.sdk.responses.topic.TopicMessage;
+import momento.sdk.responses.topic.TopicPublishResponse;
+import momento.sdk.responses.topic.TopicSubscribeResponse;
+
+public class DocExamplesJavaAPIs {
+
+  @SuppressWarnings("EmptyTryBlock")
+  public static void example_API_InstantiateTopicClient() {
+    try (final TopicClient topicClient =
+        new TopicClient(
+            CredentialProvider.fromEnvVar("MOMENTO_API_KEY"),
+            TopicConfigurations.Laptop.latest())) {
+      // ...
+    }
+  }
+
+  public static void example_API_TopicSubscribe(TopicClient topicClient) {
+    final TopicSubscribeResponse topicSubscribeResponse =
+        topicClient
+            .subscribe(
+                "test-cache",
+                "test-topic",
+                new ISubscriptionCallbacks() {
+                  @Override
+                  public void onItem(TopicMessage message) {
+                    System.out.println("Received message on 'test-topic': " + message.toString());
+                  }
+
+                  @Override
+                  public void onError(Throwable error) {
+                    System.err.println(
+                        "Error: Subscription to 'test-topic' failed. Details: "
+                            + error.getMessage());
+                  }
+
+                  @Override
+                  public void onCompleted() {
+                    System.out.println("Subscription to 'test-topic' completed");
+                  }
+                })
+            .join();
+
+    if (topicSubscribeResponse instanceof TopicSubscribeResponse.Error error) {
+      throw new RuntimeException(
+          "An error occurred while attempting to subscribe to topic 'test-topic': "
+              + error.getErrorCode(),
+          error);
+    }
+  }
+
+  public static void example_API_TopicPublish(TopicClient topicClient, String message) {
+    final TopicPublishResponse publishResponse =
+        topicClient.publish("test-cache", "test-topic", message).join();
+    if (publishResponse instanceof TopicPublishResponse.Error error) {
+      throw new RuntimeException(
+          "An error occurred reading messages from topic 'test-topic':" + error.getErrorCode(),
+          error);
+    }
+  }
+
+  public static void main(String[] args) {
+    example_API_InstantiateTopicClient();
+
+    try (final TopicClient topicClient =
+        new TopicClient(
+            CredentialProvider.fromEnvVar("MOMENTO_API_KEY"),
+            TopicConfigurations.Laptop.latest())) {
+
+      example_API_TopicSubscribe(topicClient);
+      example_API_TopicPublish(topicClient, "Hello world");
+    }
+  }
+}


### PR DESCRIPTION
Hi there,

the public-dev-docs contain a [readme](https://github.com/momentohq/public-dev-docs/blob/main/docs/sdks/java/topics.mdx) for topics in java which depends on the snippet ids "API_InstantiateTopicClient", "API_TopicPublish" and "API_TopicSubscribe". 

Those do not seem to exist yet, hence why the rendered page has [empty code snippets](https://docs.momentohq.com/sdks/java/topics#set-up-a-topicclient).

To address this, I've taken the initiative to create the necessary documentation and add the missing snippets. If there are any concerns or required changes regarding this contribution, please feel free to reach out.

Changes would require a follow up MR in the api-docs [JavaSnippetSourceParser](https://github.com/momentohq/public-dev-docs/blob/main/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/java-snippet-source-parser.ts#L15).

