### PR TITLE
docs: fix list fetch end index description

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -1668,7 +1668,7 @@ public final class CacheClient implements AutoCloseable {
    * @param cacheName The cache containing the list.
    * @param listName The list to fetch.
    * @param startIndex Start index (inclusive) for fetch operation. Defaults to 0 if not provided.
-   * @param endIndex End index (inclusive) for fetch operation. Defaults to the end of the list if
+   * @param endIndex End index (exclusive) for fetch operation. Defaults to the end of the list if
    *     not provided.
    * @return Future containing the result of the list fetch back operation: {@link
    *     ListFetchResponse.Hit} containing the fetched data, {@link ListFetchResponse.Miss} if no

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -1667,12 +1667,13 @@ public final class CacheClient implements AutoCloseable {
    *
    * @param cacheName The cache containing the list.
    * @param listName The list to fetch.
-   * @param startIndex Start index (inclusive) for the fetch operation. Defaults to 0 if not provided.
-   * @param endIndex End index (exclusive) for the fetch operation. Defaults to the end of the list if
-   *     not provided.
-   * @return Future containing the result of the list fetch operation: {@link
-   *     ListFetchResponse.Hit} containing the fetched data, {@link ListFetchResponse.Miss} if no
-   *     data was found, or {@link ListFetchResponse.Error}.
+   * @param startIndex Start index (inclusive) for the fetch operation. Defaults to 0 if not
+   *     provided.
+   * @param endIndex End index (exclusive) for the fetch operation. Defaults to the end of the list
+   *     if not provided.
+   * @return Future containing the result of the list fetch operation: {@link ListFetchResponse.Hit}
+   *     containing the fetched data, {@link ListFetchResponse.Miss} if no data was found, or {@link
+   *     ListFetchResponse.Error}.
    */
   public CompletableFuture<ListFetchResponse> listFetch(
       @Nonnull String cacheName,
@@ -1687,9 +1688,9 @@ public final class CacheClient implements AutoCloseable {
    *
    * @param cacheName The cache containing the list.
    * @param listName The list to fetch.
-   * @return Future containing the result of the list fetch operation: {@link
-   *     ListFetchResponse.Hit} containing the fetched data, {@link ListFetchResponse.Miss} if no
-   *     data was found, or {@link ListFetchResponse.Error}.
+   * @return Future containing the result of the list fetch operation: {@link ListFetchResponse.Hit}
+   *     containing the fetched data, {@link ListFetchResponse.Miss} if no data was found, or {@link
+   *     ListFetchResponse.Error}.
    */
   public CompletableFuture<ListFetchResponse> listFetch(
       @Nonnull String cacheName, @Nonnull String listName) {

--- a/momento-sdk/src/main/java/momento/sdk/CacheClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/CacheClient.java
@@ -1667,10 +1667,10 @@ public final class CacheClient implements AutoCloseable {
    *
    * @param cacheName The cache containing the list.
    * @param listName The list to fetch.
-   * @param startIndex Start index (inclusive) for fetch operation. Defaults to 0 if not provided.
-   * @param endIndex End index (exclusive) for fetch operation. Defaults to the end of the list if
+   * @param startIndex Start index (inclusive) for the fetch operation. Defaults to 0 if not provided.
+   * @param endIndex End index (exclusive) for the fetch operation. Defaults to the end of the list if
    *     not provided.
-   * @return Future containing the result of the list fetch back operation: {@link
+   * @return Future containing the result of the list fetch operation: {@link
    *     ListFetchResponse.Hit} containing the fetched data, {@link ListFetchResponse.Miss} if no
    *     data was found, or {@link ListFetchResponse.Error}.
    */
@@ -1687,7 +1687,7 @@ public final class CacheClient implements AutoCloseable {
    *
    * @param cacheName The cache containing the list.
    * @param listName The list to fetch.
-   * @return Future containing the result of the list fetch back operation: {@link
+   * @return Future containing the result of the list fetch operation: {@link
    *     ListFetchResponse.Hit} containing the fetched data, {@link ListFetchResponse.Miss} if no
    *     data was found, or {@link ListFetchResponse.Error}.
    */


### PR DESCRIPTION
Corrects the end index documentation on `listFetch` to indicate it is
exclusive, not inclusive.
