### PR TITLE
fix: fix failing storage tests

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/storage/DataTests.java
@@ -102,11 +102,11 @@ public class DataTests extends BaseStorageTestClass {
   }
 
   @Test
-  public void allowEmptyKeyValuesOnGet() throws Exception {
-    final String emptyKey = "";
+  public void allowEmptyValuesOnGet() throws Exception {
+    final String key = randomString("key");
     final String emptyValue = "";
-    storageClient.put(storeName, emptyKey, emptyValue).get();
-    final GetResponse response = storageClient.get(storeName, emptyKey).get();
+    storageClient.put(storeName, key, emptyValue).get();
+    final GetResponse response = storageClient.get(storeName, key).get();
     assertThat(response).isInstanceOf(GetResponse.Found.class);
     assert response.valueWhenFound().get().getString().get().isEmpty();
   }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -77,7 +77,9 @@ public final class CacheServiceExceptionMapper {
             return new CacheNotFoundException(grpcException, errorDetails);
           }
         case ALREADY_EXISTS:
-          if (errorCause.contains("Store with name")) {
+          // TODO: Switch to use the metadata when that can distinguish between a store and cache
+          // already exists
+          if (grpcException.getMessage().contains("Store with name")) {
             return new StoreAlreadyExistsException(grpcException, errorDetails);
           } else {
             return new CacheAlreadyExistsException(grpcException, errorDetails);


### PR DESCRIPTION
Stop looking at error metadata to determine whether an already exists error is for a store or cache. We can check it when that is added on the server side.

Update a test that was checking that the server could support empty keys in the store client. That changed on the server side.