### PR TITLE
feat: setup momento-local (wip)

### DIFF
--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -53,3 +53,10 @@ tasks.named("analyzeIntTestClassesDependencies").configure {
 tasks.named("analyzeTestClassesDependencies").configure {
     enabled = false
 }
+
+tasks.register<JavaExec>("run") {
+    group = "application"
+    description = "Runs the Program class"
+    mainClass.set("momento.sdk.Program") // Fully qualified class name
+    classpath = sourceSets["main"].runtimeClasspath
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/CacheGetBatchTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/CacheGetBatchTest.java
@@ -1,0 +1,44 @@
+package momento.sdk;
+
+import java.time.Duration;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.Configurations;
+import momento.sdk.responses.cache.control.CacheCreateResponse;
+import org.junit.jupiter.api.Test;
+
+final class CacheGetBatchTest {
+  @Test
+  public void getBatchSetBatchHappyPath() {
+    CredentialProvider credentialProvider =
+        CredentialProvider.withMomentoLocal(System.getenv("MOMENTO_API_KEY"));
+    CacheClient cacheClient =
+        new CacheClientBuilder(
+                credentialProvider, Configurations.Laptop.latest(), Duration.ofMinutes(1))
+            .build();
+
+    CacheCreateResponse resp = cacheClient.createCache("cache").join();
+    System.out.println(resp);
+    //    SetResponse setCacheResponse = cacheClient.set("cache", "key1", "val1",
+    // Duration.ofMinutes(1)).join();
+    //    System.out.println(setCacheResponse);
+
+    //    final Map<String, String> items = new HashMap<>();
+    //    items.put("key1", "val1");
+    //    items.put("key2", "val2");
+    //    items.put("key3", "val3");
+    //    final SetBatchResponse setBatchResponse =
+    //        cacheClient.setBatch("cache", items, Duration.ofMinutes(1)).join();
+    //    assertThat(setBatchResponse).isInstanceOf(SetBatchResponse.Success.class);
+    //    for (SetResponse setResponse :
+    //        ((SetBatchResponse.Success) setBatchResponse).results().values()) {
+    //      assertThat(setResponse).isInstanceOf(SetResponse.Success.class);
+    //    }
+    //
+    //    final GetBatchResponse getBatchResponse = cacheClient.getBatch("cache",
+    // items.keySet()).join();
+    //
+    //    assertThat(getBatchResponse).isInstanceOf(GetBatchResponse.Success.class);
+    //    assertThat(((GetBatchResponse.Success) getBatchResponse).valueMapStringString())
+    //        .containsExactlyEntriesOf(items);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/Program.java
+++ b/momento-sdk/src/main/java/momento/sdk/Program.java
@@ -1,0 +1,102 @@
+package momento.sdk;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.Configuration;
+import momento.sdk.config.Configurations;
+import momento.sdk.responses.cache.GetBatchResponse;
+import momento.sdk.responses.cache.GetResponse;
+import momento.sdk.responses.cache.SetBatchResponse;
+import momento.sdk.responses.cache.SetResponse;
+import momento.sdk.responses.cache.control.CacheCreateResponse;
+
+public class Program {
+  public static void main(String[] args) {
+    String cacheName = "test-cache";
+    CredentialProvider credentialProvider =
+        CredentialProvider.withMomentoLocal(System.getenv("MOMENTO_API_KEY"));
+
+    Configuration configuration = Configurations.Laptop.latest();
+    CacheClient cacheClient =
+        new CacheClientBuilder(credentialProvider, configuration, Duration.ofMinutes(1)).build();
+
+    CacheCreateResponse createResponse = cacheClient.createCache(cacheName).join();
+    if (createResponse instanceof CacheCreateResponse.Success) {
+      System.out.println("Cache created successfully");
+    } else {
+      System.out.println("Failed to create cache" + createResponse.toString());
+      CacheCreateResponse.Error error = (CacheCreateResponse.Error) createResponse;
+      System.out.println("Failed to create cache: " + error.getErrorCode());
+    }
+
+
+    // Set requests
+//    for (int i = 0; i < 10; i++) {
+//      SetResponse setResponse =
+//          cacheClient
+//              .set(
+//                  cacheName,
+//                  "key" + i,
+//                    "val" + i,
+//                  Duration.ofMinutes(1))
+//              .join();
+//      if (setResponse instanceof SetResponse.Success) {
+//        System.out.println("Set successful");
+//      } else {
+//        System.out.println("Failed to set batch" + setResponse.toString());
+//        SetResponse.Error error = (SetResponse.Error) setResponse;
+//        System.out.println("Failed to set: " + error.getErrorCode());
+//      }
+//    }
+//
+//    // Get requests
+//    for (int i = 0; i < 10; i++) {
+//      final GetResponse getResponse =
+//          cacheClient.get(cacheName, "key" + i).join();
+//      if (getResponse instanceof GetResponse.Hit) {
+//        System.out.println("Get successful");
+//        String value =
+//            ((GetResponse.Hit) getResponse).valueString();
+//        System.out.println("Value: " + value);
+//      } else if (getResponse instanceof GetResponse.Miss) {
+//        System.out.println("Get successful");
+//        System.out.println("Value: null");
+//      } else {
+//        System.out.println("Failed to get" + getResponse.toString());
+//        GetResponse.Error error = (GetResponse.Error) getResponse;
+//        System.out.println("Failed to get: " + error.getErrorCode());
+//      }
+//    }
+
+    final Map<String, String> items = new HashMap<>();
+    for (int i = 0; i < 10; i++) {
+      items.put("key" + i, "val" + i);
+    }
+    final SetBatchResponse setBatchResponse =
+        cacheClient.setBatch(cacheName, items, Duration.ofMinutes(1)).join();
+    if (setBatchResponse instanceof SetBatchResponse.Success) {
+      System.out.println("Set batch successful");
+    } else {
+      System.out.println("Failed to set batch" + setBatchResponse.toString());
+      SetBatchResponse.Error error = (SetBatchResponse.Error) setBatchResponse;
+      System.out.println("Failed to set batch: " + error.getErrorCode());
+    }
+
+    final GetBatchResponse getBatchResponse =
+        cacheClient.getBatch(cacheName, items.keySet()).join();
+    if (getBatchResponse instanceof GetBatchResponse.Success) {
+      System.out.println("Get batch successful");
+      Map<String, String> values =
+          ((GetBatchResponse.Success) getBatchResponse).valueMapStringString();
+      for (Map.Entry<String, String> entry : values.entrySet()) {
+        System.out.println("Key: " + entry.getKey() + " Value: " + entry.getValue());
+      }
+    } else {
+      System.out.println("Failed to get batch" + getBatchResponse.toString());
+      GetBatchResponse.Error error = (GetBatchResponse.Error) getBatchResponse;
+      System.out.println("Failed to get batch: " + error.getErrorCode());
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -38,7 +38,8 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
   private static ManagedChannel setupConnection(
       CredentialProvider credentialProvider, Configuration configuration) {
     final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
+        NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 8080)
+            .usePlaintext();
 
     // Override grpc config to disable keepalive for control clients
     final GrpcConfiguration controlConfig =

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -179,7 +179,7 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
   private ManagedChannel setupChannel(
       CredentialProvider credentialProvider, Configuration configuration) {
     final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
+        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 8080).usePlaintext();
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -28,6 +28,16 @@ public abstract class CredentialProvider {
     return new EnvVarCredentialProvider(envVar);
   }
 
+  public static CredentialProvider withMomentoLocal(@Nonnull String authToken) {
+    String momentoLocalOverride = "127.0.0.1";
+    return new StringCredentialProvider(
+        authToken,
+        momentoLocalOverride,
+        momentoLocalOverride,
+        momentoLocalOverride,
+        momentoLocalOverride);
+  }
+
   /**
    * Gets the token used to authenticate to Momento.
    *

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -18,8 +18,10 @@ public class GrpcChannelOptions {
 
   public static void applyGrpcConfigurationToChannelBuilder(
       GrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
-    channelBuilder.useTransportSecurity();
-    channelBuilder.disableRetry();
+    //    channelBuilder.useTransportSecurity();
+    //    channelBuilder.disableRetry();
+    channelBuilder.enableRetry();
+    channelBuilder.maxRetryAttempts(3);
 
     final Optional<Integer> maxMessageSize = grpcConfig.getMaxMessageSize();
     if (maxMessageSize.isPresent()) {

--- a/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/DefaultRetryEligibilityStrategy.java
@@ -57,6 +57,7 @@ public class DefaultRetryEligibilityStrategy implements RetryEligibilityStrategy
           add("cache_client.Scs/ListLength");
           // not idempotent: "/cache_client.Scs/ListConcatenateFront",
           // not idempotent: "/cache_client.Scs/ListConcatenateBack"
+          add("cache_client.Scs/GetBatch");
         }
       };
 

--- a/momento-sdk/src/test/java/momento/sdk/auth/StringCredentialProviderTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/auth/StringCredentialProviderTest.java
@@ -145,4 +145,20 @@ class StringCredentialProviderTest {
         .isThrownBy(() -> new StringCredentialProvider(TEST_V1_MISSING_API_KEY))
         .withMessageContaining("parse auth token");
   }
+
+  //    @Test
+  //    public void testCredentialProviderWithMomentoLocal() {
+  //      String apiKey =
+  // "eyJlbmRwb2ludCI6ImNlbGwtYWxwaGEtZGV2LnByZXByb2QuYS5tb21lbnRvaHEuY29tIiwiYXBpX2tleSI6ImV5SmhiR2NpT2lKSVV6STFOaUo5LmV5SnpkV0lpT2lKeWFYTm9kR2xBYlc5dFpXNTBiMmh4TG1OdmJTSXNJblpsY2lJNk1Td2ljQ0k2SWtOQlFUMGlMQ0psZUhBaU9qRTNNekEwTURZMU9ESjkuTHJmNTNMNEg2bDlVY05XNGJMLXJtRm96elluQm1RUjFSaUUxZzdGZktiWSJ9";
+  //        assertThat(CredentialProvider.withMomentoLocal(apiKey))
+  //                .satisfies(
+  //                        provider -> {
+  ////                            assertThat(provider.getAuthToken()).isEqualTo(apiKey);
+  //
+  // assertThat(provider.getControlEndpoint()).isEqualTo("127.0.0.1:8080");
+  //                            assertThat(provider.getCacheEndpoint()).isEqualTo("127.0.0.1:8080");
+  //
+  // assertThat(provider.getStorageEndpoint()).isEqualTo("127.0.0.1:8080");
+  //                        });
+  //    }
 }


### PR DESCRIPTION
## PR Description:
1. **Tweaked gRPC Configuration:** This commit adjusts the gRPC configuration to allow testing against Momento Local.
2. **Added Test Program:** Introduces a simple test program (Program.java) that performs batch get/set operations, designed to trigger the RetryInterceptor logic for testing retry behavior.

## Details
**1. Momento Local Update:**
    - Modified the get_batch logic inside Momento Local to simulate a "SERVER_UNAVAILABLE" error on the first request and return the actual getBatch response on subsequent attempts.
    - This allows us to verify the RetryInterceptor functionality by reproducing failure scenarios locally.


```

#[derive(Debug)]
pub struct LocalCacheService<C>
where
    C: Cache + Control,
{
    cache: C,
    request_counter: Arc<Mutex<u32>>,
}

impl<C> LocalCacheService<C>
where
    C: Cache + Control + Clone + Send + Sync + 'static,
{
    pub fn new(cache: C) -> Self {
        Self { cache, request_counter: Arc::new(Mutex::new(0)) }
    }
}

async fn get_batch(
        &self,
        request: tonic::Request<cache_client::GetBatchRequest>,
    ) -> Result<tonic::Response<Self::GetBatchStream>, tonic::Status> {

        let mut counter = self.request_counter.lock().unwrap();
        *counter += 1;

        // Check the counter for the first request
        println!("Counter: {}", *counter);
        if *counter == 1 {
            println!("Returning unavailable status for the first request.");
            return Err(tonic::Status::unavailable("Service is unavailable"));
        }

        let cache_name = utils::read_cache_name(&request)?;
        let get_requests = request.into_inner();

        let mut results: Vec<Result<cache_client::GetResponse, tonic::Status>> = vec![];
        for get_request in get_requests.items {
            match self
                .cache
                .scalar_get(ACCOUNT_ID, cache_name.as_str(), get_request.cache_key)
            {
                Ok(Some(value)) => results.push(Ok(cache_client::GetResponse {
                    result: cache_client::ECacheResult::Hit as i32,
                    cache_body: value,
                    message: "".into(), // unused field
                })),
                Ok(None) => results.push(Ok(cache_client::GetResponse {
                    result: cache_client::ECacheResult::Miss as i32,
                    cache_body: vec![],
                    message: "".into(), // unused field
                })),
                Err(e) => results.push(Err(tonic::Status::internal(e.to_string()))),
            }
        }

        let response_stream = futures::StreamExt::boxed(async_stream::stream! {
            for result in results {
                println!("Yielding result: {:?}", result);
                yield result
            }
            println!("All results yielded, stream will now close.");
        });
        Ok(tonic::Response::new(response_stream))
    }

```

**2. Testing Workflow:**
- Step 1: In one terminal, run cargo run to start Momento Local on port 8080.
- Step 2: In a second terminal, compile and run the Java test program (javac momento/sdk/Program.java) to observe the retry behavior after the "SERVER_UNAVAILABLE" error is triggered and resolved.