### PR TITLE
feat: Concurrency limiter

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/ScsClientBase.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsClientBase.java
@@ -5,10 +5,15 @@ import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 import io.grpc.Metadata;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
+import javax.annotation.Nullable;
 
 abstract class ScsClientBase extends ClientBase {
   private static final Metadata.Key<String> CACHE_NAME_KEY =
       Metadata.Key.of("cache", ASCII_STRING_MARSHALLER);
+
+  public ScsClientBase(@Nullable Integer concurrencyLimit) {
+    super(concurrencyLimit);
+  }
 
   protected Metadata metadataWithCache(String cacheName) {
     return metadataWithItem(CACHE_NAME_KEY, cacheName);

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
@@ -50,6 +50,7 @@ final class ScsControlClient extends ScsClientBase {
   private final ScsControlGrpcStubsManager controlGrpcStubsManager;
 
   ScsControlClient(@Nonnull CredentialProvider credentialProvider, Configuration configuration) {
+    super(null);
     this.credentialProvider = credentialProvider;
     this.controlGrpcStubsManager =
         new ScsControlGrpcStubsManager(credentialProvider, configuration);
@@ -278,7 +279,7 @@ final class ScsControlClient extends ScsClientBase {
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     controlGrpcStubsManager.close();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
@@ -50,7 +50,7 @@ final class ScsControlClient extends ScsClientBase {
   private final ScsControlGrpcStubsManager controlGrpcStubsManager;
 
   ScsControlClient(@Nonnull CredentialProvider credentialProvider, Configuration configuration) {
-    super(null);
+    super(configuration.getTransportStrategy().getMaxConcurrentRequests());
     this.credentialProvider = credentialProvider;
     this.controlGrpcStubsManager =
         new ScsControlGrpcStubsManager(credentialProvider, configuration);

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -166,6 +166,7 @@ final class ScsDataClient extends ScsClientBase {
       @Nonnull CredentialProvider credentialProvider,
       @Nonnull Configuration configuration,
       @Nonnull Duration defaultTtl) {
+    super(null);
     this.itemDefaultTtl = defaultTtl;
     this.scsDataGrpcStubsManager = new ScsDataGrpcStubsManager(credentialProvider, configuration);
   }
@@ -3642,7 +3643,7 @@ final class ScsDataClient extends ScsClientBase {
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     scsDataGrpcStubsManager.close();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -166,7 +166,7 @@ final class ScsDataClient extends ScsClientBase {
       @Nonnull CredentialProvider credentialProvider,
       @Nonnull Configuration configuration,
       @Nonnull Duration defaultTtl) {
-    super(null);
+    super(configuration.getTransportStrategy().getMaxConcurrentRequests());
     this.itemDefaultTtl = defaultTtl;
     this.scsDataGrpcStubsManager = new ScsDataGrpcStubsManager(credentialProvider, configuration);
   }

--- a/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
@@ -25,6 +25,7 @@ public class ScsTopicClient extends ScsClientBase {
 
   public ScsTopicClient(
       @Nonnull CredentialProvider credentialProvider, @Nonnull TopicConfiguration configuration) {
+    super(null);
     this.topicGrpcStubsManager = new ScsTopicGrpcStubsManager(credentialProvider, configuration);
   }
 
@@ -176,7 +177,7 @@ public class ScsTopicClient extends ScsClientBase {
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     topicGrpcStubsManager.close();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/StorageClientBase.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageClientBase.java
@@ -3,10 +3,15 @@ package momento.sdk;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 
 import io.grpc.Metadata;
+import javax.annotation.Nullable;
 
 abstract class StorageClientBase extends ClientBase {
   private static final Metadata.Key<String> STORE_NAME_KEY =
       Metadata.Key.of("store", ASCII_STRING_MARSHALLER);
+
+  public StorageClientBase(@Nullable Integer concurrencyLimit) {
+    super(concurrencyLimit);
+  }
 
   protected Metadata metadataWithStore(String storeName) {
     return metadataWithItem(STORE_NAME_KEY, storeName);

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
@@ -32,6 +32,7 @@ final class StorageControlClient extends ScsClientBase {
 
   StorageControlClient(
       @Nonnull CredentialProvider credentialProvider, StorageConfiguration configuration) {
+    super(null);
     this.credentialProvider = credentialProvider;
     this.controlGrpcStubsManager =
         new StorageControlGrpcStubsManager(credentialProvider, configuration);
@@ -128,7 +129,7 @@ final class StorageControlClient extends ScsClientBase {
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     controlGrpcStubsManager.close();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
@@ -33,6 +33,7 @@ final class StorageDataClient extends StorageClientBase {
 
   StorageDataClient(
       @Nonnull CredentialProvider credentialProvider, @Nonnull StorageConfiguration configuration) {
+    super(null);
     this.storageDataGrpcStubsManager =
         new StorageDataGrpcStubsManager(credentialProvider, configuration);
   }
@@ -253,7 +254,7 @@ final class StorageDataClient extends StorageClientBase {
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     storageDataGrpcStubsManager.close();
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/StaticTransportStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/StaticTransportStrategy.java
@@ -1,5 +1,7 @@
 package momento.sdk.config.transport;
 
+import javax.annotation.Nullable;
+
 /**
  * The simplest way to configure gRPC for the Momento client. Specifies static values the transport
  * options.
@@ -7,6 +9,7 @@ package momento.sdk.config.transport;
 public class StaticTransportStrategy implements TransportStrategy {
 
   private final GrpcConfiguration grpcConfiguration;
+  private final Integer maxConcurrentRequests;
 
   /**
    * Constructs a StaticTransportStrategy.
@@ -15,6 +18,19 @@ public class StaticTransportStrategy implements TransportStrategy {
    */
   public StaticTransportStrategy(GrpcConfiguration grpcConfiguration) {
     this.grpcConfiguration = grpcConfiguration;
+    this.maxConcurrentRequests = null;
+  }
+
+  /**
+   * Constructs a StaticTransportStrategy.
+   *
+   * @param grpcConfiguration gRPC tunables.
+   * @param maxConcurrentRequests the maximum number of concurrent requests to Momento.
+   */
+  public StaticTransportStrategy(
+      GrpcConfiguration grpcConfiguration, Integer maxConcurrentRequests) {
+    this.grpcConfiguration = grpcConfiguration;
+    this.maxConcurrentRequests = maxConcurrentRequests;
   }
 
   @Override
@@ -25,5 +41,16 @@ public class StaticTransportStrategy implements TransportStrategy {
   @Override
   public TransportStrategy withGrpcConfiguration(GrpcConfiguration grpcConfiguration) {
     return new StaticTransportStrategy(grpcConfiguration);
+  }
+
+  @Nullable
+  @Override
+  public Integer getMaxConcurrentRequests() {
+    return maxConcurrentRequests;
+  }
+
+  @Override
+  public TransportStrategy withMaxConcurrentRequests(int maxConcurrentRequests) {
+    return new StaticTransportStrategy(grpcConfiguration, maxConcurrentRequests);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/TransportStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/TransportStrategy.java
@@ -1,5 +1,7 @@
 package momento.sdk.config.transport;
 
+import javax.annotation.Nullable;
+
 /** Configuration for network tunables. */
 public interface TransportStrategy {
   /**
@@ -16,4 +18,21 @@ public interface TransportStrategy {
    * @return The modified TransportStrategy.
    */
   TransportStrategy withGrpcConfiguration(GrpcConfiguration grpcConfiguration);
+
+  /**
+   * The maximum number of concurrent requests that the Momento client will allow onto the wire at a
+   * given time.
+   *
+   * @return the max requests, or null if there is no maximum
+   */
+  @Nullable
+  Integer getMaxConcurrentRequests();
+
+  /**
+   * Copy constructor that sets the maximum concurrent requests.
+   *
+   * @param maxConcurrentRequests the maximum number of concurrent requests to Momento.
+   * @return The modified TransportStrategy.
+   */
+  TransportStrategy withMaxConcurrentRequests(int maxConcurrentRequests);
 }


### PR DESCRIPTION
Adds concurrency limiting to the base client class in the style of https://github.com/momentohq/client-sdk-java/pull/385.

The concurrency limiting function is almost the same as the prototype and wraps the existing generic `executeGrpcFunction` and `executeGrpcBatchFunction` methods.

The PR is broken up into 3 commits:
The first adds the concurrency limiting fixed thread pool to the base client class, along with the constructor to configure it and the `close()` method to shut it down. It replaces the `close()` in the child classes with a new abstract `doClose()` so that there is still a close that the children are forced to implement.

The second adds the max concurrent requests integer to the transport strategy layer of the config and plumbs it through the cache data and control clients to the base client. The storage client config doesn't have it yet. It could have request limiting if we add the configuration option.

The third commit adds the request limiting function copied from the POC draft pr.