### PR TITLE
fix: set stub deadlines using millis instead of seconds

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -64,7 +64,7 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
    * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
    */
   ScsControlGrpc.ScsControlFutureStub getStub() {
-    return futureStub.withDeadlineAfter(DEADLINE.getSeconds(), TimeUnit.SECONDS);
+    return futureStub.withDeadlineAfter(DEADLINE.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -209,7 +209,7 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
     int nextStubIndex = this.nextStubIndex.getAndIncrement();
     return futureStubs
         .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.getSeconds(), TimeUnit.SECONDS);
+        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -226,7 +226,7 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
     int nextStubIndex = this.nextStubIndex.getAndIncrement();
     return observableStubs
         .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.getSeconds(), TimeUnit.SECONDS);
+        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsTokenGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTokenGrpcStubsManager.java
@@ -61,7 +61,7 @@ final class ScsTokenGrpcStubsManager implements AutoCloseable {
    * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
    */
   TokenGrpc.TokenFutureStub getStub() {
-    return futureStub.withDeadlineAfter(DEADLINE.getSeconds(), TimeUnit.SECONDS);
+    return futureStub.withDeadlineAfter(DEADLINE.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/ScsTopicGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTopicGrpcStubsManager.java
@@ -48,16 +48,7 @@ final class ScsTopicGrpcStubsManager implements Closeable {
     return channelBuilder.build();
   }
 
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
+  /** Returns a pubsub stub. */
   PubsubGrpc.PubsubStub getStub() {
     return stub;
   }

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlGrpcStubsManager.java
@@ -64,7 +64,7 @@ final class StorageControlGrpcStubsManager implements AutoCloseable {
    * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
    */
   ScsControlGrpc.ScsControlFutureStub getStub() {
-    return futureStub.withDeadlineAfter(DEADLINE.getSeconds(), TimeUnit.SECONDS);
+    return futureStub.withDeadlineAfter(DEADLINE.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataGrpcStubsManager.java
@@ -159,7 +159,7 @@ final class StorageDataGrpcStubsManager implements AutoCloseable {
     int nextStubIndex = this.nextStubIndex.getAndIncrement();
     return futureStubs
         .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.getSeconds(), TimeUnit.SECONDS);
+        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override


### PR DESCRIPTION
Set stub deadlines using milliseconds instead of seconds. Duration.getSeconds() truncates, so a client configuration with a timeout of less than one second, like the preconfigured LowLatency config, always has a deadline of 0, so no calls will ever succeed.

Remove the documentation from the topic stubs manager that states that it sets a deadline on the stub it returns.