### PR TITLE
chore: improve resource exhausted error message

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/CacheServiceExceptionMapper.java
@@ -66,7 +66,8 @@ public final class CacheServiceExceptionMapper {
           return new AuthenticationException(grpcException, errorDetails);
 
         case RESOURCE_EXHAUSTED:
-          return new LimitExceededException(grpcException, errorDetails);
+          return LimitExceededException.CreateWithMessageWrapper(
+              grpcException, errorDetails, errorCause);
 
         case NOT_FOUND:
           if (errorCause.contains("item_not_found")) {

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
@@ -4,19 +4,92 @@ import momento.sdk.internal.MomentoTransportErrorDetails;
 
 /** Requested operation couldn't be completed because system limits were hit. */
 public class LimitExceededException extends MomentoServiceException {
-
-  private static final String MESSAGE =
-      "Request rate, bandwidth, or object size exceeded the limits for this account. To resolve this error, "
-          + "reduce your usage as appropriate or contact Momento to request a limit increase.";
-
   /**
    * Constructs a LimitExceededException with a cause and error details.
    *
    * @param cause the cause.
    * @param transportErrorDetails details about the request and error.
+   * @param messageWrapper details about which limit was exceeded.
    */
   public LimitExceededException(
-      Throwable cause, MomentoTransportErrorDetails transportErrorDetails) {
-    super(MomentoErrorCode.LIMIT_EXCEEDED_ERROR, MESSAGE, cause, transportErrorDetails);
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails, String messageWrapper) {
+    super(MomentoErrorCode.LIMIT_EXCEEDED_ERROR, messageWrapper, cause, transportErrorDetails);
+  }
+
+  /**
+   * Creates a LimitExceededException with a cause and error details. Determines the limit exceeded
+   * message wrapper to use based on the error cause.
+   *
+   * @param cause
+   * @param transportErrorDetails
+   * @param errorCause
+   * @return
+   */
+  public static LimitExceededException CreateWithMessageWrapper(
+      Throwable cause, MomentoTransportErrorDetails transportErrorDetails, String errorCause) {
+    String messageWrapper = LimitExceededMessageWrapper.UNKNOWN_LIMIT_EXCEEDED.toString();
+    switch (errorCause) {
+      case "topic_subscriptions_limit_exceeded":
+        messageWrapper = LimitExceededMessageWrapper.TOPIC_SUBSCRIPTIONS_LIMIT_EXCEEDED.toString();
+        break;
+      case "operations_rate_limit_exceeded":
+        messageWrapper = LimitExceededMessageWrapper.OPERATIONS_RATE_LIMIT_EXCEEDED.toString();
+        break;
+      case "throughput_rate_limit_exceeded":
+        messageWrapper = LimitExceededMessageWrapper.THROUGHPUT_RATE_LIMIT_EXCEEDED.toString();
+        break;
+      case "request_size_limit_exceeded":
+        messageWrapper = LimitExceededMessageWrapper.REQUEST_SIZE_LIMIT_EXCEEDED.toString();
+        break;
+      case "item_size_limit_exceeded":
+        messageWrapper = LimitExceededMessageWrapper.ITEM_SIZE_LIMIT_EXCEEDED.toString();
+        break;
+      case "element_size_limit_exceeded":
+        messageWrapper = LimitExceededMessageWrapper.ELEMENT_SIZE_LIMIT_EXCEEDED.toString();
+        break;
+      default:
+        String lowerCasedMessage = errorCause.toLowerCase();
+        if (lowerCasedMessage.contains("subscribers")) {
+          messageWrapper =
+              LimitExceededMessageWrapper.TOPIC_SUBSCRIPTIONS_LIMIT_EXCEEDED.toString();
+        } else if (lowerCasedMessage.contains("operations")) {
+          messageWrapper = LimitExceededMessageWrapper.OPERATIONS_RATE_LIMIT_EXCEEDED.toString();
+        } else if (lowerCasedMessage.contains("throughput")) {
+          messageWrapper = LimitExceededMessageWrapper.THROUGHPUT_RATE_LIMIT_EXCEEDED.toString();
+        } else if (lowerCasedMessage.contains("request limit")) {
+          messageWrapper = LimitExceededMessageWrapper.REQUEST_SIZE_LIMIT_EXCEEDED.toString();
+        } else if (lowerCasedMessage.contains("item size")) {
+          messageWrapper = LimitExceededMessageWrapper.ITEM_SIZE_LIMIT_EXCEEDED.toString();
+        } else if (lowerCasedMessage.contains("element size")) {
+          messageWrapper = LimitExceededMessageWrapper.ELEMENT_SIZE_LIMIT_EXCEEDED.toString();
+        }
+        break;
+    }
+    return new LimitExceededException(cause, transportErrorDetails, messageWrapper);
+  }
+}
+
+enum LimitExceededMessageWrapper {
+  TOPIC_SUBSCRIPTIONS_LIMIT_EXCEEDED("Topic subscriptions limit exceeded for this account"),
+  OPERATIONS_RATE_LIMIT_EXCEEDED("Request rate limit exceeded for this account"),
+  THROUGHPUT_RATE_LIMIT_EXCEEDED("Bandwidth limit exceeded for this account"),
+  REQUEST_SIZE_LIMIT_EXCEEDED("Request size limit exceeded for this account"),
+  ITEM_SIZE_LIMIT_EXCEEDED("Item size limit exceeded for this account"),
+  ELEMENT_SIZE_LIMIT_EXCEEDED("Element size limit exceeded for this account"),
+  UNKNOWN_LIMIT_EXCEEDED("Limit exceeded for this account");
+
+  private final String messageWrapper;
+
+  /** @param messageWrapper */
+  LimitExceededMessageWrapper(final String messageWrapper) {
+    this.messageWrapper = messageWrapper;
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Enum#toString()
+   */
+  @Override
+  public String toString() {
+    return messageWrapper;
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
@@ -28,6 +28,9 @@ public class LimitExceededException extends MomentoServiceException {
   public static LimitExceededException CreateWithMessageWrapper(
       Throwable cause, MomentoTransportErrorDetails transportErrorDetails, String errorCause) {
     String messageWrapper = LimitExceededMessageWrapper.UNKNOWN_LIMIT_EXCEEDED.toString();
+
+    // If provided, we use the `err` metadata value to determine the most
+    // appropriate error message to return.
     switch (errorCause) {
       case "topic_subscriptions_limit_exceeded":
         messageWrapper = LimitExceededMessageWrapper.TOPIC_SUBSCRIPTIONS_LIMIT_EXCEEDED.toString();
@@ -48,6 +51,8 @@ public class LimitExceededException extends MomentoServiceException {
         messageWrapper = LimitExceededMessageWrapper.ELEMENT_SIZE_LIMIT_EXCEEDED.toString();
         break;
       default:
+        // If `err` metadata is unavailable, try to use the error details field
+        // to return the an appropriate error message.
         String lowerCasedMessage = errorCause.toLowerCase();
         if (lowerCasedMessage.contains("subscribers")) {
           messageWrapper =

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededException.java
@@ -73,28 +73,3 @@ public class LimitExceededException extends MomentoServiceException {
     return new LimitExceededException(cause, transportErrorDetails, messageWrapper);
   }
 }
-
-enum LimitExceededMessageWrapper {
-  TOPIC_SUBSCRIPTIONS_LIMIT_EXCEEDED("Topic subscriptions limit exceeded for this account"),
-  OPERATIONS_RATE_LIMIT_EXCEEDED("Request rate limit exceeded for this account"),
-  THROUGHPUT_RATE_LIMIT_EXCEEDED("Bandwidth limit exceeded for this account"),
-  REQUEST_SIZE_LIMIT_EXCEEDED("Request size limit exceeded for this account"),
-  ITEM_SIZE_LIMIT_EXCEEDED("Item size limit exceeded for this account"),
-  ELEMENT_SIZE_LIMIT_EXCEEDED("Element size limit exceeded for this account"),
-  UNKNOWN_LIMIT_EXCEEDED("Limit exceeded for this account");
-
-  private final String messageWrapper;
-
-  /** @param messageWrapper */
-  LimitExceededMessageWrapper(final String messageWrapper) {
-    this.messageWrapper = messageWrapper;
-  }
-
-  /* (non-Javadoc)
-   * @see java.lang.Enum#toString()
-   */
-  @Override
-  public String toString() {
-    return messageWrapper;
-  }
-}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededMessageWrapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/LimitExceededMessageWrapper.java
@@ -1,0 +1,30 @@
+package momento.sdk.exceptions;
+
+/**
+ * A list of all available message wrappers for the LimitExceededException. These messages specify
+ * which limit was exceeded for the account.
+ */
+public enum LimitExceededMessageWrapper {
+  TOPIC_SUBSCRIPTIONS_LIMIT_EXCEEDED("Topic subscriptions limit exceeded for this account"),
+  OPERATIONS_RATE_LIMIT_EXCEEDED("Request rate limit exceeded for this account"),
+  THROUGHPUT_RATE_LIMIT_EXCEEDED("Bandwidth limit exceeded for this account"),
+  REQUEST_SIZE_LIMIT_EXCEEDED("Request size limit exceeded for this account"),
+  ITEM_SIZE_LIMIT_EXCEEDED("Item size limit exceeded for this account"),
+  ELEMENT_SIZE_LIMIT_EXCEEDED("Element size limit exceeded for this account"),
+  UNKNOWN_LIMIT_EXCEEDED("Limit exceeded for this account");
+
+  private final String messageWrapper;
+
+  /** @param messageWrapper */
+  LimitExceededMessageWrapper(final String messageWrapper) {
+    this.messageWrapper = messageWrapper;
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Enum#toString()
+   */
+  @Override
+  public String toString() {
+    return messageWrapper;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1052

Adds a factory method for `LimitExceededException` that takes in an error cause (`err` metadata or grpc error details string) and constructs a `LimitExceededException` with a message wrapper that includes the limit that was exceeded.