### PR TITLE
chore: Add a gRPC configuration interface

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/config/transport/GrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/GrpcConfiguration.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import momento.sdk.internal.GrpcChannelOptions;
 
 /** Abstracts away the gRPC configuration tunables. */
-public class GrpcConfiguration {
+public class GrpcConfiguration implements IGrpcConfiguration {
 
   private final Duration deadline;
   private final int minNumGrpcChannels;
@@ -60,12 +60,7 @@ public class GrpcConfiguration {
     this.keepAliveTimeMs = keepAliveTime;
   }
 
-  /**
-   * How long the client will wait for an RPC to complete before it is terminated with {@link
-   * io.grpc.Status.Code#DEADLINE_EXCEEDED}.
-   *
-   * @return the deadline
-   */
+  @Override
   public Duration getDeadline() {
     return deadline;
   }
@@ -86,11 +81,7 @@ public class GrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The minimum number of gRPC channels to keep open at any given time.
-   *
-   * @return the minimum number of gRPC channels.
-   */
+  @Override
   public int getMinNumGrpcChannels() {
     return minNumGrpcChannels;
   }
@@ -111,11 +102,7 @@ public class GrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The maximum size of a message (in bytes) that can be received by the client.
-   *
-   * @return the maximum message size.
-   */
+  @Override
   public Optional<Integer> getMaxMessageSize() {
     return maxMessageSize;
   }
@@ -136,11 +123,7 @@ public class GrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * Whether keepalive will be performed when there are no outstanding requests on a connection.
-   *
-   * @return the boolean indicating whether to send keepalive pings without any active calls.
-   */
+  @Override
   public Optional<Boolean> getKeepAliveWithoutCalls() {
     return keepAliveWithoutCalls;
   }
@@ -170,11 +153,7 @@ public class GrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The time to wait for a keepalive ping response before considering the connection dead.
-   *
-   * @return the time to wait for a keepalive ping response before considering the connection dead.
-   */
+  @Override
   public Optional<Integer> getKeepAliveTimeoutMs() {
     return keepAliveTimeoutMs;
   }
@@ -203,11 +182,7 @@ public class GrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The time to wait between keepalive pings.
-   *
-   * @return the time to wait between keepalive pings.
-   */
+  @Override
   public Optional<Integer> getKeepAliveTimeMs() {
     return keepAliveTimeMs;
   }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/IGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/IGrpcConfiguration.java
@@ -24,7 +24,7 @@ public interface IGrpcConfiguration {
    *
    * @return the maximum message size, or empty if there is no specified maximum.
    */
-  Optional<Integer> getMaxMessageSize();
+  Optional<Integer> getMaxReceivedMessageSize();
 
   /**
    * Whether keepalive will be performed when there are no outstanding requests on a connection.
@@ -38,12 +38,12 @@ public interface IGrpcConfiguration {
    *
    * @return the time to wait for a keepalive ping response before considering the connection dead.
    */
-  Optional<Integer> getKeepAliveTimeoutMs();
+  Optional<Duration> getKeepAliveTimeout();
 
   /**
    * The time to wait between keepalive pings.
    *
    * @return the time to wait between keepalive pings.
    */
-  Optional<Integer> getKeepAliveTimeMs();
+  Optional<Duration> getKeepAliveTime();
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/IGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/IGrpcConfiguration.java
@@ -1,0 +1,49 @@
+package momento.sdk.config.transport;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface IGrpcConfiguration {
+  /**
+   * How long the client will wait for an RPC to complete before it is terminated with {@link
+   * io.grpc.Status.Code#DEADLINE_EXCEEDED}.
+   *
+   * @return the deadline
+   */
+  Duration getDeadline();
+
+  /**
+   * The minimum number of gRPC channels to keep open at any given time.
+   *
+   * @return the minimum number of gRPC channels.
+   */
+  int getMinNumGrpcChannels();
+
+  /**
+   * The maximum size of a message (in bytes) that can be received by the client.
+   *
+   * @return the maximum message size, or empty if there is no specified maximum.
+   */
+  Optional<Integer> getMaxMessageSize();
+
+  /**
+   * Whether keepalive will be performed when there are no outstanding requests on a connection.
+   *
+   * @return the boolean indicating whether to send keepalive pings without any active calls.
+   */
+  Optional<Boolean> getKeepAliveWithoutCalls();
+
+  /**
+   * The time to wait for a keepalive ping response before considering the connection dead.
+   *
+   * @return the time to wait for a keepalive ping response before considering the connection dead.
+   */
+  Optional<Integer> getKeepAliveTimeoutMs();
+
+  /**
+   * The time to wait between keepalive pings.
+   *
+   * @return the time to wait between keepalive pings.
+   */
+  Optional<Integer> getKeepAliveTimeMs();
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/storage/StorageGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/storage/StorageGrpcConfiguration.java
@@ -5,18 +5,19 @@ import static momento.sdk.ValidationUtils.ensureRequestDeadlineValid;
 import java.time.Duration;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import momento.sdk.config.transport.IGrpcConfiguration;
 import momento.sdk.internal.GrpcChannelOptions;
 
 /** Abstracts away the gRPC configuration tunables. */
 public class StorageGrpcConfiguration implements IGrpcConfiguration {
 
-  private final Duration deadline;
+  private final @Nonnull Duration deadline;
   private final int minNumGrpcChannels;
-  private final Optional<Integer> maxMessageSize;
-  private final Optional<Boolean> keepAliveWithoutCalls;
-  private final Optional<Integer> keepAliveTimeoutMs;
-  private final Optional<Integer> keepAliveTimeMs;
+  private final @Nullable Integer maxMessageSize;
+  private final @Nullable Boolean keepAliveWithoutCalls;
+  private final @Nullable Duration keepAliveTimeout;
+  private final @Nullable Duration keepAliveTime;
 
   /**
    * Constructs a StorageGrpcConfiguration.
@@ -27,10 +28,38 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
     this(
         deadline,
         1,
-        Optional.of(GrpcChannelOptions.DEFAULT_MAX_MESSAGE_SIZE),
-        Optional.of(GrpcChannelOptions.DEFAULT_KEEPALIVE_WITHOUT_STREAM),
-        Optional.of(GrpcChannelOptions.DEFAULT_KEEPALIVE_TIMEOUT_MS),
-        Optional.of(GrpcChannelOptions.DEFAULT_KEEPALIVE_TIME_MS));
+        GrpcChannelOptions.DEFAULT_MAX_MESSAGE_SIZE,
+        GrpcChannelOptions.DEFAULT_KEEPALIVE_WITHOUT_STREAM,
+        GrpcChannelOptions.DEFAULT_KEEPALIVE_TIMEOUT,
+        GrpcChannelOptions.DEFAULT_KEEPALIVE_TIME);
+  }
+
+  /**
+   * Constructs a StorageGrpcConfiguration.
+   *
+   * @param deadline The maximum duration of a gRPC call.
+   * @param minNumGrpcChannels The minimum number of gRPC channels to keep open at any given time.
+   * @param maxMessageSize The maximum size of a message (in bytes) that can be received by the
+   *     client.
+   * @param keepAliveWithoutCalls Whether to send keepalive pings without any active calls.
+   * @param keepAliveTimeout The time in milliseconds to wait for a keepalive ping response before
+   *     considering the connection dead.
+   * @param keepAliveTime The time in milliseconds to wait between keepalive pings.
+   */
+  public StorageGrpcConfiguration(
+      @Nonnull Duration deadline,
+      int minNumGrpcChannels,
+      Optional<Integer> maxMessageSize,
+      Optional<Boolean> keepAliveWithoutCalls,
+      Optional<Integer> keepAliveTimeout,
+      Optional<Integer> keepAliveTime) {
+    this(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize.orElse(null),
+        keepAliveWithoutCalls.orElse(null),
+        keepAliveTimeout.map(Duration::ofMillis).orElse(null),
+        keepAliveTime.map(Duration::ofMillis).orElse(null));
   }
 
   /**
@@ -48,17 +77,17 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
   public StorageGrpcConfiguration(
       @Nonnull Duration deadline,
       int minNumGrpcChannels,
-      Optional<Integer> maxMessageSize,
-      Optional<Boolean> keepAliveWithoutCalls,
-      Optional<Integer> keepAliveTimeout,
-      Optional<Integer> keepAliveTime) {
+      @Nullable Integer maxMessageSize,
+      @Nullable Boolean keepAliveWithoutCalls,
+      @Nullable Duration keepAliveTimeout,
+      @Nullable Duration keepAliveTime) {
     ensureRequestDeadlineValid(deadline);
     this.deadline = deadline;
     this.minNumGrpcChannels = minNumGrpcChannels;
     this.maxMessageSize = maxMessageSize;
     this.keepAliveWithoutCalls = keepAliveWithoutCalls;
-    this.keepAliveTimeoutMs = keepAliveTimeout;
-    this.keepAliveTimeMs = keepAliveTime;
+    this.keepAliveTimeout = keepAliveTimeout;
+    this.keepAliveTime = keepAliveTime;
   }
 
   @Override
@@ -78,8 +107,8 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
         minNumGrpcChannels,
         maxMessageSize,
         keepAliveWithoutCalls,
-        keepAliveTimeoutMs,
-        keepAliveTimeMs);
+        keepAliveTimeout,
+        keepAliveTime);
   }
 
   @Override
@@ -99,13 +128,22 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
         minNumGrpcChannels,
         maxMessageSize,
         keepAliveWithoutCalls,
-        keepAliveTimeoutMs,
-        keepAliveTimeMs);
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  /**
+   * The maximum size of a message (in bytes) that can be received by the client.
+   *
+   * @return the maximum message size, or empty if there is no specified maximum.
+   */
+  public Optional<Integer> getMaxMessageSize() {
+    return getMaxReceivedMessageSize();
   }
 
   @Override
-  public Optional<Integer> getMaxMessageSize() {
-    return maxMessageSize;
+  public Optional<Integer> getMaxReceivedMessageSize() {
+    return Optional.ofNullable(maxMessageSize);
   }
 
   /**
@@ -118,15 +156,15 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
     return new StorageGrpcConfiguration(
         deadline,
         minNumGrpcChannels,
-        Optional.of(maxMessageSize),
+        maxMessageSize,
         keepAliveWithoutCalls,
-        keepAliveTimeoutMs,
-        keepAliveTimeMs);
+        keepAliveTimeout,
+        keepAliveTime);
   }
 
   @Override
   public Optional<Boolean> getKeepAliveWithoutCalls() {
-    return keepAliveWithoutCalls;
+    return Optional.ofNullable(keepAliveWithoutCalls);
   }
 
   /**
@@ -146,18 +184,47 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
    */
   public StorageGrpcConfiguration withKeepAliveWithoutCalls(
       Optional<Boolean> keepAliveWithoutCalls) {
+    return withKeepAliveWithoutCalls(keepAliveWithoutCalls.orElse(null));
+  }
+
+  /**
+   * Copy constructor that updates whether keepalive will be performed when there are no outstanding
+   * requests on a connection.
+   *
+   * <p>NOTE: keep-alives are very important for long-lived server environments where there may be
+   * periods of time when the connection is idle. However, they are very problematic for lambda
+   * environments where the lambda runtime is continuously frozen and unfrozen, because the lambda
+   * may be frozen before the "ACK" is received from the server. This can cause the keep-alive to
+   * timeout even though the connection is completely healthy. Therefore, keep-alives should be
+   * disabled in lambda and similar environments.
+   *
+   * @param keepAliveWithoutCalls The boolean indicating whether to send keepalive pings without any
+   *     active calls.
+   * @return The updated StorageGrpcConfiguration.
+   */
+  public StorageGrpcConfiguration withKeepAliveWithoutCalls(
+      @Nullable Boolean keepAliveWithoutCalls) {
     return new StorageGrpcConfiguration(
         deadline,
         minNumGrpcChannels,
         maxMessageSize,
         keepAliveWithoutCalls,
-        keepAliveTimeoutMs,
-        keepAliveTimeMs);
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  /**
+   * The time to wait for a keepalive ping response before considering the connection dead.
+   *
+   * @return the time to wait for a keepalive ping response before considering the connection dead.
+   */
+  public Optional<Integer> getKeepAliveTimeoutMs() {
+    return getKeepAliveTimeout().map(d -> (int) d.toMillis());
   }
 
   @Override
-  public Optional<Integer> getKeepAliveTimeoutMs() {
-    return keepAliveTimeoutMs;
+  public Optional<Duration> getKeepAliveTimeout() {
+    return Optional.ofNullable(keepAliveTimeout);
   }
 
   /**
@@ -180,13 +247,22 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
         minNumGrpcChannels,
         maxMessageSize,
         keepAliveWithoutCalls,
-        Optional.of(keepAliveTimeoutMs),
-        keepAliveTimeMs);
+        Duration.ofMillis(keepAliveTimeoutMs),
+        keepAliveTime);
+  }
+
+  /**
+   * The time to wait between keepalive pings.
+   *
+   * @return the time to wait between keepalive pings.
+   */
+  public Optional<Integer> getKeepAliveTimeMs() {
+    return getKeepAliveTime().map(d -> (int) d.toMillis());
   }
 
   @Override
-  public Optional<Integer> getKeepAliveTimeMs() {
-    return keepAliveTimeMs;
+  public Optional<Duration> getKeepAliveTime() {
+    return Optional.ofNullable(keepAliveTime);
   }
 
   /**
@@ -208,8 +284,8 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
         minNumGrpcChannels,
         maxMessageSize,
         keepAliveWithoutCalls,
-        keepAliveTimeoutMs,
-        Optional.of(keepAliveTimeMs));
+        keepAliveTimeout,
+        Duration.ofMillis(keepAliveTimeMs));
   }
 
   /**
@@ -226,11 +302,6 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
    */
   public StorageGrpcConfiguration withKeepAliveDisabled() {
     return new StorageGrpcConfiguration(
-        deadline,
-        minNumGrpcChannels,
-        maxMessageSize,
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty());
+        deadline, minNumGrpcChannels, maxMessageSize, null, null, null);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/storage/StorageGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/storage/StorageGrpcConfiguration.java
@@ -5,10 +5,11 @@ import static momento.sdk.ValidationUtils.ensureRequestDeadlineValid;
 import java.time.Duration;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import momento.sdk.config.transport.IGrpcConfiguration;
 import momento.sdk.internal.GrpcChannelOptions;
 
 /** Abstracts away the gRPC configuration tunables. */
-public class StorageGrpcConfiguration {
+public class StorageGrpcConfiguration implements IGrpcConfiguration {
 
   private final Duration deadline;
   private final int minNumGrpcChannels;
@@ -60,12 +61,7 @@ public class StorageGrpcConfiguration {
     this.keepAliveTimeMs = keepAliveTime;
   }
 
-  /**
-   * How long the client will wait for an RPC to complete before it is terminated with {@link
-   * io.grpc.Status.Code#DEADLINE_EXCEEDED}.
-   *
-   * @return the deadline
-   */
+  @Override
   public Duration getDeadline() {
     return deadline;
   }
@@ -86,11 +82,7 @@ public class StorageGrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The minimum number of gRPC channels to keep open at any given time.
-   *
-   * @return the minimum number of gRPC channels.
-   */
+  @Override
   public int getMinNumGrpcChannels() {
     return minNumGrpcChannels;
   }
@@ -111,11 +103,7 @@ public class StorageGrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The maximum size of a message (in bytes) that can be received by the client.
-   *
-   * @return the maximum message size.
-   */
+  @Override
   public Optional<Integer> getMaxMessageSize() {
     return maxMessageSize;
   }
@@ -136,11 +124,7 @@ public class StorageGrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * Whether keepalive will be performed when there are no outstanding requests on a connection.
-   *
-   * @return the boolean indicating whether to send keepalive pings without any active calls.
-   */
+  @Override
   public Optional<Boolean> getKeepAliveWithoutCalls() {
     return keepAliveWithoutCalls;
   }
@@ -171,11 +155,7 @@ public class StorageGrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The time to wait for a keepalive ping response before considering the connection dead.
-   *
-   * @return the time to wait for a keepalive ping response before considering the connection dead.
-   */
+  @Override
   public Optional<Integer> getKeepAliveTimeoutMs() {
     return keepAliveTimeoutMs;
   }
@@ -204,11 +184,7 @@ public class StorageGrpcConfiguration {
         keepAliveTimeMs);
   }
 
-  /**
-   * The time to wait between keepalive pings.
-   *
-   * @return the time to wait between keepalive pings.
-   */
+  @Override
   public Optional<Integer> getKeepAliveTimeMs() {
     return keepAliveTimeMs;
   }

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -1,6 +1,7 @@
 package momento.sdk.internal;
 
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import momento.sdk.config.transport.IGrpcConfiguration;
 
@@ -12,24 +13,28 @@ public class GrpcChannelOptions {
 
   public static final boolean DEFAULT_KEEPALIVE_WITHOUT_STREAM = true;
   public static final int DEFAULT_KEEPALIVE_TIME_MS = 5000; // milliseconds
+  public static final Duration DEFAULT_KEEPALIVE_TIME =
+      Duration.ofMillis(DEFAULT_KEEPALIVE_TIME_MS);
   public static final int DEFAULT_KEEPALIVE_TIMEOUT_MS = 1000; // milliseconds
+  public static final Duration DEFAULT_KEEPALIVE_TIMEOUT =
+      Duration.ofMillis(DEFAULT_KEEPALIVE_TIMEOUT_MS);
 
   public static void applyGrpcConfigurationToChannelBuilder(
       IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
     channelBuilder.useTransportSecurity();
     channelBuilder.disableRetry();
 
-    grpcConfig.getMaxMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);
+    grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);
 
     // no equivalent for maxOutboundMessageSize
 
     grpcConfig
-        .getKeepAliveTimeMs()
-        .ifPresent(integer -> channelBuilder.keepAliveTime(integer, TimeUnit.MILLISECONDS));
+        .getKeepAliveTime()
+        .ifPresent(d -> channelBuilder.keepAliveTime(d.toMillis(), TimeUnit.MILLISECONDS));
 
     grpcConfig
-        .getKeepAliveTimeoutMs()
-        .ifPresent(integer -> channelBuilder.keepAliveTimeout(integer, TimeUnit.MILLISECONDS));
+        .getKeepAliveTimeout()
+        .ifPresent(d -> channelBuilder.keepAliveTimeout(d.toMillis(), TimeUnit.MILLISECONDS));
 
     grpcConfig.getKeepAliveWithoutCalls().ifPresent(channelBuilder::keepAliveWithoutCalls);
   }

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -1,10 +1,8 @@
 package momento.sdk.internal;
 
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import momento.sdk.config.transport.GrpcConfiguration;
-import momento.sdk.config.transport.storage.StorageGrpcConfiguration;
+import momento.sdk.config.transport.IGrpcConfiguration;
 
 public class GrpcChannelOptions {
   // The default value for max_send_message_length is 4mb.  We need to increase this to 5mb in order
@@ -17,58 +15,22 @@ public class GrpcChannelOptions {
   public static final int DEFAULT_KEEPALIVE_TIMEOUT_MS = 1000; // milliseconds
 
   public static void applyGrpcConfigurationToChannelBuilder(
-      GrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
+      IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
     channelBuilder.useTransportSecurity();
     channelBuilder.disableRetry();
 
-    final Optional<Integer> maxMessageSize = grpcConfig.getMaxMessageSize();
-    if (maxMessageSize.isPresent()) {
-      channelBuilder.maxInboundMessageSize(maxMessageSize.get());
-    }
+    grpcConfig.getMaxMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);
 
-    // no equivalent for maxOutboundboundMessageSize
+    // no equivalent for maxOutboundMessageSize
 
-    final Optional<Integer> keepAliveTimeMs = grpcConfig.getKeepAliveTimeMs();
-    if (keepAliveTimeMs.isPresent()) {
-      channelBuilder.keepAliveTime(keepAliveTimeMs.get(), TimeUnit.MILLISECONDS);
-    }
+    grpcConfig
+        .getKeepAliveTimeMs()
+        .ifPresent(integer -> channelBuilder.keepAliveTime(integer, TimeUnit.MILLISECONDS));
 
-    final Optional<Integer> keepAliveTimeoutMs = grpcConfig.getKeepAliveTimeoutMs();
-    if (keepAliveTimeoutMs.isPresent()) {
-      channelBuilder.keepAliveTimeout(keepAliveTimeoutMs.get(), TimeUnit.MILLISECONDS);
-    }
+    grpcConfig
+        .getKeepAliveTimeoutMs()
+        .ifPresent(integer -> channelBuilder.keepAliveTimeout(integer, TimeUnit.MILLISECONDS));
 
-    final Optional<Boolean> keepAliveWithoutCalls = grpcConfig.getKeepAliveWithoutCalls();
-    if (keepAliveWithoutCalls.isPresent()) {
-      channelBuilder.keepAliveWithoutCalls(keepAliveWithoutCalls.get());
-    }
-  }
-
-  public static void applyGrpcConfigurationToChannelBuilder(
-      StorageGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
-    channelBuilder.useTransportSecurity();
-    channelBuilder.disableRetry();
-
-    final Optional<Integer> maxMessageSize = grpcConfig.getMaxMessageSize();
-    if (maxMessageSize.isPresent()) {
-      channelBuilder.maxInboundMessageSize(maxMessageSize.get());
-    }
-
-    // no equivalent for maxOutboundboundMessageSize
-
-    final Optional<Integer> keepAliveTimeMs = grpcConfig.getKeepAliveTimeMs();
-    if (keepAliveTimeMs.isPresent()) {
-      channelBuilder.keepAliveTime(keepAliveTimeMs.get(), TimeUnit.MILLISECONDS);
-    }
-
-    final Optional<Integer> keepAliveTimeoutMs = grpcConfig.getKeepAliveTimeoutMs();
-    if (keepAliveTimeoutMs.isPresent()) {
-      channelBuilder.keepAliveTimeout(keepAliveTimeoutMs.get(), TimeUnit.MILLISECONDS);
-    }
-
-    final Optional<Boolean> keepAliveWithoutCalls = grpcConfig.getKeepAliveWithoutCalls();
-    if (keepAliveWithoutCalls.isPresent()) {
-      channelBuilder.keepAliveWithoutCalls(keepAliveWithoutCalls.get());
-    }
+    grpcConfig.getKeepAliveWithoutCalls().ifPresent(channelBuilder::keepAliveWithoutCalls);
   }
 }


### PR DESCRIPTION
Add an interface for GrpcConfigration so that common code for setting up connections can work with the different implementations.

Update the applyGrpcConfigurationToChannelBuilder logic to work with IGrpcConfigration and reduce the two implementations to one.