### PR TITLE
feat: Add leaderboard upsert, fetch by rank, and remove elements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-cache-service:
 
 ## Run the leaderboard service tests
 test-leaderboard-service:
-	@echo "Leaderboard client not implemented yet."
+	@CONSISTENT_READS=1 ./gradlew test-leaderboard-service
 
 ## Run the storage service tests
 test-storage-service:

--- a/momento-sdk/build.gradle.kts
+++ b/momento-sdk/build.gradle.kts
@@ -99,3 +99,8 @@ registerIntegrationTestTask(
     "test-topics-service",
     listOf("momento.sdk.topics.*")
 )
+
+registerIntegrationTestTask(
+    "test-leaderboard-service",
+    listOf("momento.sdk.leaderboard.*")
+)

--- a/momento-sdk/src/intTest/java/momento/sdk/leaderboard/BaseLeaderboardTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/leaderboard/BaseLeaderboardTestClass.java
@@ -1,0 +1,74 @@
+package momento.sdk.leaderboard;
+
+import java.time.Duration;
+import java.util.UUID;
+import momento.sdk.CacheClient;
+import momento.sdk.LeaderboardClient;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.Configuration;
+import momento.sdk.config.Configurations;
+import momento.sdk.config.LeaderboardConfiguration;
+import momento.sdk.config.LeaderboardConfigurations;
+import momento.sdk.config.ReadConcern;
+import momento.sdk.responses.cache.control.CacheCreateResponse;
+import momento.sdk.responses.cache.control.CacheDeleteResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class BaseLeaderboardTestClass {
+  protected static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
+  protected static final Duration FIVE_SECONDS = Duration.ofSeconds(5);
+  protected static CredentialProvider credentialProvider;
+
+  protected static CacheClient cacheClient;
+  protected static LeaderboardClient leaderboardClient;
+  protected static String cacheName;
+
+  @BeforeAll
+  static void beforeAll() {
+    final boolean consistentReads = System.getenv("CONSISTENT_READS") != null;
+
+    credentialProvider = CredentialProvider.fromEnvVar("MOMENTO_API_KEY");
+
+    final Configuration config = Configurations.Laptop.latest();
+    final Configuration consistentConfig = config.withReadConcern(ReadConcern.CONSISTENT);
+
+    cacheClient =
+        consistentReads
+            ? CacheClient.builder(credentialProvider, consistentConfig, DEFAULT_TTL_SECONDS).build()
+            : CacheClient.builder(credentialProvider, config, DEFAULT_TTL_SECONDS).build();
+
+    final LeaderboardConfiguration leaderboardConfig = LeaderboardConfigurations.Laptop.latest();
+    leaderboardClient = LeaderboardClient.builder(credentialProvider, leaderboardConfig).build();
+
+    cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    cleanupTestCache(cacheName);
+    cacheClient.close();
+    leaderboardClient.close();
+  }
+
+  protected static void ensureTestCacheExists(String cacheName) {
+    CacheCreateResponse response = cacheClient.createCache(cacheName).join();
+    if (response instanceof CacheCreateResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test create cache: " + ((CacheCreateResponse.Error) response).getMessage());
+    }
+  }
+
+  public static void cleanupTestCache(String cacheName) {
+    CacheDeleteResponse response = cacheClient.deleteCache(cacheName).join();
+    if (response instanceof CacheDeleteResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test delete cache: " + ((CacheDeleteResponse.Error) response).getMessage());
+    }
+  }
+
+  public static String testCacheName() {
+    return "java-integration-test-default-" + UUID.randomUUID();
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/leaderboard/BaseLeaderboardTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/leaderboard/BaseLeaderboardTestClass.java
@@ -9,7 +9,6 @@ import momento.sdk.config.Configuration;
 import momento.sdk.config.Configurations;
 import momento.sdk.config.LeaderboardConfiguration;
 import momento.sdk.config.LeaderboardConfigurations;
-import momento.sdk.config.ReadConcern;
 import momento.sdk.responses.cache.control.CacheCreateResponse;
 import momento.sdk.responses.cache.control.CacheDeleteResponse;
 import org.junit.jupiter.api.AfterAll;
@@ -26,17 +25,11 @@ public class BaseLeaderboardTestClass {
 
   @BeforeAll
   static void beforeAll() {
-    final boolean consistentReads = System.getenv("CONSISTENT_READS") != null;
-
     credentialProvider = CredentialProvider.fromEnvVar("MOMENTO_API_KEY");
 
     final Configuration config = Configurations.Laptop.latest();
-    final Configuration consistentConfig = config.withReadConcern(ReadConcern.CONSISTENT);
 
-    cacheClient =
-        consistentReads
-            ? CacheClient.builder(credentialProvider, consistentConfig, DEFAULT_TTL_SECONDS).build()
-            : CacheClient.builder(credentialProvider, config, DEFAULT_TTL_SECONDS).build();
+    cacheClient = CacheClient.builder(credentialProvider, config, DEFAULT_TTL_SECONDS).build();
 
     final LeaderboardConfiguration leaderboardConfig = LeaderboardConfigurations.Laptop.latest();
     leaderboardClient = LeaderboardClient.builder(credentialProvider, leaderboardConfig).build();

--- a/momento-sdk/src/intTest/java/momento/sdk/leaderboard/LeaderboardClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/leaderboard/LeaderboardClientTest.java
@@ -1,0 +1,327 @@
+package momento.sdk.leaderboard;
+
+import static momento.sdk.TestUtils.randomString;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import momento.sdk.ILeaderboard;
+import momento.sdk.exceptions.CacheNotFoundException;
+import momento.sdk.exceptions.InvalidArgumentException;
+import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.FetchResponse;
+import momento.sdk.responses.leaderboard.LeaderboardElement;
+import momento.sdk.responses.leaderboard.RemoveElementsResponse;
+import momento.sdk.responses.leaderboard.UpsertResponse;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+public class LeaderboardClientTest extends BaseLeaderboardTestClass {
+
+  // upsert
+
+  @Test
+  public void upsertHappyPath() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+    elements.put(1, 1.0);
+    elements.put(2, 2.0);
+    elements.put(3, 3.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(UpsertResponse.Success.class);
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(3);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(1, 2, 3);
+            });
+
+    elements.clear();
+    elements.put(2, 4.0);
+    elements.put(3, 3.0);
+    elements.put(4, 2.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(UpsertResponse.Success.class);
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(4);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(1, 4, 3, 2);
+            });
+  }
+
+  @Test
+  public void upsertInvalidCacheName() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(null, leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+    elements.put(1, 1.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpsertResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void upsertNonExistentCache() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(randomString(), leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+    elements.put(1, 1.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpsertResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
+  }
+
+  @Test
+  public void upsertInvalidLeaderboardName() {
+    final String leaderboardName = "";
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+    elements.put(1, 1.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpsertResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void upsertInvalidElements() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(UpsertResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  // fetch by rank
+
+  @Test
+  public void fetchByRankHappyPath() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+    elements.put(1, 1.0);
+    elements.put(2, 2.0);
+    elements.put(3, 3.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(UpsertResponse.Success.class);
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(3);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(1, 2, 3);
+            });
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.DESCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(3);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(3, 2, 1);
+            });
+
+    assertThat(leaderboard.fetchByRank(0, 2, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(2);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(1, 2);
+            });
+
+    assertThat(leaderboard.fetchByRank(1, 2, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(1);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(2);
+            });
+  }
+
+  @Test
+  public void fetchByRankInvalidCacheName() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(null, leaderboardName);
+
+    assertThat(leaderboard.fetchByRank(0, 1, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void fetchByRankNonExistentCache() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(randomString(), leaderboardName);
+
+    assertThat(leaderboard.fetchByRank(0, 1, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
+  }
+
+  @Test
+  public void fetchByRankInvalidLeaderboardName() {
+    final String leaderboardName = "";
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    assertThat(leaderboard.fetchByRank(0, 1, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void fetchByRankInvalidRankRange() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    assertThat(leaderboard.fetchByRank(-1, 0, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+
+    assertThat(leaderboard.fetchByRank(10, 1, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  // remove elements
+
+  @Test
+  public void removeElementsHappyPath() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    final Map<Integer, Double> elements = new HashMap<>();
+    elements.put(1, 1.0);
+    elements.put(2, 2.0);
+    elements.put(3, 3.0);
+
+    assertThat(leaderboard.upsert(elements))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(UpsertResponse.Success.class);
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(3);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(1, 2, 3);
+            });
+
+    assertThat(leaderboard.removeElements(Collections.singleton(1)))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(RemoveElementsResponse.Success.class);
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(2);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(2, 3);
+            });
+
+    assertThat(leaderboard.removeElements(Collections.singleton(99999)))
+        .succeedsWithin(FIVE_SECONDS)
+        .isInstanceOf(RemoveElementsResponse.Success.class);
+
+    assertThat(leaderboard.fetchByRank(0, 10, SortOrder.ASCENDING))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
+        .satisfies(
+            resp -> {
+              final List<LeaderboardElement> scoredElements = resp.elementsList();
+              assertThat(scoredElements).hasSize(2);
+              assertThat(scoredElements).map(LeaderboardElement::getId).containsExactly(2, 3);
+            });
+  }
+
+  @Test
+  public void removeElementsInvalidCacheName() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(null, leaderboardName);
+
+    final List<Integer> ids = new ArrayList<>();
+    ids.add(1);
+
+    assertThat(leaderboard.removeElements(ids))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(RemoveElementsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+
+  @Test
+  public void removeElementsNonExistentCache() {
+    final String leaderboardName = randomString("leaderboard");
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(randomString(), leaderboardName);
+
+    final List<Integer> ids = new ArrayList<>();
+    ids.add(1);
+
+    assertThat(leaderboard.removeElements(ids))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(RemoveElementsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(CacheNotFoundException.class));
+  }
+
+  @Test
+  public void removeElementsInvalidLeaderboardName() {
+    final String leaderboardName = "";
+    final ILeaderboard leaderboard = leaderboardClient.leaderboard(cacheName, leaderboardName);
+
+    final List<Integer> ids = new ArrayList<>();
+    ids.add(1);
+
+    assertThat(leaderboard.removeElements(ids))
+        .succeedsWithin(FIVE_SECONDS)
+        .asInstanceOf(InstanceOfAssertFactories.type(RemoveElementsResponse.Error.class))
+        .satisfies(error -> assertThat(error).hasCauseInstanceOf(InvalidArgumentException.class));
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/ILeaderboard.java
+++ b/momento-sdk/src/main/java/momento/sdk/ILeaderboard.java
@@ -1,0 +1,50 @@
+package momento.sdk;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.FetchResponse;
+import momento.sdk.responses.leaderboard.RemoveElementsResponse;
+import momento.sdk.responses.leaderboard.UpsertResponse;
+
+public interface ILeaderboard {
+
+  /**
+   * Updates elements in a leaderboard or inserts elements if they do not already exist. The
+   * leaderboard is also created if it does not already exist. Note: can upsert a maximum of 8192
+   * elements at a time.
+   *
+   * @param elements The ID->score pairs to add to the leaderboard.
+   * @return A future containing the result of the upsert operation: {@link UpsertResponse.Success}
+   *     or {@link UpsertResponse.Error}.
+   */
+  CompletableFuture<UpsertResponse> upsert(@Nonnull Map<Integer, Double> elements);
+
+  /**
+   * Fetch the elements in the given leaderboard by index (rank). Note: can fetch a maximum of 8192
+   * elements at a time and rank is 0-based (index begins at 0).
+   *
+   * @param startRank The rank of the first element to fetch. This rank is inclusive, i.e. the
+   *     element at this rank will be fetched. Ranks can be used to manually paginate through the
+   *     leaderboard in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc.).
+   * @param endRank The rank of the last element to fetch. This rank is exclusive, i.e. the element
+   *     at this rank will not be fetched. Ranks can be used to manually paginate through the
+   *     leaderboard in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc.).
+   * @param order The order to fetch the elements in.
+   * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
+   *     containing the elements, or {@link FetchResponse.Error}.
+   */
+  CompletableFuture<FetchResponse> fetchByRank(
+      int startRank, int endRank, @Nonnull SortOrder order);
+
+  /**
+   * Remove multiple elements from the given leaderboard Note: can remove a maximum of 8192 elements
+   * at a time.
+   *
+   * @param ids The IDs of the elements to remove from the leaderboard.
+   * @return A future containing the result of the remove operation: {@link
+   *     RemoveElementsResponse.Success} or {@link RemoveElementsResponse.Error}.
+   */
+  CompletableFuture<RemoveElementsResponse> removeElements(@Nonnull Iterable<Integer> ids);
+}

--- a/momento-sdk/src/main/java/momento/sdk/Leaderboard.java
+++ b/momento-sdk/src/main/java/momento/sdk/Leaderboard.java
@@ -1,0 +1,38 @@
+package momento.sdk;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.FetchResponse;
+import momento.sdk.responses.leaderboard.RemoveElementsResponse;
+import momento.sdk.responses.leaderboard.UpsertResponse;
+
+public class Leaderboard implements ILeaderboard {
+  private final String cacheName;
+  private final String leaderboardName;
+
+  private final LeaderboardDataClient leaderboardDataClient;
+
+  Leaderboard(LeaderboardDataClient dataClient, String cacheName, String leaderboardName) {
+    this.cacheName = cacheName;
+    this.leaderboardName = leaderboardName;
+    this.leaderboardDataClient = dataClient;
+  }
+
+  @Override
+  public CompletableFuture<UpsertResponse> upsert(@Nonnull Map<Integer, Double> elements) {
+    return leaderboardDataClient.upsert(cacheName, leaderboardName, elements);
+  }
+
+  @Override
+  public CompletableFuture<FetchResponse> fetchByRank(
+      int startRank, int endRank, @Nonnull SortOrder order) {
+    return leaderboardDataClient.fetchByRank(cacheName, leaderboardName, startRank, endRank, order);
+  }
+
+  @Override
+  public CompletableFuture<RemoveElementsResponse> removeElements(@Nonnull Iterable<Integer> ids) {
+    return leaderboardDataClient.removeElements(cacheName, leaderboardName, ids);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardClient.java
@@ -1,0 +1,44 @@
+package momento.sdk;
+
+import javax.annotation.Nonnull;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.LeaderboardConfiguration;
+
+public class LeaderboardClient implements AutoCloseable {
+
+  private final LeaderboardDataClient dataClient;
+
+  /**
+   * Constructs a LeaderboardClient.
+   *
+   * @param credentialProvider Provider for the credentials required to connect to Momento.
+   * @param configuration Configuration object containing all tunable client settings.
+   */
+  public LeaderboardClient(
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull LeaderboardConfiguration configuration) {
+    this.dataClient = new LeaderboardDataClient(credentialProvider, configuration);
+  }
+
+  /**
+   * Creates a LeaderboardClient builder.
+   *
+   * @param credentialProvider Provider for the credentials required to connect to Momento.
+   * @param configuration Configuration object containing all tunable client settings.
+   * @return The builder.
+   */
+  public static LeaderboardClientBuilder builder(
+      CredentialProvider credentialProvider, LeaderboardConfiguration configuration) {
+    return new LeaderboardClientBuilder(credentialProvider, configuration);
+  }
+
+  /** Creates a leaderboard instance with the given cache and leaderboard names. */
+  public ILeaderboard leaderboard(@Nonnull String cacheName, @Nonnull String leaderboardName) {
+    return new Leaderboard(this.dataClient, cacheName, leaderboardName);
+  }
+
+  @Override
+  public void close() {
+    this.dataClient.close();
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardClientBuilder.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardClientBuilder.java
@@ -1,0 +1,34 @@
+package momento.sdk;
+
+import javax.annotation.Nonnull;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.LeaderboardConfiguration;
+
+/** Builder for {@link LeaderboardClient} */
+public final class LeaderboardClientBuilder {
+
+  private final CredentialProvider credentialProvider;
+  private LeaderboardConfiguration configuration;
+
+  /**
+   * Creates a LeaderboardClient builder.
+   *
+   * @param credentialProvider Provider for the credentials required to connect to Momento.
+   * @param configuration Configuration object containing all tunable client settings.
+   */
+  LeaderboardClientBuilder(
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull LeaderboardConfiguration configuration) {
+    this.credentialProvider = credentialProvider;
+    this.configuration = configuration;
+  }
+
+  /**
+   * Builds a LeaderboardClient.
+   *
+   * @return the client.
+   */
+  public LeaderboardClient build() {
+    return new LeaderboardClient(credentialProvider, configuration);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
@@ -125,7 +125,7 @@ final class LeaderboardDataClient extends ScsClientBase {
         rsp -> {
           final List<LeaderboardElement> elements =
               rsp.getElementsList().stream()
-                  .map(e -> new LeaderboardElement(e.getId(), e.getScore()))
+                  .map(e -> new LeaderboardElement(e.getId(), e.getScore(), e.getRank()))
                   .collect(Collectors.toList());
           return new FetchResponse.Success(elements);
         };

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
@@ -1,0 +1,198 @@
+package momento.sdk;
+
+import static momento.sdk.ValidationUtils.checkCacheNameValid;
+import static momento.sdk.ValidationUtils.validateLeaderboardElements;
+import static momento.sdk.ValidationUtils.validateLeaderboardName;
+import static momento.sdk.ValidationUtils.validateRankRange;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import grpc.common._Empty;
+import grpc.leaderboard._Element;
+import grpc.leaderboard._GetByRankRequest;
+import grpc.leaderboard._GetByRankResponse;
+import grpc.leaderboard._Order;
+import grpc.leaderboard._RankRange;
+import grpc.leaderboard._RemoveElementsRequest;
+import grpc.leaderboard._UpsertElementsRequest;
+import io.grpc.Metadata;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.LeaderboardConfiguration;
+import momento.sdk.exceptions.CacheServiceExceptionMapper;
+import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.FetchResponse;
+import momento.sdk.responses.leaderboard.LeaderboardElement;
+import momento.sdk.responses.leaderboard.RemoveElementsResponse;
+import momento.sdk.responses.leaderboard.UpsertResponse;
+
+final class LeaderboardDataClient extends ScsClientBase {
+
+  private final LeaderboardGrpcStubsManager stubsManager;
+
+  LeaderboardDataClient(
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull LeaderboardConfiguration configuration) {
+    super(null);
+
+    this.stubsManager = new LeaderboardGrpcStubsManager(credentialProvider, configuration);
+  }
+
+  public CompletableFuture<UpsertResponse> upsert(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nonnull Map<Integer, Double> elements) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+      validateLeaderboardElements(elements);
+
+      return sendUpsert(cacheName, leaderboardName, elements);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new UpsertResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  public CompletableFuture<FetchResponse> fetchByRank(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      int startRank,
+      int endRank,
+      @Nonnull SortOrder order) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+      validateRankRange(startRank, endRank);
+
+      return sendFetchByRank(cacheName, leaderboardName, startRank, endRank, order);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new FetchResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  public CompletableFuture<RemoveElementsResponse> removeElements(
+      @Nonnull String cacheName, @Nonnull String leaderboardName, @Nonnull Iterable<Integer> ids) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+
+      return sendRemoveElements(cacheName, leaderboardName, ids);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new RemoveElementsResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  private CompletableFuture<UpsertResponse> sendUpsert(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nonnull Map<Integer, Double> elements) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_Empty>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .upsertElements(buildUpsertElementsRequest(cacheName, leaderboardName, elements));
+
+    final Function<_Empty, UpsertResponse> success = rsp -> new UpsertResponse.Success();
+
+    final Function<Throwable, UpsertResponse> failure =
+        e -> new UpsertResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
+  CompletableFuture<FetchResponse> sendFetchByRank(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      int startRank,
+      int endRank,
+      @Nonnull SortOrder order) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_GetByRankResponse>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .getByRank(
+                    buildGetByRankRequest(cacheName, leaderboardName, startRank, endRank, order));
+
+    final Function<_GetByRankResponse, FetchResponse> success =
+        rsp -> {
+          final List<LeaderboardElement> elements =
+              rsp.getElementsList().stream()
+                  .map(e -> new LeaderboardElement(e.getId(), e.getScore()))
+                  .collect(Collectors.toList());
+          return new FetchResponse.Success(elements);
+        };
+
+    final Function<Throwable, FetchResponse> failure =
+        e -> new FetchResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
+  private CompletableFuture<RemoveElementsResponse> sendRemoveElements(
+      @Nonnull String cacheName, @Nonnull String leaderboardName, @Nonnull Iterable<Integer> ids) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_Empty>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .removeElements(buildRemoveElementsRequest(cacheName, leaderboardName, ids));
+
+    final Function<_Empty, RemoveElementsResponse> success =
+        rsp -> new RemoveElementsResponse.Success();
+
+    final Function<Throwable, RemoveElementsResponse> failure =
+        e -> new RemoveElementsResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
+  private _UpsertElementsRequest buildUpsertElementsRequest(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nonnull Map<Integer, Double> elements) {
+    return _UpsertElementsRequest.newBuilder()
+        .setCacheName(cacheName)
+        .setLeaderboard(leaderboardName)
+        .addAllElements(
+            elements.entrySet().stream()
+                .map(e -> _Element.newBuilder().setId(e.getKey()).setScore(e.getValue()).build())
+                .collect(Collectors.toList()))
+        .build();
+  }
+
+  private _GetByRankRequest buildGetByRankRequest(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      int startRank,
+      int endRank,
+      @Nonnull SortOrder order) {
+    return _GetByRankRequest.newBuilder()
+        .setCacheName(cacheName)
+        .setLeaderboard(leaderboardName)
+        .setRankRange(
+            _RankRange.newBuilder().setStartInclusive(startRank).setEndExclusive(endRank).build())
+        .setOrder(order == SortOrder.ASCENDING ? _Order.ASCENDING : _Order.DESCENDING)
+        .build();
+  }
+
+  private _RemoveElementsRequest buildRemoveElementsRequest(
+      @Nonnull String cacheName, @Nonnull String leaderboardName, @Nonnull Iterable<Integer> ids) {
+    return _RemoveElementsRequest.newBuilder()
+        .setCacheName(cacheName)
+        .setLeaderboard(leaderboardName)
+        .addAllIds(ids)
+        .build();
+  }
+
+  @Override
+  public void doClose() {
+    stubsManager.close();
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardGrpcStubsManager.java
@@ -1,0 +1,84 @@
+package momento.sdk;
+
+import grpc.leaderboard.LeaderboardGrpc;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.LeaderboardConfiguration;
+import momento.sdk.internal.GrpcChannelOptions;
+
+/** Manager responsible for GRPC channels and stubs for leaderboards. */
+final class LeaderboardGrpcStubsManager implements AutoCloseable {
+
+  private final List<ManagedChannel> channels;
+  private final List<LeaderboardGrpc.LeaderboardFutureStub> futureStubs;
+  private final AtomicInteger nextStubIndex = new AtomicInteger(0);
+
+  private final int numGrpcChannels;
+  private final Duration deadline;
+
+  LeaderboardGrpcStubsManager(
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull LeaderboardConfiguration configuration) {
+    this.deadline = configuration.getTransportStrategy().getGrpcConfiguration().getDeadline();
+    this.numGrpcChannels =
+        configuration.getTransportStrategy().getGrpcConfiguration().getMinNumGrpcChannels();
+
+    this.channels =
+        IntStream.range(0, this.numGrpcChannels)
+            .mapToObj(i -> setupChannel(credentialProvider, configuration))
+            .collect(Collectors.toList());
+    this.futureStubs =
+        channels.stream().map(LeaderboardGrpc::newFutureStub).collect(Collectors.toList());
+  }
+
+  private static ManagedChannel setupChannel(
+      CredentialProvider credentialProvider, LeaderboardConfiguration configuration) {
+    final NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
+
+    // set additional channel options (message size, keepalive, auth, etc)
+    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
+        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder);
+
+    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    clientInterceptors.add(
+        new UserHeaderInterceptor(credentialProvider.getAuthToken(), "leaderboard"));
+    channelBuilder.intercept(clientInterceptors);
+
+    return channelBuilder.build();
+  }
+
+  /**
+   * Returns a stub with appropriate deadlines.
+   *
+   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
+   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
+   * before the deadline expires. Hence, the stub returned from here should never be cached and the
+   * safest behavior is for clients to request a new stub each time.
+   *
+   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
+   */
+  LeaderboardGrpc.LeaderboardFutureStub getStub() {
+    int nextStubIndex = this.nextStubIndex.getAndIncrement();
+    return futureStubs
+        .get(nextStubIndex % this.numGrpcChannels)
+        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void close() {
+    for (ManagedChannel channel : channels) {
+      channel.shutdown();
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
+++ b/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
@@ -1,6 +1,7 @@
 package momento.sdk;
 
 import java.time.Duration;
+import java.util.Map;
 import momento.sdk.auth.accessControl.ExpiresIn;
 import momento.sdk.exceptions.InvalidArgumentException;
 
@@ -35,6 +36,10 @@ public final class ValidationUtils {
       "Disposable token must expire within 1 hour";
   static final String DISPOSABLE_TOKEN_MUST_HAVE_AN_EXPIRY =
       "Disposable tokens must have an expiry";
+  static final String LEADERBOARD_NAME_IS_REQUIRED = "Non-empty leaderboard name is required.";
+  static final String LEADERBOARD_ELEMENTS_NON_EMPTY = "Leaderboard elements cannot be empty.";
+  static final String RANK_RANGE_INVALID =
+      "Ranks must not be negative and endRank (exclusive) must be larger than startRank (inclusive).";
 
   ValidationUtils() {}
 
@@ -168,6 +173,24 @@ public final class ValidationUtils {
       throw new InvalidArgumentException(DISPOSABLE_TOKEN_EXPIRY_EXCEEDS_ONE_HOUR);
     } else if (expiresIn.getSeconds() <= 0) {
       throw new InvalidArgumentException(DISPOSABLE_TOKEN_EXPIRY_MUST_BE_POSITIVE);
+    }
+  }
+
+  static void validateLeaderboardName(String leaderboardName) {
+    if (leaderboardName == null || leaderboardName.isEmpty()) {
+      throw new InvalidArgumentException(LEADERBOARD_NAME_IS_REQUIRED);
+    }
+  }
+
+  static void validateLeaderboardElements(Map<Integer, Double> elements) {
+    if (elements == null || elements.isEmpty()) {
+      throw new InvalidArgumentException(LEADERBOARD_ELEMENTS_NON_EMPTY);
+    }
+  }
+
+  static void validateRankRange(int startRank, int endRank) {
+    if (startRank < 0 || endRank < 0 || endRank <= startRank) {
+      throw new InvalidArgumentException(RANK_RANGE_INVALID);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/LeaderboardConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/LeaderboardConfiguration.java
@@ -1,0 +1,38 @@
+package momento.sdk.config;
+
+import momento.sdk.config.transport.leaderboard.LeaderboardTransportStrategy;
+
+/** The contract for SDK configurables. A configuration must have a transport strategy. */
+public class LeaderboardConfiguration {
+
+  private final LeaderboardTransportStrategy transportStrategy;
+
+  /**
+   * Creates a new configuration object.
+   *
+   * @param transportStrategy Responsible for configuring network tunables.
+   */
+  public LeaderboardConfiguration(LeaderboardTransportStrategy transportStrategy) {
+    this.transportStrategy = transportStrategy;
+  }
+
+  /**
+   * Configuration for network tunables.
+   *
+   * @return The transport strategy
+   */
+  public LeaderboardTransportStrategy getTransportStrategy() {
+    return transportStrategy;
+  }
+
+  /**
+   * Copy constructor that modifies the transport strategy.
+   *
+   * @param transportStrategy the new transport strategy
+   * @return a new Configuration with the updated transport strategy
+   */
+  public LeaderboardConfiguration withTransportStrategy(
+      final LeaderboardTransportStrategy transportStrategy) {
+    return new LeaderboardConfiguration(transportStrategy);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/LeaderboardConfigurations.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/LeaderboardConfigurations.java
@@ -1,0 +1,91 @@
+package momento.sdk.config;
+
+import java.time.Duration;
+import momento.sdk.config.transport.leaderboard.LeaderboardGrpcConfiguration;
+import momento.sdk.config.transport.leaderboard.LeaderboardTransportStrategy;
+import momento.sdk.config.transport.leaderboard.StaticLeaderboardTransportStrategy;
+
+/** Prebuilt {@link LeaderboardConfiguration}s for different environments. */
+public class LeaderboardConfigurations {
+  /**
+   * Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts,
+   * retries, and relaxed latency and throughput targets.
+   */
+  public static class Laptop extends LeaderboardConfiguration {
+
+    private Laptop(LeaderboardTransportStrategy transportStrategy) {
+      super(transportStrategy);
+    }
+
+    /**
+     * Provides the latest recommended configuration for a dev environment.
+     *
+     * <p>This configuration may change in future releases to take advantage of improvements we
+     * identify for default configurations.
+     *
+     * @return the latest Laptop configuration
+     */
+    public static LeaderboardConfiguration latest() {
+      final LeaderboardTransportStrategy transportStrategy =
+          new StaticLeaderboardTransportStrategy(
+              new LeaderboardGrpcConfiguration(Duration.ofMillis(15000)));
+      return new Laptop(transportStrategy);
+    }
+  }
+
+  /**
+   * Provides defaults suitable for an environment where your client is running in the same region
+   * as the Momento service. It has more aggressive timeouts and retry behavior than the Laptop
+   * config.
+   */
+  public static class InRegion extends LeaderboardConfiguration {
+
+    private InRegion(LeaderboardTransportStrategy transportStrategy) {
+      super(transportStrategy);
+    }
+
+    /**
+     * Provides the latest recommended configuration for an in-region environment.
+     *
+     * <p>This configuration may change in future releases to take advantage of improvements we
+     * identify for default configurations.
+     *
+     * @return the latest in-region configuration
+     */
+    public static LeaderboardConfiguration latest() {
+      final LeaderboardTransportStrategy transportStrategy =
+          new StaticLeaderboardTransportStrategy(
+              new LeaderboardGrpcConfiguration(Duration.ofMillis(1100)));
+      return new InRegion(transportStrategy);
+    }
+  }
+
+  public static class Lambda extends LeaderboardConfiguration {
+    private Lambda(LeaderboardTransportStrategy transportStrategy) {
+      super(transportStrategy);
+    }
+
+    /**
+     * Provides the latest recommended configuration for a Lambda environment.
+     *
+     * <p>This configuration may change in future releases to take advantage of improvements we
+     * identify for default configurations.
+     *
+     * <p>NOTE: keep-alives are very important for long-lived server environments where there may be
+     * periods of time when the connection is idle. However, they are very problematic for lambda
+     * environments where the lambda runtime is continuously frozen and unfrozen, because the lambda
+     * may be frozen before the "ACK" is received from the server. This can cause the keep-alive to
+     * timeout even though the connection is completely healthy. Therefore, keep-alives should be
+     * disabled in lambda and similar environments.
+     *
+     * @return the latest Lambda configuration
+     */
+    public static LeaderboardConfiguration latest() {
+      final LeaderboardGrpcConfiguration grpcConfig =
+          new LeaderboardGrpcConfiguration(Duration.ofMillis(1100)).withKeepAliveDisabled();
+      final LeaderboardTransportStrategy transportStrategy =
+          new StaticLeaderboardTransportStrategy(grpcConfig);
+      return new Lambda(transportStrategy);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardGrpcConfiguration.java
@@ -1,0 +1,244 @@
+package momento.sdk.config.transport.leaderboard;
+
+import static momento.sdk.ValidationUtils.ensureRequestDeadlineValid;
+
+import java.time.Duration;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import momento.sdk.config.transport.IGrpcConfiguration;
+import momento.sdk.internal.GrpcChannelOptions;
+
+/** Abstracts away the gRPC configuration tunables. */
+public class LeaderboardGrpcConfiguration implements IGrpcConfiguration {
+
+  private final @Nonnull Duration deadline;
+  private final int minNumGrpcChannels;
+  private final @Nullable Integer maxMessageSize;
+  private final @Nullable Boolean keepAliveWithoutCalls;
+  private final @Nullable Duration keepAliveTimeout;
+  private final @Nullable Duration keepAliveTime;
+
+  /**
+   * Constructs a LeaderboardGrpcConfiguration.
+   *
+   * @param deadline The maximum duration of a gRPC call.
+   */
+  public LeaderboardGrpcConfiguration(@Nonnull Duration deadline) {
+    this(
+        deadline,
+        1,
+        GrpcChannelOptions.DEFAULT_MAX_MESSAGE_SIZE,
+        GrpcChannelOptions.DEFAULT_KEEPALIVE_WITHOUT_STREAM,
+        GrpcChannelOptions.DEFAULT_KEEPALIVE_TIMEOUT,
+        GrpcChannelOptions.DEFAULT_KEEPALIVE_TIME);
+  }
+
+  /**
+   * Constructs a LeaderboardGrpcConfiguration.
+   *
+   * @param deadline The maximum duration of a gRPC call.
+   * @param minNumGrpcChannels The minimum number of gRPC channels to keep open at any given time.
+   * @param maxMessageSize The maximum size of a message (in bytes) that can be received by the
+   *     client.
+   * @param keepAliveWithoutCalls Whether to send keepalive pings without any active calls.
+   * @param keepAliveTimeout The time to wait for a keepalive ping response before considering the
+   *     connection dead.
+   * @param keepAliveTime The time to wait between keepalive pings.
+   */
+  public LeaderboardGrpcConfiguration(
+      @Nonnull Duration deadline,
+      int minNumGrpcChannels,
+      @Nullable Integer maxMessageSize,
+      @Nullable Boolean keepAliveWithoutCalls,
+      @Nullable Duration keepAliveTimeout,
+      @Nullable Duration keepAliveTime) {
+    ensureRequestDeadlineValid(deadline);
+    this.deadline = deadline;
+    this.minNumGrpcChannels = minNumGrpcChannels;
+    this.maxMessageSize = maxMessageSize;
+    this.keepAliveWithoutCalls = keepAliveWithoutCalls;
+    this.keepAliveTimeout = keepAliveTimeout;
+    this.keepAliveTime = keepAliveTime;
+  }
+
+  /**
+   * How long the client will wait for an RPC to complete before it is terminated with {@link
+   * io.grpc.Status.Code#DEADLINE_EXCEEDED}.
+   *
+   * @return the deadline
+   */
+  public Duration getDeadline() {
+    return deadline;
+  }
+
+  /**
+   * Copy constructor that updates the deadline.
+   *
+   * @param deadline The new deadline.
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withDeadline(Duration deadline) {
+    return new LeaderboardGrpcConfiguration(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize,
+        keepAliveWithoutCalls,
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  /**
+   * The minimum number of gRPC channels to keep open at any given time.
+   *
+   * @return the minimum number of gRPC channels.
+   */
+  public int getMinNumGrpcChannels() {
+    return minNumGrpcChannels;
+  }
+
+  /**
+   * Copy constructor that updates the minimum number of gRPC channels.
+   *
+   * @param minNumGrpcChannels The new minimum number of gRPC channels.
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withMinNumGrpcChannels(int minNumGrpcChannels) {
+    return new LeaderboardGrpcConfiguration(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize,
+        keepAliveWithoutCalls,
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  @Override
+  public Optional<Integer> getMaxReceivedMessageSize() {
+    return Optional.ofNullable(maxMessageSize);
+  }
+
+  /**
+   * Copy constructor that updates the maximum message size.
+   *
+   * @param maxMessageSize The new maximum message size.
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withMaxMessageSize(int maxMessageSize) {
+    return new LeaderboardGrpcConfiguration(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize,
+        keepAliveWithoutCalls,
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  @Override
+  public Optional<Boolean> getKeepAliveWithoutCalls() {
+    return Optional.ofNullable(keepAliveWithoutCalls);
+  }
+
+  /**
+   * Copy constructor that updates whether keepalive will be performed when there are no outstanding
+   * requests on a connection.
+   *
+   * <p>NOTE: keep-alives are very important for long-lived server environments where there may be
+   * periods of time when the connection is idle. However, they are very problematic for lambda
+   * environments where the lambda runtime is continuously frozen and unfrozen, because the lambda
+   * may be frozen before the "ACK" is received from the server. This can cause the keep-alive to
+   * timeout even though the connection is completely healthy. Therefore, keep-alives should be
+   * disabled in lambda and similar environments.
+   *
+   * @param keepAliveWithoutCalls The boolean indicating whether to send keepalive pings without any
+   *     active calls.
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withKeepAliveWithoutCalls(boolean keepAliveWithoutCalls) {
+    return new LeaderboardGrpcConfiguration(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize,
+        keepAliveWithoutCalls,
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  @Override
+  public Optional<Duration> getKeepAliveTimeout() {
+    return Optional.ofNullable(keepAliveTimeout);
+  }
+
+  /**
+   * Copy constructor that updates the time to wait for a keepalive ping response before considering
+   * the connection dead.
+   *
+   * <p>NOTE: keep-alives are very important for long-lived server environments where there may be
+   * periods of time when the connection is idle. However, they are very problematic for lambda
+   * environments where the lambda runtime is continuously frozen and unfrozen, because the lambda
+   * may be frozen before the "ACK" is received from the server. This can cause the keep-alive to
+   * timeout even though the connection is completely healthy. Therefore, keep-alives should be
+   * disabled in lambda and similar environments.
+   *
+   * @param keepAliveTimeout The new time to wait for a keepalive ping response.
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withKeepAliveTimeout(Duration keepAliveTimeout) {
+    return new LeaderboardGrpcConfiguration(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize,
+        keepAliveWithoutCalls,
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  /**
+   * The time to wait between keepalive pings.
+   *
+   * @return the time to wait between keepalive pings.
+   */
+  public Optional<Duration> getKeepAliveTime() {
+    return Optional.ofNullable(keepAliveTime);
+  }
+
+  /**
+   * Copy constructor that updates the time to wait between keepalive pings.
+   *
+   * <p>NOTE: keep-alives are very important for long-lived server environments where there may be
+   * periods of time when the connection is idle. However, they are very problematic for lambda
+   * environments where the lambda runtime is continuously frozen and unfrozen, because the lambda
+   * may be frozen before the "ACK" is received from the server. This can cause the keep-alive to
+   * timeout even though the connection is completely healthy. Therefore, keep-alives should be
+   * disabled in lambda and similar environments.
+   *
+   * @param keepAliveTime The new time to wait between keepalive pings.
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withKeepAliveTime(Duration keepAliveTime) {
+    return new LeaderboardGrpcConfiguration(
+        deadline,
+        minNumGrpcChannels,
+        maxMessageSize,
+        keepAliveWithoutCalls,
+        keepAliveTimeout,
+        keepAliveTime);
+  }
+
+  /**
+   * Copy constructor that disables all client-side keepalive settings.
+   *
+   * <p>NOTE: keep-alives are very important for long-lived server environments where there may be
+   * periods of time when the connection is idle. However, they are very problematic for lambda
+   * environments where the lambda runtime is continuously frozen and unfrozen, because the lambda
+   * may be frozen before the "ACK" is received from the server. This can cause the keep-alive to
+   * timeout even though the connection is completely healthy. Therefore, keep-alives should be
+   * disabled in lambda and similar environments.
+   *
+   * @return The updated LeaderboardGrpcConfiguration.
+   */
+  public LeaderboardGrpcConfiguration withKeepAliveDisabled() {
+    return new LeaderboardGrpcConfiguration(
+        deadline, minNumGrpcChannels, maxMessageSize, null, null, null);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardTransportStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardTransportStrategy.java
@@ -1,0 +1,20 @@
+package momento.sdk.config.transport.leaderboard;
+
+/** Configuration for network tunables. */
+public interface LeaderboardTransportStrategy {
+  /**
+   * Configures the low-level gRPC settings for the client's communication with the Momento server.
+   *
+   * @return the gRPC configuration.
+   */
+  LeaderboardGrpcConfiguration getGrpcConfiguration();
+
+  /**
+   * Copy constructor that modifies the gRPC configuration.
+   *
+   * @param grpcConfiguration low-level gRPC settings.
+   * @return The modified StorageTransportStrategy.
+   */
+  LeaderboardTransportStrategy withGrpcConfiguration(
+      LeaderboardGrpcConfiguration grpcConfiguration);
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/StaticLeaderboardTransportStrategy.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/StaticLeaderboardTransportStrategy.java
@@ -1,0 +1,30 @@
+package momento.sdk.config.transport.leaderboard;
+
+/**
+ * The simplest way to configure gRPC for the Momento leaderboard client. Specifies static values
+ * the transport options.
+ */
+public class StaticLeaderboardTransportStrategy implements LeaderboardTransportStrategy {
+
+  private final LeaderboardGrpcConfiguration grpcConfiguration;
+
+  /**
+   * Constructs a StaticStorageTransportStrategy.
+   *
+   * @param grpcConfiguration gRPC tunables.
+   */
+  public StaticLeaderboardTransportStrategy(LeaderboardGrpcConfiguration grpcConfiguration) {
+    this.grpcConfiguration = grpcConfiguration;
+  }
+
+  @Override
+  public LeaderboardGrpcConfiguration getGrpcConfiguration() {
+    return grpcConfiguration;
+  }
+
+  @Override
+  public LeaderboardTransportStrategy withGrpcConfiguration(
+      LeaderboardGrpcConfiguration grpcConfiguration) {
+    return new StaticLeaderboardTransportStrategy(grpcConfiguration);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/FetchResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/FetchResponse.java
@@ -1,0 +1,74 @@
+package momento.sdk.responses.leaderboard;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.responses.SortOrder;
+
+/** Response for a leaderboard fetch operation */
+public interface FetchResponse {
+
+  /** A successful leaderboard fetch operation. */
+  class Success implements FetchResponse {
+    private final List<LeaderboardElement> elements;
+
+    /**
+     * Constructs a leaderboard fetch success with a list of elements.
+     *
+     * @param elements the retrieved elements.
+     */
+    public Success(List<LeaderboardElement> elements) {
+      this.elements = elements;
+    }
+
+    /**
+     * Returns a list of the retrieved IDs and their scores. The set is ordered by the {@link
+     * SortOrder} used in the fetch method call or ascending if no order was specified.
+     *
+     * @return An ordered list of IDs and their scores
+     */
+    public List<LeaderboardElement> elementsList() {
+      return elements;
+    }
+
+    /**
+     * Returns a list of the retrieved IDs and their scores. The set is ordered by the {@link
+     * SortOrder} used in the fetch method call or ascending if no order was specified.
+     *
+     * @return An ordered list of IDs and their scores
+     */
+    public List<LeaderboardElement> values() {
+      return elements;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Truncates the list of elements to bound the size of the string.
+     */
+    @Override
+    public String toString() {
+      return elements.stream()
+          .limit(5)
+          .map(e -> "ID: " + e.getId() + " score: " + e.getScore())
+          .collect(Collectors.joining(", ", "", "..."));
+    }
+  }
+
+  /**
+   * A failed leaderboard fetch operation. The response itself is an exception, so it can be
+   * directly thrown, or the cause of the error can be retrieved with {@link #getCause()}. The
+   * message is a copy of the message of the cause.
+   */
+  class Error extends SdkException implements FetchResponse {
+
+    /**
+     * Constructs a leaderboard fetch error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/LeaderboardElement.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/LeaderboardElement.java
@@ -3,12 +3,13 @@ package momento.sdk.responses.leaderboard;
 import javax.annotation.Nonnull;
 
 /**
- * A pairing of an integer ID to a score. LeaderboardElements have equality based on their ID and
- * ordering based on their score.
+ * A leaderboard element consisting of an element ID, a score and a rank. LeaderboardElements have
+ * equality based on their ID and ordering based on their score.
  */
 public class LeaderboardElement implements Comparable<LeaderboardElement> {
   private final int id;
   private final double score;
+  private final int rank;
 
   /**
    * Constructs a LeaderboardElement with an ID and a score.
@@ -16,13 +17,14 @@ public class LeaderboardElement implements Comparable<LeaderboardElement> {
    * @param id The element's ID.
    * @param score The element's score.
    */
-  public LeaderboardElement(int id, double score) {
+  public LeaderboardElement(int id, double score, int rank) {
     this.id = id;
     this.score = score;
+    this.rank = rank;
   }
 
   /**
-   * Gets the ID.
+   * Gets the ID of the element.
    *
    * @return the ID
    */
@@ -31,12 +33,21 @@ public class LeaderboardElement implements Comparable<LeaderboardElement> {
   }
 
   /**
-   * Gets the score.
+   * Gets the score of the element.
    *
    * @return the score
    */
   public double getScore() {
     return score;
+  }
+
+  /**
+   * Gets the rank of the element.
+   *
+   * @return the rank
+   */
+  public int getRank() {
+    return rank;
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/LeaderboardElement.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/LeaderboardElement.java
@@ -1,0 +1,66 @@
+package momento.sdk.responses.leaderboard;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A pairing of an integer ID to a score. LeaderboardElements have equality based on their ID and
+ * ordering based on their score.
+ */
+public class LeaderboardElement implements Comparable<LeaderboardElement> {
+  private final int id;
+  private final double score;
+
+  /**
+   * Constructs a LeaderboardElement with an ID and a score.
+   *
+   * @param id The element's ID.
+   * @param score The element's score.
+   */
+  public LeaderboardElement(int id, double score) {
+    this.id = id;
+    this.score = score;
+  }
+
+  /**
+   * Gets the ID.
+   *
+   * @return the ID
+   */
+  public int getId() {
+    return id;
+  }
+
+  /**
+   * Gets the score.
+   *
+   * @return the score
+   */
+  public double getScore() {
+    return score;
+  }
+
+  @Override
+  public int compareTo(@Nonnull LeaderboardElement that) {
+    if (this == that) {
+      return 0;
+    }
+    return Double.compare(this.score, that.score);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LeaderboardElement that = (LeaderboardElement) o;
+    return this.id == that.id;
+  }
+
+  @Override
+  public int hashCode() {
+    return id;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/RemoveElementsResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/RemoveElementsResponse.java
@@ -1,0 +1,38 @@
+package momento.sdk.responses.leaderboard;
+
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/** Response for a leaderboard remove elements operation */
+public interface RemoveElementsResponse {
+
+  /** A successful remove elements operation. */
+  class Success implements RemoveElementsResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("RemoveElementsResponse.Success");
+    }
+  }
+
+  /**
+   * A failed remove operation. The response itself is an exception, so it can be directly thrown,
+   * or the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of
+   * the message of the cause.
+   */
+  class Error extends SdkException implements RemoveElementsResponse {
+
+    /**
+     * Constructs a leaderboard remove elements error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return buildToString("RemoveElementsResponse.Error");
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/UpsertResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/UpsertResponse.java
@@ -1,0 +1,38 @@
+package momento.sdk.responses.leaderboard;
+
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/** Response for a leaderboard upsert operation */
+public interface UpsertResponse {
+
+  /** A successful upsert operation. */
+  class Success implements UpsertResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("UpsertResponse.Success");
+    }
+  }
+
+  /**
+   * A failed upsert operation. The response itself is an exception, so it can be directly thrown,
+   * or the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of
+   * the message of the cause.
+   */
+  class Error extends SdkException implements UpsertResponse {
+
+    /**
+     * Constructs a leaderboard upsert error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return buildToString("UpsertResponse.Error");
+    }
+  }
+}


### PR DESCRIPTION
Add a new client for interacting with Momento leaderboards and the configuration objects required for creating one.

Add the leaderboard upsert, fetch by rank, and remove elements methods.