### PR TITLE
feat: add the remaining leaderboard APIs

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/leaderboard/LeaderboardClientTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/leaderboard/LeaderboardClientTest.java
@@ -144,7 +144,7 @@ public class LeaderboardClientTest extends BaseLeaderboardTestClass {
         .isInstanceOf(UpsertResponse.Success.class);
 
     // ascending
-    assertThat(leaderboard.fetchByScore(null, null, SortOrder.ASCENDING))
+    assertThat(leaderboard.fetchByScore())
         .succeedsWithin(FIVE_SECONDS)
         .asInstanceOf(InstanceOfAssertFactories.type(FetchResponse.Success.class))
         .satisfies(

--- a/momento-sdk/src/main/java/momento/sdk/ILeaderboard.java
+++ b/momento-sdk/src/main/java/momento/sdk/ILeaderboard.java
@@ -3,8 +3,11 @@ package momento.sdk;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.DeleteResponse;
 import momento.sdk.responses.leaderboard.FetchResponse;
+import momento.sdk.responses.leaderboard.LengthResponse;
 import momento.sdk.responses.leaderboard.RemoveElementsResponse;
 import momento.sdk.responses.leaderboard.UpsertResponse;
 
@@ -22,7 +25,46 @@ public interface ILeaderboard {
   CompletableFuture<UpsertResponse> upsert(@Nonnull Map<Integer, Double> elements);
 
   /**
-   * Fetch the elements in the given leaderboard by index (rank). Note: can fetch a maximum of 8192
+   * Fetch the elements of the leaderboard by score. Note: can fetch a maximum of 8192 elements at a
+   * time.
+   *
+   * @param minScore The minimum score (inclusive) of the elements to fetch. Defaults to negative
+   *     infinity.
+   * @param maxScore The maximum score (exclusive) of the elements to fetch. Defaults to positive
+   *     infinity.
+   * @param order The order to fetch the elements in. Defaults to {@link SortOrder#ASCENDING}.
+   * @param offset The number of elements to skip before returning the first element. Defaults to 0.
+   *     Note: this is not the score of the first element to return, but the number of elements of
+   *     the result set to skip before returning the first element.
+   * @param count The maximum number of elements to return. Defaults to 8192, which is the maximum
+   *     that can be fetched at a time.
+   * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
+   *     containing the elements, or {@link FetchResponse.Error}.
+   */
+  CompletableFuture<FetchResponse> fetchByScore(
+      @Nullable Double minScore,
+      @Nullable Double maxScore,
+      @Nullable SortOrder order,
+      @Nullable Integer offset,
+      @Nullable Integer count);
+
+  /**
+   * Fetch the elements of the leaderboard by score. Note: can fetch a maximum of 8192 elements at a
+   * time.
+   *
+   * @param minScore The minimum score (inclusive) of the elements to fetch. Defaults to negative
+   *     infinity.
+   * @param maxScore The maximum score (exclusive) of the elements to fetch. Defaults to positive
+   *     infinity.
+   * @param order The order to fetch the elements in. Defaults to {@link SortOrder#ASCENDING}.
+   * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
+   *     containing the elements, or {@link FetchResponse.Error}.
+   */
+  CompletableFuture<FetchResponse> fetchByScore(
+      @Nullable Double minScore, @Nullable Double maxScore, @Nullable SortOrder order);
+
+  /**
+   * Fetch the elements of the leaderboard by index (rank). Note: can fetch a maximum of 8192
    * elements at a time and rank is 0-based (index begins at 0).
    *
    * @param startRank The rank of the first element to fetch. This rank is inclusive, i.e. the
@@ -31,20 +73,48 @@ public interface ILeaderboard {
    * @param endRank The rank of the last element to fetch. This rank is exclusive, i.e. the element
    *     at this rank will not be fetched. Ranks can be used to manually paginate through the
    *     leaderboard in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc.).
-   * @param order The order to fetch the elements in.
+   * @param order The order to fetch the elements in. Defaults to {@link SortOrder#ASCENDING}.
    * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
    *     containing the elements, or {@link FetchResponse.Error}.
    */
   CompletableFuture<FetchResponse> fetchByRank(
-      int startRank, int endRank, @Nonnull SortOrder order);
+      int startRank, int endRank, @Nullable SortOrder order);
 
   /**
-   * Remove multiple elements from the given leaderboard Note: can remove a maximum of 8192 elements
-   * at a time.
+   * Looks up the rank of the given elements in the leaderboard. The returned elements will be
+   * sorted numerically by their IDs. Note: rank is 0-based (index begins at 0).
+   *
+   * @param ids The IDs of the elements to fetch from the leaderboard.
+   * @param order The order to fetch the elements in. Defaults to {@link SortOrder#ASCENDING}.
+   * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
+   *     containing the elements, or {@link FetchResponse.Error}.
+   */
+  CompletableFuture<FetchResponse> getRank(
+      @Nonnull Iterable<Integer> ids, @Nullable SortOrder order);
+
+  /**
+   * Fetches the length (number of items) of the leaderboard.
+   *
+   * @return A future containing the result of the length operation: {@link LengthResponse.Success}
+   *     containing the length of the leaderboard, or {@link LengthResponse.Error}.
+   */
+  CompletableFuture<LengthResponse> length();
+
+  /**
+   * Remove multiple elements from the leaderboard. Note: can remove a maximum of 8192 elements at a
+   * time.
    *
    * @param ids The IDs of the elements to remove from the leaderboard.
    * @return A future containing the result of the remove operation: {@link
    *     RemoveElementsResponse.Success} or {@link RemoveElementsResponse.Error}.
    */
   CompletableFuture<RemoveElementsResponse> removeElements(@Nonnull Iterable<Integer> ids);
+
+  /**
+   * Deletes all elements in the leaderboard.
+   *
+   * @return A future containing the result of the delete operation: {@link DeleteResponse.Success},
+   *     or {@link DeleteResponse.Error}.
+   */
+  CompletableFuture<DeleteResponse> delete();
 }

--- a/momento-sdk/src/main/java/momento/sdk/ILeaderboard.java
+++ b/momento-sdk/src/main/java/momento/sdk/ILeaderboard.java
@@ -14,7 +14,7 @@ import momento.sdk.responses.leaderboard.UpsertResponse;
 public interface ILeaderboard {
 
   /**
-   * Updates elements in a leaderboard or inserts elements if they do not already exist. The
+   * Update elements in a leaderboard or insert elements if they do not already exist. The
    * leaderboard is also created if it does not already exist. Note: can upsert a maximum of 8192
    * elements at a time.
    *
@@ -64,6 +64,14 @@ public interface ILeaderboard {
       @Nullable Double minScore, @Nullable Double maxScore, @Nullable SortOrder order);
 
   /**
+   * Fetch the first 8192 elements of the leaderboard, sorted by score ascending.
+   *
+   * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
+   *     containing the elements, or {@link FetchResponse.Error}.
+   */
+  CompletableFuture<FetchResponse> fetchByScore();
+
+  /**
    * Fetch the elements of the leaderboard by index (rank). Note: can fetch a maximum of 8192
    * elements at a time and rank is 0-based (index begins at 0).
    *
@@ -81,11 +89,12 @@ public interface ILeaderboard {
       int startRank, int endRank, @Nullable SortOrder order);
 
   /**
-   * Looks up the rank of the given elements in the leaderboard. The returned elements will be
-   * sorted numerically by their IDs. Note: rank is 0-based (index begins at 0).
+   * Look up the rank of the given elements in the leaderboard. The returned elements will be sorted
+   * numerically by their IDs. Note: rank is 0-based (index begins at 0).
    *
    * @param ids The IDs of the elements to fetch from the leaderboard.
-   * @param order The order to fetch the elements in. Defaults to {@link SortOrder#ASCENDING}.
+   * @param order The rank order to fetch the elements in, based on their scores. Defaults to {@link
+   *     SortOrder#ASCENDING}.
    * @return A future containing the result of the fetch operation: {@link FetchResponse.Success}
    *     containing the elements, or {@link FetchResponse.Error}.
    */
@@ -93,7 +102,7 @@ public interface ILeaderboard {
       @Nonnull Iterable<Integer> ids, @Nullable SortOrder order);
 
   /**
-   * Fetches the length (number of items) of the leaderboard.
+   * Fetch the length (number of items) of the leaderboard.
    *
    * @return A future containing the result of the length operation: {@link LengthResponse.Success}
    *     containing the length of the leaderboard, or {@link LengthResponse.Error}.
@@ -111,7 +120,7 @@ public interface ILeaderboard {
   CompletableFuture<RemoveElementsResponse> removeElements(@Nonnull Iterable<Integer> ids);
 
   /**
-   * Deletes all elements in the leaderboard.
+   * Delete all elements in the leaderboard.
    *
    * @return A future containing the result of the delete operation: {@link DeleteResponse.Success},
    *     or {@link DeleteResponse.Error}.

--- a/momento-sdk/src/main/java/momento/sdk/Leaderboard.java
+++ b/momento-sdk/src/main/java/momento/sdk/Leaderboard.java
@@ -3,8 +3,11 @@ package momento.sdk;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.DeleteResponse;
 import momento.sdk.responses.leaderboard.FetchResponse;
+import momento.sdk.responses.leaderboard.LengthResponse;
 import momento.sdk.responses.leaderboard.RemoveElementsResponse;
 import momento.sdk.responses.leaderboard.UpsertResponse;
 
@@ -26,13 +29,47 @@ public class Leaderboard implements ILeaderboard {
   }
 
   @Override
+  public CompletableFuture<FetchResponse> fetchByScore(
+      @Nullable Double minScore,
+      @Nullable Double maxScore,
+      @Nullable SortOrder order,
+      @Nullable Integer offset,
+      @Nullable Integer count) {
+    return leaderboardDataClient.fetchByScore(
+        cacheName, leaderboardName, minScore, maxScore, order, offset, count);
+  }
+
+  @Override
+  public CompletableFuture<FetchResponse> fetchByScore(
+      @Nullable Double minScore, @Nullable Double maxScore, @Nullable SortOrder order) {
+    return leaderboardDataClient.fetchByScore(
+        cacheName, leaderboardName, minScore, maxScore, order, null, null);
+  }
+
+  @Override
   public CompletableFuture<FetchResponse> fetchByRank(
-      int startRank, int endRank, @Nonnull SortOrder order) {
+      int startRank, int endRank, @Nullable SortOrder order) {
     return leaderboardDataClient.fetchByRank(cacheName, leaderboardName, startRank, endRank, order);
+  }
+
+  @Override
+  public CompletableFuture<FetchResponse> getRank(
+      @Nonnull Iterable<Integer> ids, @Nullable SortOrder order) {
+    return leaderboardDataClient.getRank(cacheName, leaderboardName, ids, order);
+  }
+
+  @Override
+  public CompletableFuture<LengthResponse> length() {
+    return leaderboardDataClient.length(cacheName, leaderboardName);
   }
 
   @Override
   public CompletableFuture<RemoveElementsResponse> removeElements(@Nonnull Iterable<Integer> ids) {
     return leaderboardDataClient.removeElements(cacheName, leaderboardName, ids);
+  }
+
+  @Override
+  public CompletableFuture<DeleteResponse> delete() {
+    return leaderboardDataClient.delete(cacheName, leaderboardName);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/Leaderboard.java
+++ b/momento-sdk/src/main/java/momento/sdk/Leaderboard.java
@@ -47,6 +47,12 @@ public class Leaderboard implements ILeaderboard {
   }
 
   @Override
+  public CompletableFuture<FetchResponse> fetchByScore() {
+    return leaderboardDataClient.fetchByScore(
+        cacheName, leaderboardName, null, null, null, null, null);
+  }
+
+  @Override
   public CompletableFuture<FetchResponse> fetchByRank(
       int startRank, int endRank, @Nullable SortOrder order) {
     return leaderboardDataClient.fetchByRank(cacheName, leaderboardName, startRank, endRank, order);

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
@@ -1,18 +1,31 @@
 package momento.sdk;
 
 import static momento.sdk.ValidationUtils.checkCacheNameValid;
+import static momento.sdk.ValidationUtils.checkScoreRangeValid;
+import static momento.sdk.ValidationUtils.validateCount;
 import static momento.sdk.ValidationUtils.validateLeaderboardElements;
 import static momento.sdk.ValidationUtils.validateLeaderboardName;
+import static momento.sdk.ValidationUtils.validateNotNull;
+import static momento.sdk.ValidationUtils.validateOffset;
 import static momento.sdk.ValidationUtils.validateRankRange;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import grpc.common._Empty;
+import grpc.leaderboard._DeleteLeaderboardRequest;
 import grpc.leaderboard._Element;
 import grpc.leaderboard._GetByRankRequest;
 import grpc.leaderboard._GetByRankResponse;
+import grpc.leaderboard._GetByScoreRequest;
+import grpc.leaderboard._GetByScoreResponse;
+import grpc.leaderboard._GetLeaderboardLengthRequest;
+import grpc.leaderboard._GetLeaderboardLengthResponse;
+import grpc.leaderboard._GetRankRequest;
+import grpc.leaderboard._GetRankResponse;
 import grpc.leaderboard._Order;
 import grpc.leaderboard._RankRange;
+import grpc.leaderboard._RankedElement;
 import grpc.leaderboard._RemoveElementsRequest;
+import grpc.leaderboard._ScoreRange;
 import grpc.leaderboard._UpsertElementsRequest;
 import io.grpc.Metadata;
 import java.util.List;
@@ -22,12 +35,15 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.LeaderboardConfiguration;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.responses.SortOrder;
+import momento.sdk.responses.leaderboard.DeleteResponse;
 import momento.sdk.responses.leaderboard.FetchResponse;
 import momento.sdk.responses.leaderboard.LeaderboardElement;
+import momento.sdk.responses.leaderboard.LengthResponse;
 import momento.sdk.responses.leaderboard.RemoveElementsResponse;
 import momento.sdk.responses.leaderboard.UpsertResponse;
 
@@ -59,12 +75,34 @@ final class LeaderboardDataClient extends ScsClientBase {
     }
   }
 
+  public CompletableFuture<FetchResponse> fetchByScore(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nullable Double minScore,
+      @Nullable Double maxScore,
+      @Nullable SortOrder order,
+      @Nullable Integer offset,
+      @Nullable Integer count) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+      checkScoreRangeValid(minScore, maxScore);
+      validateOffset(offset);
+      validateCount(count);
+
+      return sendFetchByScore(cacheName, leaderboardName, minScore, maxScore, order, offset, count);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new FetchResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
   public CompletableFuture<FetchResponse> fetchByRank(
       @Nonnull String cacheName,
       @Nonnull String leaderboardName,
       int startRank,
       int endRank,
-      @Nonnull SortOrder order) {
+      @Nullable SortOrder order) {
     try {
       checkCacheNameValid(cacheName);
       validateLeaderboardName(leaderboardName);
@@ -77,16 +115,60 @@ final class LeaderboardDataClient extends ScsClientBase {
     }
   }
 
+  public CompletableFuture<FetchResponse> getRank(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nonnull Iterable<Integer> ids,
+      @Nullable SortOrder order) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+      validateNotNull(ids, "ids");
+
+      return sendGetRank(cacheName, leaderboardName, ids, order);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new FetchResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  public CompletableFuture<LengthResponse> length(
+      @Nonnull String cacheName, @Nonnull String leaderboardName) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+
+      return sendLength(cacheName, leaderboardName);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new LengthResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
   public CompletableFuture<RemoveElementsResponse> removeElements(
       @Nonnull String cacheName, @Nonnull String leaderboardName, @Nonnull Iterable<Integer> ids) {
     try {
       checkCacheNameValid(cacheName);
       validateLeaderboardName(leaderboardName);
+      validateNotNull(ids, "ids");
 
       return sendRemoveElements(cacheName, leaderboardName, ids);
     } catch (Exception e) {
       return CompletableFuture.completedFuture(
           new RemoveElementsResponse.Error(CacheServiceExceptionMapper.convert(e)));
+    }
+  }
+
+  public CompletableFuture<DeleteResponse> delete(
+      @Nonnull String cacheName, @Nonnull String leaderboardName) {
+    try {
+      checkCacheNameValid(cacheName);
+      validateLeaderboardName(leaderboardName);
+
+      return sendDelete(cacheName, leaderboardName);
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new DeleteResponse.Error(CacheServiceExceptionMapper.convert(e)));
     }
   }
 
@@ -108,12 +190,37 @@ final class LeaderboardDataClient extends ScsClientBase {
     return executeGrpcFunction(stubSupplier, success, failure);
   }
 
+  CompletableFuture<FetchResponse> sendFetchByScore(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nullable Double minScore,
+      @Nullable Double maxScore,
+      @Nullable SortOrder order,
+      @Nullable Integer offset,
+      @Nullable Integer count) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_GetByScoreResponse>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .getByScore(
+                    buildGetByScoreRequest(
+                        cacheName, leaderboardName, minScore, maxScore, order, offset, count));
+
+    final Function<_GetByScoreResponse, FetchResponse> success =
+        rsp -> new FetchResponse.Success(convertToLeaderboardElements(rsp.getElementsList()));
+
+    final Function<Throwable, FetchResponse> failure =
+        e -> new FetchResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
   CompletableFuture<FetchResponse> sendFetchByRank(
       @Nonnull String cacheName,
       @Nonnull String leaderboardName,
       int startRank,
       int endRank,
-      @Nonnull SortOrder order) {
+      @Nullable SortOrder order) {
     final Metadata metadata = metadataWithCache(cacheName);
     final Supplier<ListenableFuture<_GetByRankResponse>> stubSupplier =
         () ->
@@ -122,16 +229,56 @@ final class LeaderboardDataClient extends ScsClientBase {
                     buildGetByRankRequest(cacheName, leaderboardName, startRank, endRank, order));
 
     final Function<_GetByRankResponse, FetchResponse> success =
-        rsp -> {
-          final List<LeaderboardElement> elements =
-              rsp.getElementsList().stream()
-                  .map(e -> new LeaderboardElement(e.getId(), e.getScore(), e.getRank()))
-                  .collect(Collectors.toList());
-          return new FetchResponse.Success(elements);
-        };
+        rsp -> new FetchResponse.Success(convertToLeaderboardElements(rsp.getElementsList()));
 
     final Function<Throwable, FetchResponse> failure =
         e -> new FetchResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
+  CompletableFuture<FetchResponse> sendGetRank(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nonnull Iterable<Integer> ids,
+      @Nullable SortOrder order) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_GetRankResponse>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .getRank(buildGetRankRequest(cacheName, leaderboardName, ids, order));
+
+    final Function<_GetRankResponse, FetchResponse> success =
+        rsp -> new FetchResponse.Success(convertToLeaderboardElements(rsp.getElementsList()));
+
+    final Function<Throwable, FetchResponse> failure =
+        e -> new FetchResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
+  private List<LeaderboardElement> convertToLeaderboardElements(List<_RankedElement> elements) {
+    return elements.stream()
+        .map(e -> new LeaderboardElement(e.getId(), e.getScore(), e.getRank()))
+        .collect(Collectors.toList());
+  }
+
+  private CompletableFuture<LengthResponse> sendLength(
+      @Nonnull String cacheName, @Nonnull String leaderboardName) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_GetLeaderboardLengthResponse>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .getLeaderboardLength(buildLengthRequest(cacheName, leaderboardName));
+
+    final Function<_GetLeaderboardLengthResponse, LengthResponse> success =
+        rsp -> {
+          final int length = rsp.getCount();
+          return new LengthResponse.Success(length);
+        };
+
+    final Function<Throwable, LengthResponse> failure =
+        e -> new LengthResponse.Error(CacheServiceExceptionMapper.convert(e));
 
     return executeGrpcFunction(stubSupplier, success, failure);
   }
@@ -153,6 +300,22 @@ final class LeaderboardDataClient extends ScsClientBase {
     return executeGrpcFunction(stubSupplier, success, failure);
   }
 
+  private CompletableFuture<DeleteResponse> sendDelete(
+      @Nonnull String cacheName, @Nonnull String leaderboardName) {
+    final Metadata metadata = metadataWithCache(cacheName);
+    final Supplier<ListenableFuture<_Empty>> stubSupplier =
+        () ->
+            attachMetadata(stubsManager.getStub(), metadata)
+                .deleteLeaderboard(buildDeleteRequest(cacheName, leaderboardName));
+
+    final Function<_Empty, DeleteResponse> success = rsp -> new DeleteResponse.Success();
+
+    final Function<Throwable, DeleteResponse> failure =
+        e -> new DeleteResponse.Error(CacheServiceExceptionMapper.convert(e));
+
+    return executeGrpcFunction(stubSupplier, success, failure);
+  }
+
   private _UpsertElementsRequest buildUpsertElementsRequest(
       @Nonnull String cacheName,
       @Nonnull String leaderboardName,
@@ -167,18 +330,102 @@ final class LeaderboardDataClient extends ScsClientBase {
         .build();
   }
 
+  private _GetByScoreRequest buildGetByScoreRequest(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nullable Double minScore,
+      @Nullable Double maxScore,
+      @Nullable SortOrder order,
+      @Nullable Integer offset,
+      @Nullable Integer count) {
+    final _ScoreRange.Builder scoreBuilder = _ScoreRange.newBuilder();
+    if (minScore != null) {
+      scoreBuilder.setMinInclusive(minScore);
+    } else {
+      scoreBuilder.setUnboundedMin(scoreBuilder.getUnboundedMin());
+    }
+    if (maxScore != null) {
+      scoreBuilder.setMaxExclusive(maxScore);
+    } else {
+      scoreBuilder.setUnboundedMax(scoreBuilder.getUnboundedMax());
+    }
+
+    final _GetByScoreRequest.Builder requestBuilder =
+        _GetByScoreRequest.newBuilder()
+            .setCacheName(cacheName)
+            .setLeaderboard(leaderboardName)
+            .setScoreRange(scoreBuilder.build());
+
+    if (order == SortOrder.DESCENDING) {
+      requestBuilder.setOrder(_Order.DESCENDING);
+    } else {
+      requestBuilder.setOrder(_Order.ASCENDING);
+    }
+
+    if (offset != null) {
+      requestBuilder.setOffset(offset);
+    } else {
+      requestBuilder.setOffset(0);
+    }
+
+    if (count != null) {
+      requestBuilder.setLimitElements(count);
+    } else {
+      requestBuilder.setLimitElements(8192);
+    }
+
+    return requestBuilder.build();
+  }
+
   private _GetByRankRequest buildGetByRankRequest(
       @Nonnull String cacheName,
       @Nonnull String leaderboardName,
       int startRank,
       int endRank,
-      @Nonnull SortOrder order) {
-    return _GetByRankRequest.newBuilder()
+      @Nullable SortOrder order) {
+    final _GetByRankRequest.Builder requestBuilder =
+        _GetByRankRequest.newBuilder()
+            .setCacheName(cacheName)
+            .setLeaderboard(leaderboardName)
+            .setRankRange(
+                _RankRange.newBuilder()
+                    .setStartInclusive(startRank)
+                    .setEndExclusive(endRank)
+                    .build());
+
+    if (order == SortOrder.DESCENDING) {
+      requestBuilder.setOrder(_Order.DESCENDING);
+    } else {
+      requestBuilder.setOrder(_Order.ASCENDING);
+    }
+    return requestBuilder.build();
+  }
+
+  private _GetRankRequest buildGetRankRequest(
+      @Nonnull String cacheName,
+      @Nonnull String leaderboardName,
+      @Nonnull Iterable<Integer> ids,
+      @Nullable SortOrder order) {
+    final _GetRankRequest.Builder requestBuilder =
+        _GetRankRequest.newBuilder()
+            .setCacheName(cacheName)
+            .setLeaderboard(leaderboardName)
+            .addAllIds(ids);
+
+    if (order == SortOrder.DESCENDING) {
+      requestBuilder.setOrder(_Order.DESCENDING);
+    } else {
+      requestBuilder.setOrder(_Order.ASCENDING);
+    }
+
+    return requestBuilder.build();
+  }
+
+  private _GetLeaderboardLengthRequest buildLengthRequest(
+      @Nonnull String cacheName, @Nonnull String leaderboardName) {
+    return _GetLeaderboardLengthRequest.newBuilder()
         .setCacheName(cacheName)
         .setLeaderboard(leaderboardName)
-        .setRankRange(
-            _RankRange.newBuilder().setStartInclusive(startRank).setEndExclusive(endRank).build())
-        .setOrder(order == SortOrder.ASCENDING ? _Order.ASCENDING : _Order.DESCENDING)
         .build();
   }
 
@@ -188,6 +435,14 @@ final class LeaderboardDataClient extends ScsClientBase {
         .setCacheName(cacheName)
         .setLeaderboard(leaderboardName)
         .addAllIds(ids)
+        .build();
+  }
+
+  private _DeleteLeaderboardRequest buildDeleteRequest(
+      @Nonnull String cacheName, @Nonnull String leaderboardName) {
+    return _DeleteLeaderboardRequest.newBuilder()
+        .setCacheName(cacheName)
+        .setLeaderboard(leaderboardName)
         .build();
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataClient.java
@@ -6,14 +6,14 @@ import static momento.sdk.ValidationUtils.checkIndexRangeValid;
 import static momento.sdk.ValidationUtils.checkListNameValid;
 import static momento.sdk.ValidationUtils.checkScoreRangeValid;
 import static momento.sdk.ValidationUtils.checkSetNameValid;
-import static momento.sdk.ValidationUtils.checkSortedSetCountValid;
 import static momento.sdk.ValidationUtils.checkSortedSetNameValid;
-import static momento.sdk.ValidationUtils.checkSortedSetOffsetValid;
 import static momento.sdk.ValidationUtils.ensureValidCacheSet;
 import static momento.sdk.ValidationUtils.ensureValidKey;
 import static momento.sdk.ValidationUtils.ensureValidTruncateToSize;
 import static momento.sdk.ValidationUtils.ensureValidTtl;
 import static momento.sdk.ValidationUtils.ensureValidValue;
+import static momento.sdk.ValidationUtils.validateCount;
+import static momento.sdk.ValidationUtils.validateOffset;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -734,8 +734,8 @@ final class ScsDataClient extends ScsClientBase {
       checkCacheNameValid(cacheName);
       checkSortedSetNameValid(sortedSetName);
       checkScoreRangeValid(minScore, maxScore);
-      checkSortedSetOffsetValid(offset);
-      checkSortedSetCountValid(count);
+      validateOffset(offset);
+      validateCount(count);
 
       return sendSortedSetFetchByScore(
           cacheName, convert(sortedSetName), minScore, maxScore, order, offset, count);

--- a/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
+++ b/momento-sdk/src/main/java/momento/sdk/ValidationUtils.java
@@ -14,15 +14,7 @@ public final class ValidationUtils {
 
   static final String REQUEST_DEADLINE_MUST_BE_POSITIVE = "Request deadline must be positive";
   static final String CACHE_ITEM_TTL_CANNOT_BE_NEGATIVE = "Cache item TTL cannot be negative.";
-  static final String A_NON_NULL_KEY_IS_REQUIRED = "A non-null key is required.";
-  static final String A_NON_NULL_VALUE_IS_REQUIRED = "A non-null value is required.";
-  static final String CACHE_NAME_IS_REQUIRED = "Cache name is required.";
-  static final String STORE_NAME_IS_REQUIRED = "Store name is required.";
-  static final String TOPIC_NAME_IS_REQUIRED = "Topic name is required.";
-  static final String DICTIONARY_NAME_IS_REQUIRED = "Dictionary name is required.";
-  static final String SET_NAME_CANNOT_BE_NULL = "Set name cannot be null.";
-  static final String SORTED_SET_NAME_CANNOT_BE_NULL = "Sorted set name cannot be null.";
-  static final String LIST_NAME_CANNOT_BE_NULL = "List name cannot be null.";
+  static final String CANNOT_BE_NULL = " cannot be null.";
   static final String INDEX_RANGE_INVALID =
       "endIndex (exclusive) must be larger than startIndex (inclusive).";
   static final String SCORE_RANGE_INVALID =
@@ -55,51 +47,35 @@ public final class ValidationUtils {
   }
 
   static void checkCacheNameValid(String cacheName) {
-    if (cacheName == null) {
-      throw new InvalidArgumentException(CACHE_NAME_IS_REQUIRED);
-    }
+    validateNotNull(cacheName, "Cache name");
   }
 
   static void checkStoreNameValid(String storeName) {
-    if (storeName == null) {
-      throw new InvalidArgumentException(STORE_NAME_IS_REQUIRED);
-    }
+    validateNotNull(storeName, "Store name");
   }
 
   static void checkTopicNameValid(String topicName) {
-    if (topicName == null) {
-      throw new InvalidArgumentException(TOPIC_NAME_IS_REQUIRED);
-    }
+    validateNotNull(topicName, "Topic name");
   }
 
   static void checkDictionaryNameValid(String dictionaryName) {
-    if (dictionaryName == null) {
-      throw new InvalidArgumentException(DICTIONARY_NAME_IS_REQUIRED);
-    }
+    validateNotNull(dictionaryName, "Dictionary name");
   }
 
   static void checkListNameValid(byte[] listName) {
-    if (listName == null) {
-      throw new InvalidArgumentException(LIST_NAME_CANNOT_BE_NULL);
-    }
+    validateNotNull(listName, "List name");
   }
 
   static void checkListNameValid(String listName) {
-    if (listName == null) {
-      throw new InvalidArgumentException(LIST_NAME_CANNOT_BE_NULL);
-    }
+    validateNotNull(listName, "List name");
   }
 
   static void checkSetNameValid(String setName) {
-    if (setName == null) {
-      throw new InvalidArgumentException(SET_NAME_CANNOT_BE_NULL);
-    }
+    validateNotNull(setName, "Set name");
   }
 
   static void checkSortedSetNameValid(String sortedSetName) {
-    if (sortedSetName == null) {
-      throw new InvalidArgumentException(SORTED_SET_NAME_CANNOT_BE_NULL);
-    }
+    validateNotNull(sortedSetName, "Sorted set name");
   }
 
   static void checkIndexRangeValid(Integer startIndex, Integer endIndex) {
@@ -118,13 +94,13 @@ public final class ValidationUtils {
     }
   }
 
-  static void checkSortedSetOffsetValid(Integer offset) {
+  static void validateOffset(Integer offset) {
     if (offset != null && offset < 0) {
       throw new InvalidArgumentException("Offset must be greater than or equal to 0.");
     }
   }
 
-  static void checkSortedSetCountValid(Integer count) {
+  static void validateCount(Integer count) {
     if (count != null && count <= 0) {
       throw new InvalidArgumentException("Count must be greater than 0.");
     }
@@ -137,15 +113,11 @@ public final class ValidationUtils {
   }
 
   static void ensureValidKey(Object key) {
-    if (key == null) {
-      throw new InvalidArgumentException(A_NON_NULL_KEY_IS_REQUIRED);
-    }
+    validateNotNull(key, "Key");
   }
 
   static void ensureValidValue(Object value) {
-    if (value == null) {
-      throw new InvalidArgumentException(A_NON_NULL_VALUE_IS_REQUIRED);
-    }
+    validateNotNull(value, "Value");
   }
 
   static void ensureValidTtl(Duration ttl) {
@@ -191,6 +163,12 @@ public final class ValidationUtils {
   static void validateRankRange(int startRank, int endRank) {
     if (startRank < 0 || endRank < 0 || endRank <= startRank) {
       throw new InvalidArgumentException(RANK_RANGE_INVALID);
+    }
+  }
+
+  static void validateNotNull(Object object, String name) {
+    if (object == null) {
+      throw new InvalidArgumentException(name + CANNOT_BE_NULL);
     }
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardGrpcConfiguration.java
@@ -28,7 +28,7 @@ public class LeaderboardGrpcConfiguration implements IGrpcConfiguration {
     this(
         deadline,
         1,
-        GrpcChannelOptions.DEFAULT_MAX_MESSAGE_SIZE,
+        GrpcChannelOptions.DEFAULT_LEADERBOARD_MAX_MESSAGE_SIZE,
         GrpcChannelOptions.DEFAULT_KEEPALIVE_WITHOUT_STREAM,
         GrpcChannelOptions.DEFAULT_KEEPALIVE_TIMEOUT,
         GrpcChannelOptions.DEFAULT_KEEPALIVE_TIME);

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -6,10 +6,13 @@ import java.util.concurrent.TimeUnit;
 import momento.sdk.config.transport.IGrpcConfiguration;
 
 public class GrpcChannelOptions {
-  // The default value for max_send_message_length is 4mb.  We need to increase this to 5mb in order
-  // to
-  // support cases where users have requested a limit increase up to our maximum item size of 5mb.
+  // The default value for max_send_message_length is 4MB.  We need to increase this to 5MB in order
+  // to support cases where users have requested a limit increase up to our maximum item size of
+  // 5MB.
   public static final int DEFAULT_MAX_MESSAGE_SIZE = 5_243_000; // bytes
+  // Leaderboards have a separate max message size from the cache methods. This default limit of
+  // 200MB is in place to prevent memory issues in the event of an erroneously large message.
+  public static final int DEFAULT_LEADERBOARD_MAX_MESSAGE_SIZE = 209_715_200; // bytes
 
   public static final boolean DEFAULT_KEEPALIVE_WITHOUT_STREAM = true;
   public static final int DEFAULT_KEEPALIVE_TIME_MS = 5000; // milliseconds

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/DeleteResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/DeleteResponse.java
@@ -1,0 +1,38 @@
+package momento.sdk.responses.leaderboard;
+
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/** Response for a leaderboard delete operation */
+public interface DeleteResponse {
+
+  /** A successful delete operation. */
+  class Success implements DeleteResponse {
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("DeleteResponse.Success");
+    }
+  }
+
+  /**
+   * A failed delete operation. The response itself is an exception, so it can be directly thrown,
+   * or the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of
+   * the message of the cause.
+   */
+  class Error extends SdkException implements DeleteResponse {
+
+    /**
+     * Constructs a leaderboard delete error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return buildToString("DeleteResponse.Error");
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/LengthResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/leaderboard/LengthResponse.java
@@ -1,0 +1,53 @@
+package momento.sdk.responses.leaderboard;
+
+import momento.sdk.exceptions.SdkException;
+import momento.sdk.internal.StringHelpers;
+
+/** Response for a leaderboard length operation */
+public interface LengthResponse {
+
+  /** A successful length operation. */
+  class Success implements LengthResponse {
+    private final int length;
+
+    public Success(int length) {
+      this.length = length;
+    }
+
+    /**
+     * Gets the length of the leaderboard.
+     *
+     * @return the length.
+     */
+    public int length() {
+      return length;
+    }
+
+    @Override
+    public String toString() {
+      return StringHelpers.emptyToString("LengthResponse.Success") + ": length: " + length;
+    }
+  }
+
+  /**
+   * A failed length operation. The response itself is an exception, so it can be directly thrown,
+   * or the cause of the error can be retrieved with {@link #getCause()}. The message is a copy of
+   * the message of the cause.
+   */
+  class Error extends SdkException implements LengthResponse {
+
+    /**
+     * Constructs a leaderboard length error with a cause.
+     *
+     * @param cause the cause.
+     */
+    public Error(SdkException cause) {
+      super(cause);
+    }
+
+    @Override
+    public String toString() {
+      return buildToString("LengthResponse.Error");
+    }
+  }
+}


### PR DESCRIPTION
Add leaderboard fetchByRank, getRank, length, and delete APIs.

Set the default leaderboard max received message size to 200MB.

Make SortOrder in fetchByRank nullable and have it default to ascending if null.

Make the different null check validation methods use the same backing validateNotNull.