### PR TITLE
fix: update a comment that fails the build in some instances

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/responses/cache/ttl/ItemGetTtlResponse.java
+++ b/momento-sdk/src/main/java/momento/sdk/responses/cache/ttl/ItemGetTtlResponse.java
@@ -10,7 +10,7 @@ import momento.sdk.internal.StringHelpers;
  */
 public interface ItemGetTtlResponse {
 
-  /** A successful ≈ operation for a key that exists. */
+  /** A successful item get ttl operation for a key that exists. */
   class Hit implements ItemGetTtlResponse {
     private final Duration remainingTtl;
 


### PR DESCRIPTION
Remove a non-ASCII character from a javadoc comment that was preventing the canary docker image from building.