### PR TITLE
chore: consolidate gRPC stubs handling logic into an abstract class

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/AbstractGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/AbstractGrpcStubsManager.java
@@ -1,0 +1,352 @@
+package momento.sdk;
+
+import io.grpc.ClientInterceptor;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.AbstractStub;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import momento.sdk.config.ReadConcern;
+import momento.sdk.config.transport.IGrpcConfiguration;
+import momento.sdk.exceptions.ConnectionFailedException;
+import momento.sdk.internal.GrpcChannelOptions;
+import momento.sdk.retry.RetryStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractGrpcStubsManager<S extends AbstractStub<S>> implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGrpcStubsManager.class);
+
+  /**
+   * These two executors are used by {@link RetryClientInterceptor} to schedule and execute retries
+   * on failed gRPC requests. One is a single threaded scheduling executor {@link
+   * ScheduledExecutorService} that's only responsible to schedule retries with a given delay. The
+   * other executor {@link ThreadPoolExecutor} is a dynamic executor that spawns threads as
+   * necessary and executes the retries (essentially doing the I/O work).
+   *
+   * <p>{@link ScheduledExecutorService} creates idle threads and hence the choice of using two
+   * executors. The small overhead of a single thread doing the scheduling negates the implications
+   * of creating potentially hundreds of idle threads with the ScheduledExecutorService. This
+   * executor is chosen to avoid a Thread.sleep() while doing retries. There are no available
+   * configurations to ScheduledExecutorService such that it grows dynamically.
+   *
+   * <p>The {@link ThreadPoolExecutor} has a size of 0 and grows onDemand. The maximumPoolSize is
+   * present to cap the number of threads we create for retries; where the {@link
+   * LinkedBlockingQueue} essentially stores any pending retries. Note that the keep alive time for
+   * each thread is 60 seconds, beyond which the JVM will destroy the thread. This is the default
+   * value of {@link Executors#newCachedThreadPool()} and also applies in our situation as even with
+   * backoffs, one retry should be below 60 seconds. We aren't directly using a cached thread pool
+   * because it grows unbounded.
+   */
+  private final ScheduledExecutorService retryScheduler;
+
+  private final ExecutorService retryExecutor;
+  private final RetryStrategy retryStrategy;
+
+  private static final int MAX_RETRY_THREAD_POOL_SIZE = 64;
+  // Timeout to keep threads idle/alive in the retry thread pool
+  private static final long RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS = 60L;
+
+  protected final List<ManagedChannel> channels;
+  protected final List<S> futureStubs;
+  protected final AtomicInteger nextStubIndex = new AtomicInteger(0);
+  @Nullable protected final Duration deadline;
+  protected final int numGrpcChannels;
+
+  protected AbstractGrpcStubsManager(@Nonnull Config<S> config) {
+    this.deadline = config.grpcConfiguration.getDeadline();
+    this.numGrpcChannels = config.grpcConfiguration.getMinNumGrpcChannels();
+    this.channels = new ArrayList<>(numGrpcChannels);
+    this.futureStubs = new ArrayList<>(numGrpcChannels);
+
+    if (config.retryStrategy != null) {
+      this.retryStrategy = config.retryStrategy;
+      this.retryScheduler = Executors.newSingleThreadScheduledExecutor();
+      this.retryExecutor =
+          new ThreadPoolExecutor(
+              0,
+              MAX_RETRY_THREAD_POOL_SIZE,
+              RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS,
+              TimeUnit.SECONDS,
+              new LinkedBlockingQueue<>());
+    } else {
+      this.retryStrategy = null;
+      this.retryScheduler = null;
+      this.retryExecutor = null;
+    }
+
+    channels.addAll(
+        IntStream.range(0, this.numGrpcChannels)
+            .mapToObj(
+                i ->
+                    setupConnection(
+                        config.clientType,
+                        config.endpoint,
+                        config.authToken,
+                        config.grpcConfiguration,
+                        config.readConcern))
+            .collect(Collectors.toList()));
+    futureStubs.addAll(channels.stream().map(config.stubFactory).collect(Collectors.toList()));
+  }
+
+  private ManagedChannel setupConnection(
+      String clientType,
+      String endpoint,
+      String authToken,
+      IGrpcConfiguration grpcConfiguration,
+      @Nullable ReadConcern readConcern) {
+    final NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(endpoint, 443);
+
+    // set additional channel options (message size, keepalive, auth, etc)
+    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(grpcConfiguration, channelBuilder);
+
+    final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
+    if (readConcern != null && readConcern != ReadConcern.BALANCED) {
+      extraHeaders.put(UserHeaderInterceptor.READ_CONCERN, readConcern.toLowerCase());
+    }
+
+    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    clientInterceptors.add(new UserHeaderInterceptor(authToken, clientType, extraHeaders));
+
+    if (retryStrategy != null) {
+      clientInterceptors.add(
+          new RetryClientInterceptor(retryStrategy, retryScheduler, retryExecutor));
+    }
+
+    channelBuilder.intercept(clientInterceptors);
+    return channelBuilder.build();
+  }
+
+  /**
+   * This method tries to connect to Momento's gRPC server during client initialization (eagerly).
+   *
+   * @param timeoutSeconds the timeout value beyond which to give up on the eager connection
+   *     attempt.
+   */
+  public void connect(final long timeoutSeconds) {
+    // TODO: client initialization time could be optimized, in the case where a user configures more
+    // than one gRPC
+    //  channel, by attempting to connect these channels asynchronously rather than serially.
+    for (ManagedChannel channel : channels) {
+      final ConnectivityState currentState = channel.getState(true /* tryToConnect */);
+      if (ConnectivityState.READY.equals(currentState)) {
+        LOGGER.debug("Connected to Momento's server! Happy Caching!");
+        continue;
+      }
+
+      final CompletableFuture<Void> connectionFuture = new CompletableFuture<>();
+      eagerlyConnect(
+          currentState, connectionFuture, channel, Instant.now().plusSeconds(timeoutSeconds));
+
+      try {
+        connectionFuture.get(timeoutSeconds, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+        connectionFuture.cancel(true);
+        throw new ConnectionFailedException(
+            "Failed to connect within the allotted time of " + timeoutSeconds + " seconds.", e);
+      } catch (InterruptedException | ExecutionException e) {
+        connectionFuture.cancel(true);
+        throw new ConnectionFailedException(
+            "Error while waiting for eager connection to establish.", e);
+      }
+    }
+  }
+
+  private static void eagerlyConnect(
+      final ConnectivityState lastObservedState,
+      final CompletableFuture<Void> connectionFuture,
+      final ManagedChannel channel,
+      final Instant timeout) {
+
+    if (Instant.now().toEpochMilli() > timeout.toEpochMilli()) {
+      connectionFuture.completeExceptionally(
+          new ConnectionFailedException("Connection failed: Deadline exceeded"));
+      return;
+    }
+    channel.notifyWhenStateChanged(
+        lastObservedState,
+        () -> {
+          final ConnectivityState currentState = channel.getState(false /* tryToConnect */);
+          switch (currentState) {
+            case READY:
+              LOGGER.debug("Connected to Momento's server! Happy Caching!");
+              connectionFuture.complete(null);
+              return;
+            case IDLE:
+              LOGGER.debug("State is idle; waiting to transition to CONNECTING");
+              eagerlyConnect(currentState, connectionFuture, channel, timeout);
+              break;
+            case CONNECTING:
+              LOGGER.debug("State transitioned to CONNECTING; waiting to get READY");
+              eagerlyConnect(currentState, connectionFuture, channel, timeout);
+              break;
+            default:
+              LOGGER.debug(
+                  "Unexpected state encountered {}. Contact Momento if this persists.",
+                  currentState.name());
+              connectionFuture.completeExceptionally(
+                  new ConnectionFailedException(
+                      "Connection failed due to unexpected state: " + currentState));
+              break;
+          }
+        });
+  }
+
+  protected <T extends AbstractStub<T>> T getNextStub(List<T> stubs) {
+    int nextStubIndex = this.nextStubIndex.getAndIncrement();
+    T stub = stubs.get(nextStubIndex % this.numGrpcChannels);
+    if (deadline != null) {
+      stub = stub.withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
+    }
+    return stub;
+  }
+
+  /**
+   * Returns a stub with appropriate deadlines.
+   *
+   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
+   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
+   * before the deadline expires. Hence, the stub returned from here should never be cached and the
+   * safest behavior is for clients to request a new stub each time.
+   *
+   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
+   */
+  S getStub() {
+    return getNextStub(futureStubs);
+  }
+
+  @Override
+  public void close() {
+    doClose();
+    boolean wasInterrupted = false;
+
+    // Initiate shutdown of all channels and then wait for them to shut down
+    for (ManagedChannel channel : channels) {
+      channel.shutdown();
+    }
+    for (ManagedChannel channel : channels) {
+      try {
+        if (!channel.awaitTermination(20, TimeUnit.SECONDS)) {
+          channel.shutdownNow();
+          if (!channel.awaitTermination(10, TimeUnit.SECONDS)) {
+            LOGGER.warn("Channel failed to shut down within 30 seconds");
+          }
+        }
+      } catch (InterruptedException e) {
+        channel.shutdownNow();
+        wasInterrupted = true;
+      }
+    }
+
+    // Shut down retry executors if they are present. They are not likely be processing anything
+    // since the channels are shut down.
+    if (retryExecutor != null) {
+      retryExecutor.shutdown();
+      try {
+        if (!retryExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+          retryExecutor.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        retryExecutor.shutdownNow();
+        wasInterrupted = true;
+      }
+    }
+    if (retryScheduler != null) {
+      retryScheduler.shutdown();
+      try {
+        if (!retryScheduler.awaitTermination(10, TimeUnit.SECONDS)) {
+          retryScheduler.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        retryScheduler.shutdownNow();
+        wasInterrupted = true;
+      }
+    }
+
+    if (wasInterrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  protected void doClose() {}
+
+  protected static class Config<S extends AbstractStub<S>> {
+    @Nonnull public final String clientType;
+    @Nonnull public final String endpoint;
+    @Nonnull public final String authToken;
+    @Nonnull public final IGrpcConfiguration grpcConfiguration;
+    @Nonnull public final Function<ManagedChannel, S> stubFactory;
+    @Nullable public final RetryStrategy retryStrategy;
+    @Nullable public final ReadConcern readConcern;
+
+    private Config(
+        @Nonnull String clientType,
+        @Nonnull String endpoint,
+        @Nonnull String authToken,
+        @Nonnull IGrpcConfiguration grpcConfiguration,
+        @Nonnull Function<ManagedChannel, S> stubFactory,
+        @Nullable RetryStrategy retryStrategy,
+        @Nullable ReadConcern readConcern) {
+      this.clientType = clientType;
+      this.endpoint = endpoint;
+      this.authToken = authToken;
+      this.grpcConfiguration = grpcConfiguration;
+      this.stubFactory = stubFactory;
+      this.retryStrategy = retryStrategy;
+      this.readConcern = readConcern;
+    }
+
+    public static <S extends AbstractStub<S>> Config<S> create(
+        @Nonnull String clientType,
+        @Nonnull String endpoint,
+        @Nonnull String authToken,
+        @Nonnull IGrpcConfiguration grpcConfiguration,
+        @Nonnull Function<ManagedChannel, S> stubFactory) {
+      return new Config<>(
+          clientType, endpoint, authToken, grpcConfiguration, stubFactory, null, null);
+    }
+
+    public Config<S> withRetryStrategy(RetryStrategy retryStrategy) {
+      return new Config<>(
+          clientType,
+          endpoint,
+          authToken,
+          grpcConfiguration,
+          stubFactory,
+          retryStrategy,
+          readConcern);
+    }
+
+    public Config<S> withReadConcern(ReadConcern readConcern) {
+      return new Config<>(
+          clientType,
+          endpoint,
+          authToken,
+          grpcConfiguration,
+          stubFactory,
+          retryStrategy,
+          readConcern);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/ClientBase.java
+++ b/momento-sdk/src/main/java/momento/sdk/ClientBase.java
@@ -174,7 +174,8 @@ abstract class ClientBase implements AutoCloseable {
               "Momento requests still processing after 30 seconds while awaiting shutdown.");
         }
       } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+        logger.warn("Request concurrency executor was interrupted while awaiting shutdown.");
+        Thread.currentThread().interrupt();
       }
     }
   }

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardDataClient.java
@@ -56,7 +56,9 @@ final class LeaderboardDataClient extends ScsClientBase {
       @Nonnull LeaderboardConfiguration configuration) {
     super(null);
 
-    this.stubsManager = new LeaderboardGrpcStubsManager(credentialProvider, configuration);
+    this.stubsManager =
+        new LeaderboardGrpcStubsManager(
+            credentialProvider, configuration.getTransportStrategy().getGrpcConfiguration());
   }
 
   public CompletableFuture<UpsertResponse> upsert(

--- a/momento-sdk/src/main/java/momento/sdk/LeaderboardGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/LeaderboardGrpcStubsManager.java
@@ -1,84 +1,23 @@
 package momento.sdk;
 
 import grpc.leaderboard.LeaderboardGrpc;
-import io.grpc.ClientInterceptor;
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.LeaderboardConfiguration;
-import momento.sdk.internal.GrpcChannelOptions;
+import momento.sdk.config.transport.IGrpcConfiguration;
 
 /** Manager responsible for GRPC channels and stubs for leaderboards. */
-final class LeaderboardGrpcStubsManager implements AutoCloseable {
-
-  private final List<ManagedChannel> channels;
-  private final List<LeaderboardGrpc.LeaderboardFutureStub> futureStubs;
-  private final AtomicInteger nextStubIndex = new AtomicInteger(0);
-
-  private final int numGrpcChannels;
-  private final Duration deadline;
+final class LeaderboardGrpcStubsManager
+    extends AbstractGrpcStubsManager<LeaderboardGrpc.LeaderboardFutureStub> {
 
   LeaderboardGrpcStubsManager(
       @Nonnull CredentialProvider credentialProvider,
-      @Nonnull LeaderboardConfiguration configuration) {
-    this.deadline = configuration.getTransportStrategy().getGrpcConfiguration().getDeadline();
-    this.numGrpcChannels =
-        configuration.getTransportStrategy().getGrpcConfiguration().getMinNumGrpcChannels();
-
-    this.channels =
-        IntStream.range(0, this.numGrpcChannels)
-            .mapToObj(i -> setupChannel(credentialProvider, configuration))
-            .collect(Collectors.toList());
-    this.futureStubs =
-        channels.stream().map(LeaderboardGrpc::newFutureStub).collect(Collectors.toList());
-  }
-
-  private static ManagedChannel setupChannel(
-      CredentialProvider credentialProvider, LeaderboardConfiguration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder);
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(
-        new UserHeaderInterceptor(credentialProvider.getAuthToken(), "leaderboard"));
-    channelBuilder.intercept(clientInterceptors);
-
-    return channelBuilder.build();
-  }
-
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
-  LeaderboardGrpc.LeaderboardFutureStub getStub() {
-    int nextStubIndex = this.nextStubIndex.getAndIncrement();
-    return futureStubs
-        .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void close() {
-    for (ManagedChannel channel : channels) {
-      channel.shutdown();
-    }
+      @Nonnull IGrpcConfiguration grpcConfiguration) {
+    super(
+        AbstractGrpcStubsManager.Config.create(
+            "leaderboard",
+            credentialProvider.getCacheEndpoint(),
+            credentialProvider.getAuthToken(),
+            grpcConfiguration,
+            LeaderboardGrpc::newFutureStub));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlClient.java
@@ -53,7 +53,8 @@ final class ScsControlClient extends ScsClientBase {
     super(configuration.getTransportStrategy().getMaxConcurrentRequests());
     this.credentialProvider = credentialProvider;
     this.controlGrpcStubsManager =
-        new ScsControlGrpcStubsManager(credentialProvider, configuration);
+        new ScsControlGrpcStubsManager(
+            credentialProvider, configuration.getTransportStrategy().getGrpcConfiguration());
   }
 
   CompletableFuture<CacheCreateResponse> createCache(String cacheName) {

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -1,18 +1,10 @@
 package momento.sdk;
 
 import grpc.control_client.ScsControlGrpc;
-import io.grpc.ClientInterceptor;
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.Configuration;
-import momento.sdk.config.transport.GrpcConfiguration;
-import momento.sdk.internal.GrpcChannelOptions;
+import momento.sdk.config.transport.IGrpcConfiguration;
 
 /**
  * Manager responsible for GRPC channels and stubs for the Control Plane.
@@ -21,54 +13,20 @@ import momento.sdk.internal.GrpcChannelOptions;
  * independent and any future pooling of channels can happen exclusively in the manager without
  * impacting the API business logic.
  */
-final class ScsControlGrpcStubsManager implements AutoCloseable {
+final class ScsControlGrpcStubsManager
+    extends AbstractGrpcStubsManager<ScsControlGrpc.ScsControlFutureStub> {
 
   private static final Duration DEADLINE = Duration.ofMinutes(1);
 
-  private final ManagedChannel channel;
-
-  private final ScsControlGrpc.ScsControlFutureStub futureStub;
-
   ScsControlGrpcStubsManager(
-      @Nonnull CredentialProvider credentialProvider, Configuration configuration) {
-    this.channel = setupConnection(credentialProvider, configuration);
-    this.futureStub = ScsControlGrpc.newFutureStub(channel);
-  }
-
-  private static ManagedChannel setupConnection(
-      CredentialProvider credentialProvider, Configuration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
-
-    // Override grpc config to disable keepalive for control clients
-    final GrpcConfiguration controlConfig =
-        configuration.getTransportStrategy().getGrpcConfiguration().withKeepAliveDisabled();
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(controlConfig, channelBuilder);
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache"));
-    channelBuilder.intercept(clientInterceptors);
-    return channelBuilder.build();
-  }
-
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
-  ScsControlGrpc.ScsControlFutureStub getStub() {
-    return futureStub.withDeadlineAfter(DEADLINE.toMillis(), TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void close() {
-    channel.shutdown();
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull IGrpcConfiguration grpcConfiguration) {
+    super(
+        AbstractGrpcStubsManager.Config.create(
+            "cache",
+            credentialProvider.getControlEndpoint(),
+            credentialProvider.getAuthToken(),
+            grpcConfiguration.withDeadline(DEADLINE),
+            ScsControlGrpc::newFutureStub));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -1,37 +1,11 @@
 package momento.sdk;
 
 import grpc.cache_client.ScsGrpc;
-import io.grpc.ClientInterceptor;
-import io.grpc.ConnectivityState;
-import io.grpc.ManagedChannel;
-import io.grpc.Metadata;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.Configuration;
-import momento.sdk.config.ReadConcern;
-import momento.sdk.exceptions.ConnectionFailedException;
-import momento.sdk.internal.GrpcChannelOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Manager responsible for GRPC channels and stubs for the Data Plane.
@@ -40,187 +14,23 @@ import org.slf4j.LoggerFactory;
  * independent and any future pooling of channels can happen exclusively in the manager without
  * impacting the API business logic.
  */
-final class ScsDataGrpcStubsManager implements AutoCloseable {
+final class ScsDataGrpcStubsManager extends AbstractGrpcStubsManager<ScsGrpc.ScsFutureStub> {
 
-  private final List<ManagedChannel> channels;
-  private final List<ScsGrpc.ScsFutureStub> futureStubs;
   private final List<ScsGrpc.ScsStub> observableStubs;
-  private final AtomicInteger nextStubIndex = new AtomicInteger(0);
-
-  private final int numGrpcChannels;
-  private final Duration deadline;
-
-  /**
-   * These two executors are used by {@link RetryClientInterceptor} to schedule and execute retries
-   * on failed gRPC requests. One is a single threaded scheduling executor {@link
-   * ScheduledExecutorService} that's only responsible to schedule retries with a given delay. The
-   * other executor {@link ThreadPoolExecutor} is a dynamic executor that spawns threads as
-   * necessary and executes the retries (essentially doing the I/O work).
-   *
-   * <p>{@link ScheduledExecutorService} creates idle threads and hence the choice of using two
-   * executors. The small overhead of a single thread doing the scheduling negates the implications
-   * of creating potentially hundreds of idle threads with the ScheduledExecutorService. This
-   * executor is chosen to avoid a Thread.sleep() while doing retries. There are no available
-   * configurations to ScheduledExecutorService such that it grows dynamically.
-   *
-   * <p>The {@link ThreadPoolExecutor} has a size of 0 and grows onDemand. The maximumPoolSize is
-   * present to cap the number of threads we create for retries; where the {@link
-   * LinkedBlockingQueue} essentially stores any pending retries. Note that the keep alive time for
-   * each thread is 60 seconds, beyond which the JVM will destroy the thread. This is the default
-   * value of {@link Executors#newCachedThreadPool()} and also applies in our situation as even with
-   * backoffs, one retry should be below 60 seconds. We aren't directly using a cached thread pool
-   * because it grows unbounded.
-   */
-  private final ScheduledExecutorService retryScheduler;
-
-  private final ExecutorService retryExecutor;
-
-  // An arbitrary selection of twice the number of available processors.
-  private static final int MAX_RETRY_THREAD_POOL_SIZE = 64;
-  // Timeout to keep threads idle/alive in the retry thread pool
-  private static final long RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS = 60L;
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ScsDataGrpcStubsManager.class);
 
   ScsDataGrpcStubsManager(
       @Nonnull CredentialProvider credentialProvider, @Nonnull Configuration configuration) {
-    this.deadline = configuration.getTransportStrategy().getGrpcConfiguration().getDeadline();
-    this.numGrpcChannels =
-        configuration.getTransportStrategy().getGrpcConfiguration().getMinNumGrpcChannels();
+    super(
+        AbstractGrpcStubsManager.Config.create(
+                "cache",
+                credentialProvider.getCacheEndpoint(),
+                credentialProvider.getAuthToken(),
+                configuration.getTransportStrategy().getGrpcConfiguration(),
+                ScsGrpc::newFutureStub)
+            .withReadConcern(configuration.getReadConcern())
+            .withRetryStrategy(configuration.getRetryStrategy()));
 
-    this.retryScheduler = Executors.newSingleThreadScheduledExecutor();
-    this.retryExecutor =
-        new ThreadPoolExecutor(
-            0,
-            MAX_RETRY_THREAD_POOL_SIZE,
-            RETRY_THREAD_POOL_KEEP_ALIVE_SECONDS,
-            TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>());
-
-    this.channels =
-        IntStream.range(0, this.numGrpcChannels)
-            .mapToObj(i -> setupChannel(credentialProvider, configuration))
-            .collect(Collectors.toList());
-    this.futureStubs = channels.stream().map(ScsGrpc::newFutureStub).collect(Collectors.toList());
     this.observableStubs = channels.stream().map(ScsGrpc::newStub).collect(Collectors.toList());
-  }
-
-  /**
-   * This method tries to connect to Momento's gRPC server during client initialization (eagerly).
-   *
-   * @param timeoutSeconds the timeout value beyond which to give up on the eager connection
-   *     attempt.
-   */
-  public void connect(final long timeoutSeconds) {
-    // TODO: client initialization time could be optimized, in the case where a user configures more
-    // than one gRPC
-    //  channel, by attempting to connect these channels asynchronously rather than serially.
-    for (ManagedChannel channel : channels) {
-      final ConnectivityState currentState = channel.getState(true /* tryToConnect */);
-      if (ConnectivityState.READY.equals(currentState)) {
-        LOGGER.debug("Connected to Momento's server! Happy Caching!");
-        continue;
-      }
-
-      final CompletableFuture<Void> connectionFuture = new CompletableFuture<>();
-      eagerlyConnect(
-          currentState, connectionFuture, channel, Instant.now().plusSeconds(timeoutSeconds));
-
-      try {
-        connectionFuture.get(timeoutSeconds, TimeUnit.SECONDS);
-      } catch (TimeoutException e) {
-        connectionFuture.cancel(true);
-        throw new ConnectionFailedException(
-            "Failed to connect within the allotted time of " + timeoutSeconds + " seconds.", e);
-      } catch (InterruptedException | ExecutionException e) {
-        connectionFuture.cancel(true);
-        throw new ConnectionFailedException(
-            "Error while waiting for eager connection to establish.", e);
-      }
-    }
-  }
-
-  private static void eagerlyConnect(
-      final ConnectivityState lastObservedState,
-      final CompletableFuture<Void> connectionFuture,
-      final ManagedChannel channel,
-      final Instant timeout) {
-
-    if (Instant.now().toEpochMilli() > timeout.toEpochMilli()) {
-      connectionFuture.completeExceptionally(
-          new ConnectionFailedException("Connection failed: Deadline exceeded"));
-      return;
-    }
-    channel.notifyWhenStateChanged(
-        lastObservedState,
-        () -> {
-          final ConnectivityState currentState = channel.getState(false /* tryToConnect */);
-          switch (currentState) {
-            case READY:
-              LOGGER.debug("Connected to Momento's server! Happy Caching!");
-              connectionFuture.complete(null);
-              return;
-            case IDLE:
-              LOGGER.debug("State is idle; waiting to transition to CONNECTING");
-              eagerlyConnect(currentState, connectionFuture, channel, timeout);
-              break;
-            case CONNECTING:
-              LOGGER.debug("State transitioned to CONNECTING; waiting to get READY");
-              eagerlyConnect(currentState, connectionFuture, channel, timeout);
-              break;
-            default:
-              LOGGER.debug(
-                  "Unexpected state encountered {}. Contact Momento if this persists.",
-                  currentState.name());
-              connectionFuture.completeExceptionally(
-                  new ConnectionFailedException(
-                      "Connection failed due to unexpected state: " + currentState));
-              break;
-          }
-        });
-  }
-
-  private ManagedChannel setupChannel(
-      CredentialProvider credentialProvider, Configuration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder);
-
-    final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
-    if (configuration.getReadConcern() != ReadConcern.BALANCED) {
-      extraHeaders.put(
-          UserHeaderInterceptor.READ_CONCERN, configuration.getReadConcern().toLowerCase());
-    }
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(
-        new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache", extraHeaders));
-    clientInterceptors.add(
-        new RetryClientInterceptor(
-            configuration.getRetryStrategy(), retryScheduler, retryExecutor));
-    channelBuilder.intercept(clientInterceptors);
-
-    return channelBuilder.build();
-  }
-
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
-  ScsGrpc.ScsFutureStub getStub() {
-    int nextStubIndex = this.nextStubIndex.getAndIncrement();
-    return futureStubs
-        .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -234,18 +44,6 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
    * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
    */
   ScsGrpc.ScsStub getObservableStub() {
-    int nextStubIndex = this.nextStubIndex.getAndIncrement();
-    return observableStubs
-        .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void close() {
-    retryScheduler.shutdown();
-    retryExecutor.shutdown();
-    for (ManagedChannel channel : channels) {
-      channel.shutdown();
-    }
+    return getNextStub(observableStubs);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsTokenGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTokenGrpcStubsManager.java
@@ -1,16 +1,9 @@
 package momento.sdk;
 
-import io.grpc.ClientInterceptor;
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
 import momento.sdk.config.transport.GrpcConfiguration;
-import momento.sdk.internal.GrpcChannelOptions;
 import momento.token.TokenGrpc;
 
 /**
@@ -20,52 +13,19 @@ import momento.token.TokenGrpc;
  * independent and any future pooling of channels can happen exclusively in the manager without
  * impacting the API business logic.
  */
-final class ScsTokenGrpcStubsManager implements AutoCloseable {
+final class ScsTokenGrpcStubsManager extends AbstractGrpcStubsManager<TokenGrpc.TokenFutureStub> {
 
   private static final Duration DEADLINE = Duration.ofMinutes(1);
 
-  private final ManagedChannel channel;
-
-  private final TokenGrpc.TokenFutureStub futureStub;
-
   ScsTokenGrpcStubsManager(@Nonnull CredentialProvider credentialProvider) {
-    this.channel = setupConnection(credentialProvider);
-    this.futureStub = TokenGrpc.newFutureStub(channel);
-  }
-
-  private static ManagedChannel setupConnection(CredentialProvider credentialProvider) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getTokenEndpoint(), 443);
-
-    // Note: This is hard-coded for now but we may want to expose it via configuration object
-    // in the future, as we do with some of the other clients.
-    final GrpcConfiguration grpcConfig = new GrpcConfiguration(Duration.ofMillis(15000));
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(grpcConfig, channelBuilder);
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "auth"));
-    channelBuilder.intercept(clientInterceptors);
-    return channelBuilder.build();
-  }
-
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
-  TokenGrpc.TokenFutureStub getStub() {
-    return futureStub.withDeadlineAfter(DEADLINE.toMillis(), TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void close() {
-    channel.shutdown();
+    super(
+        AbstractGrpcStubsManager.Config.create(
+            "auth",
+            credentialProvider.getTokenEndpoint(),
+            credentialProvider.getAuthToken(),
+            // Note: This is hard-coded for now but we may want to expose it via configuration
+            // object in the future, as we do with some of the other clients.
+            new GrpcConfiguration(DEADLINE),
+            TokenGrpc::newFutureStub));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/ScsTopicGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTopicGrpcStubsManager.java
@@ -1,16 +1,9 @@
 package momento.sdk;
 
 import grpc.cache_client.pubsub.PubsubGrpc;
-import io.grpc.ClientInterceptor;
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
-import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.TopicConfiguration;
-import momento.sdk.internal.GrpcChannelOptions;
+import momento.sdk.config.transport.IGrpcConfiguration;
 
 /**
  * Manager responsible for GRPC channels and stubs for the Topics.
@@ -19,46 +12,17 @@ import momento.sdk.internal.GrpcChannelOptions;
  * independent and any future pooling of channels can happen exclusively in the manager without
  * impacting the API business logic.
  */
-final class ScsTopicGrpcStubsManager implements Closeable {
-
-  private final ManagedChannel channel;
-  private final PubsubGrpc.PubsubStub stub;
-
-  private final TopicConfiguration configuration;
+final class ScsTopicGrpcStubsManager extends AbstractGrpcStubsManager<PubsubGrpc.PubsubStub> {
 
   ScsTopicGrpcStubsManager(
-      @Nonnull CredentialProvider credentialProvider, @Nonnull TopicConfiguration configuration) {
-    this.channel = setupConnection(credentialProvider, configuration);
-    this.stub = PubsubGrpc.newStub(channel);
-    this.configuration = configuration;
-  }
-
-  private static ManagedChannel setupConnection(
-      CredentialProvider credentialProvider, TopicConfiguration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder);
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "topic"));
-    channelBuilder.intercept(clientInterceptors);
-    return channelBuilder.build();
-  }
-
-  /** Returns a pubsub stub. */
-  PubsubGrpc.PubsubStub getStub() {
-    return stub;
-  }
-
-  TopicConfiguration getConfiguration() {
-    return configuration;
-  }
-
-  @Override
-  public void close() {
-    channel.shutdown();
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull IGrpcConfiguration grpcConfiguration) {
+    super(
+        AbstractGrpcStubsManager.Config.create(
+            "topic",
+            credentialProvider.getCacheEndpoint(),
+            credentialProvider.getAuthToken(),
+            grpcConfiguration,
+            PubsubGrpc::newStub));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlClient.java
@@ -27,15 +27,14 @@ import momento.sdk.responses.storage.StoreInfo;
 /** Client for interacting with Scs Control Plane. */
 final class StorageControlClient extends ScsClientBase {
 
-  private final CredentialProvider credentialProvider;
   private final StorageControlGrpcStubsManager controlGrpcStubsManager;
 
   StorageControlClient(
       @Nonnull CredentialProvider credentialProvider, StorageConfiguration configuration) {
     super(null);
-    this.credentialProvider = credentialProvider;
     this.controlGrpcStubsManager =
-        new StorageControlGrpcStubsManager(credentialProvider, configuration);
+        new StorageControlGrpcStubsManager(
+            credentialProvider, configuration.getTransportStrategy().getGrpcConfiguration());
   }
 
   CompletableFuture<CreateStoreResponse> createStore(String storeName) {

--- a/momento-sdk/src/main/java/momento/sdk/StorageControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageControlGrpcStubsManager.java
@@ -1,18 +1,10 @@
 package momento.sdk;
 
 import grpc.control_client.ScsControlGrpc;
-import io.grpc.ClientInterceptor;
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.StorageConfiguration;
-import momento.sdk.config.transport.storage.StorageGrpcConfiguration;
-import momento.sdk.internal.GrpcChannelOptions;
+import momento.sdk.config.transport.IGrpcConfiguration;
 
 /**
  * Manager responsible for GRPC channels and stubs for the Control Plane.
@@ -21,54 +13,20 @@ import momento.sdk.internal.GrpcChannelOptions;
  * independent and any future pooling of channels can happen exclusively in the manager without
  * impacting the API business logic.
  */
-final class StorageControlGrpcStubsManager implements AutoCloseable {
+final class StorageControlGrpcStubsManager
+    extends AbstractGrpcStubsManager<ScsControlGrpc.ScsControlFutureStub> {
 
   private static final Duration DEADLINE = Duration.ofMinutes(1);
 
-  private final ManagedChannel channel;
-
-  private final ScsControlGrpc.ScsControlFutureStub futureStub;
-
   StorageControlGrpcStubsManager(
-      @Nonnull CredentialProvider credentialProvider, StorageConfiguration configuration) {
-    this.channel = setupConnection(credentialProvider, configuration);
-    this.futureStub = ScsControlGrpc.newFutureStub(channel);
-  }
-
-  private static ManagedChannel setupConnection(
-      CredentialProvider credentialProvider, StorageConfiguration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
-
-    // Override grpc config to disable keepalive for control clients
-    final StorageGrpcConfiguration controlConfig =
-        configuration.getTransportStrategy().getGrpcConfiguration().withKeepAliveDisabled();
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(controlConfig, channelBuilder);
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "store"));
-    channelBuilder.intercept(clientInterceptors);
-    return channelBuilder.build();
-  }
-
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
-  ScsControlGrpc.ScsControlFutureStub getStub() {
-    return futureStub.withDeadlineAfter(DEADLINE.toMillis(), TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void close() {
-    channel.shutdown();
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull IGrpcConfiguration grpcConfiguration) {
+    super(
+        AbstractGrpcStubsManager.Config.create(
+            "store",
+            credentialProvider.getControlEndpoint(),
+            credentialProvider.getAuthToken(),
+            grpcConfiguration.withDeadline(DEADLINE),
+            ScsControlGrpc::newFutureStub));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataClient.java
@@ -35,7 +35,8 @@ final class StorageDataClient extends StorageClientBase {
       @Nonnull CredentialProvider credentialProvider, @Nonnull StorageConfiguration configuration) {
     super(null);
     this.storageDataGrpcStubsManager =
-        new StorageDataGrpcStubsManager(credentialProvider, configuration);
+        new StorageDataGrpcStubsManager(
+            credentialProvider, configuration.getTransportStrategy().getGrpcConfiguration());
   }
 
   public void connect(final long eagerConnectionTimeout) {

--- a/momento-sdk/src/main/java/momento/sdk/StorageDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/StorageDataGrpcStubsManager.java
@@ -1,28 +1,9 @@
 package momento.sdk;
 
 import grpc.store.StoreGrpc;
-import io.grpc.ClientInterceptor;
-import io.grpc.ConnectivityState;
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.config.StorageConfiguration;
-import momento.sdk.exceptions.ConnectionFailedException;
-import momento.sdk.internal.GrpcChannelOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import momento.sdk.config.transport.IGrpcConfiguration;
 
 /**
  * Manager responsible for GRPC channels and stubs for the Data Plane.
@@ -31,141 +12,18 @@ import org.slf4j.LoggerFactory;
  * independent and any future pooling of channels can happen exclusively in the manager without
  * impacting the API business logic.
  */
-final class StorageDataGrpcStubsManager implements AutoCloseable {
-
-  private final List<ManagedChannel> channels;
-  private final List<StoreGrpc.StoreFutureStub> futureStubs;
-  private final AtomicInteger nextStubIndex = new AtomicInteger(0);
-
-  private final int numGrpcChannels;
-  private final Duration deadline;
-  private static final Logger LOGGER = LoggerFactory.getLogger(StorageDataGrpcStubsManager.class);
+final class StorageDataGrpcStubsManager
+    extends AbstractGrpcStubsManager<StoreGrpc.StoreFutureStub> {
 
   StorageDataGrpcStubsManager(
-      @Nonnull CredentialProvider credentialProvider, @Nonnull StorageConfiguration configuration) {
-    this.deadline = configuration.getTransportStrategy().getGrpcConfiguration().getDeadline();
-    this.numGrpcChannels =
-        configuration.getTransportStrategy().getGrpcConfiguration().getMinNumGrpcChannels();
-
-    this.channels =
-        IntStream.range(0, this.numGrpcChannels)
-            .mapToObj(i -> setupChannel(credentialProvider, configuration))
-            .collect(Collectors.toList());
-    this.futureStubs = channels.stream().map(StoreGrpc::newFutureStub).collect(Collectors.toList());
-  }
-
-  /**
-   * This method tries to connect to Momento's gRPC server during client initialization (eagerly).
-   *
-   * @param timeoutSeconds the timeout value beyond which to give up on the eager connection
-   *     attempt.
-   */
-  public void connect(final long timeoutSeconds) {
-    // TODO: client initialization time could be optimized, in the case where a user configures more
-    // than one gRPC
-    //  channel, by attempting to connect these channels asynchronously rather than serially.
-    for (ManagedChannel channel : channels) {
-      final ConnectivityState currentState = channel.getState(true /* tryToConnect */);
-      if (ConnectivityState.READY.equals(currentState)) {
-        LOGGER.debug("Connected to Momento's server! Happy Caching!");
-        continue;
-      }
-
-      final CompletableFuture<Void> connectionFuture = new CompletableFuture<>();
-      eagerlyConnect(
-          currentState, connectionFuture, channel, Instant.now().plusSeconds(timeoutSeconds));
-
-      try {
-        connectionFuture.get(timeoutSeconds, TimeUnit.SECONDS);
-      } catch (TimeoutException e) {
-        connectionFuture.cancel(true);
-        throw new ConnectionFailedException(
-            "Failed to connect within the allotted time of " + timeoutSeconds + " seconds.", e);
-      } catch (InterruptedException | ExecutionException e) {
-        connectionFuture.cancel(true);
-        throw new ConnectionFailedException(
-            "Error while waiting for eager connection to establish.", e);
-      }
-    }
-  }
-
-  private static void eagerlyConnect(
-      final ConnectivityState lastObservedState,
-      final CompletableFuture<Void> connectionFuture,
-      final ManagedChannel channel,
-      final Instant timeout) {
-
-    if (Instant.now().toEpochMilli() > timeout.toEpochMilli()) {
-      connectionFuture.completeExceptionally(
-          new ConnectionFailedException("Connection failed: Deadline exceeded"));
-      return;
-    }
-    channel.notifyWhenStateChanged(
-        lastObservedState,
-        () -> {
-          final ConnectivityState currentState = channel.getState(false /* tryToConnect */);
-          switch (currentState) {
-            case READY:
-              LOGGER.debug("Connected to Momento's server! Happy Caching!");
-              connectionFuture.complete(null);
-              return;
-            case IDLE:
-              LOGGER.debug("State is idle; waiting to transition to CONNECTING");
-              eagerlyConnect(currentState, connectionFuture, channel, timeout);
-              break;
-            case CONNECTING:
-              LOGGER.debug("State transitioned to CONNECTING; waiting to get READY");
-              eagerlyConnect(currentState, connectionFuture, channel, timeout);
-              break;
-            default:
-              LOGGER.debug(
-                  "Unexpected state encountered {}. Contact Momento if this persists.",
-                  currentState.name());
-              connectionFuture.completeExceptionally(
-                  new ConnectionFailedException(
-                      "Connection failed due to unexpected state: " + currentState));
-              break;
-          }
-        });
-  }
-
-  private ManagedChannel setupChannel(
-      CredentialProvider credentialProvider, StorageConfiguration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
-
-    // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder);
-
-    final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "store"));
-    channelBuilder.intercept(clientInterceptors);
-
-    return channelBuilder.build();
-  }
-
-  /**
-   * Returns a stub with appropriate deadlines.
-   *
-   * <p>Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
-   * When a deadline is set on a stub, it simply means that once the stub is created it must be used
-   * before the deadline expires. Hence, the stub returned from here should never be cached and the
-   * safest behavior is for clients to request a new stub each time.
-   *
-   * <p><a href="https://github.com/grpc/grpc-java/issues/1495">more information</a>
-   */
-  StoreGrpc.StoreFutureStub getStub() {
-    int nextStubIndex = this.nextStubIndex.getAndIncrement();
-    return futureStubs
-        .get(nextStubIndex % this.numGrpcChannels)
-        .withDeadlineAfter(deadline.toMillis(), TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void close() {
-    for (ManagedChannel channel : channels) {
-      channel.shutdown();
-    }
+      @Nonnull CredentialProvider credentialProvider,
+      @Nonnull IGrpcConfiguration grpcConfiguration) {
+    super(
+        AbstractGrpcStubsManager.Config.create(
+            "store",
+            credentialProvider.getCacheEndpoint(),
+            credentialProvider.getAuthToken(),
+            grpcConfiguration,
+            StoreGrpc::newFutureStub));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/GrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/GrpcConfiguration.java
@@ -94,12 +94,7 @@ public class GrpcConfiguration implements IGrpcConfiguration {
     return deadline;
   }
 
-  /**
-   * Copy constructor that updates the deadline.
-   *
-   * @param deadline The new deadline.
-   * @return The updated GrpcConfiguration.
-   */
+  @Override
   public GrpcConfiguration withDeadline(Duration deadline) {
     return new GrpcConfiguration(
         deadline,

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/IGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/IGrpcConfiguration.java
@@ -13,6 +13,14 @@ public interface IGrpcConfiguration {
   Duration getDeadline();
 
   /**
+   * Copy constructor that updates the deadline.
+   *
+   * @param deadline The new deadline.
+   * @return The updated configuration.
+   */
+  IGrpcConfiguration withDeadline(Duration deadline);
+
+  /**
    * The minimum number of gRPC channels to keep open at any given time.
    *
    * @return the minimum number of gRPC channels.

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/leaderboard/LeaderboardGrpcConfiguration.java
@@ -72,12 +72,7 @@ public class LeaderboardGrpcConfiguration implements IGrpcConfiguration {
     return deadline;
   }
 
-  /**
-   * Copy constructor that updates the deadline.
-   *
-   * @param deadline The new deadline.
-   * @return The updated LeaderboardGrpcConfiguration.
-   */
+  @Override
   public LeaderboardGrpcConfiguration withDeadline(Duration deadline) {
     return new LeaderboardGrpcConfiguration(
         deadline,

--- a/momento-sdk/src/main/java/momento/sdk/config/transport/storage/StorageGrpcConfiguration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/transport/storage/StorageGrpcConfiguration.java
@@ -95,12 +95,7 @@ public class StorageGrpcConfiguration implements IGrpcConfiguration {
     return deadline;
   }
 
-  /**
-   * Copy constructor that updates the deadline.
-   *
-   * @param deadline The new deadline.
-   * @return The updated StorageGrpcConfiguration.
-   */
+  @Override
   public StorageGrpcConfiguration withDeadline(Duration deadline) {
     return new StorageGrpcConfiguration(
         deadline,


### PR DESCRIPTION
Create an abstract gRPC stubs manager that the existing stubs managers can descend from. Almost all the logic in the stubs managers is shared, so it should go into one place. Retries and the read concern header are moved into the common logic, even though they are only used in the cache data manager, to make them easier to use by other managers in the future.

Make the close method in the stubs managers await termination of the gRPC channels and retry executors. This ensures they will try to complete any in-flight calls before shutting down.

Propagate the thread interruption flag in the base internal client close method to make it work better with other close methods.

Add withDeadline to the grpc configuration interface so it can be used in the stubs managers.