### PR TITLE
feat: implement momento local provider for momento local

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
+import momento.sdk.auth.MomentoLocalProvider;
 import momento.sdk.config.Configuration;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.internal.GrpcChannelOptions;
@@ -37,15 +38,23 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
 
   private static ManagedChannel setupConnection(
       CredentialProvider credentialProvider, Configuration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
+      final NettyChannelBuilder channelBuilder;
+
+    if (credentialProvider.isControlEndpointSecure()) {
+      channelBuilder =
+              NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
+    } else {
+      int port = ((MomentoLocalProvider) credentialProvider).getPort();
+      channelBuilder =
+              NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), port);
+    }
 
     // Override grpc config to disable keepalive for control clients
     final GrpcConfiguration controlConfig =
         configuration.getTransportStrategy().getGrpcConfiguration().withKeepAliveDisabled();
 
     // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(controlConfig, channelBuilder);
+    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(controlConfig, channelBuilder, credentialProvider.isControlEndpointSecure());
 
     final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
     clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache"));

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -47,9 +47,7 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        controlConfig,
-        channelBuilder,
-        credentialProvider.isEndpointSecure(credentialProvider.getControlEndpoint()));
+        controlConfig, channelBuilder, credentialProvider.isEndpointSecure());
 
     final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
     clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache"));

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -38,15 +38,14 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
 
   private static ManagedChannel setupConnection(
       CredentialProvider credentialProvider, Configuration configuration) {
-      final NettyChannelBuilder channelBuilder;
+    final NettyChannelBuilder channelBuilder;
 
     if (credentialProvider.isControlEndpointSecure()) {
-      channelBuilder =
-              NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
+      channelBuilder = NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
     } else {
       int port = ((MomentoLocalProvider) credentialProvider).getPort();
       channelBuilder =
-              NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), port);
+          NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), port);
     }
 
     // Override grpc config to disable keepalive for control clients
@@ -54,7 +53,8 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
         configuration.getTransportStrategy().getGrpcConfiguration().withKeepAliveDisabled();
 
     // set additional channel options (message size, keepalive, auth, etc)
-    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(controlConfig, channelBuilder, credentialProvider.isControlEndpointSecure());
+    GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
+        controlConfig, channelBuilder, credentialProvider.isControlEndpointSecure());
 
     final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
     clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache"));

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -47,7 +47,7 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        controlConfig, channelBuilder, credentialProvider.isControlEndpointSecure());
+        controlConfig, channelBuilder, credentialProvider.isEndpointSecure());
 
     final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
     clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache"));

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -47,7 +47,9 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        controlConfig, channelBuilder, credentialProvider.isEndpointSecure());
+        controlConfig,
+        channelBuilder,
+        credentialProvider.isEndpointSecure(credentialProvider.getControlEndpoint()));
 
     final List<ClientInterceptor> clientInterceptors = new ArrayList<>();
     clientInterceptors.add(new UserHeaderInterceptor(credentialProvider.getAuthToken(), "cache"));

--- a/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsControlGrpcStubsManager.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import momento.sdk.auth.CredentialProvider;
-import momento.sdk.auth.MomentoLocalProvider;
 import momento.sdk.config.Configuration;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.internal.GrpcChannelOptions;
@@ -38,15 +37,9 @@ final class ScsControlGrpcStubsManager implements AutoCloseable {
 
   private static ManagedChannel setupConnection(
       CredentialProvider credentialProvider, Configuration configuration) {
-    final NettyChannelBuilder channelBuilder;
-
-    if (credentialProvider.isControlEndpointSecure()) {
-      channelBuilder = NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), 443);
-    } else {
-      int port = ((MomentoLocalProvider) credentialProvider).getPort();
-      channelBuilder =
-          NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), port);
-    }
+    int port = credentialProvider.getPort();
+    final NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forAddress(credentialProvider.getControlEndpoint(), port);
 
     // Override grpc config to disable keepalive for control clients
     final GrpcConfiguration controlConfig =

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -190,7 +190,7 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
         configuration.getTransportStrategy().getGrpcConfiguration(),
         channelBuilder,
-        credentialProvider.isCacheEndpointSecure());
+        credentialProvider.isEndpointSecure());
 
     final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
     if (configuration.getReadConcern() != ReadConcern.BALANCED) {

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -190,7 +190,7 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
         configuration.getTransportStrategy().getGrpcConfiguration(),
         channelBuilder,
-        credentialProvider.isEndpointSecure());
+        credentialProvider.isEndpointSecure(credentialProvider.getCacheEndpoint()));
 
     final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
     if (configuration.getReadConcern() != ReadConcern.BALANCED) {

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -182,18 +182,18 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
 
   private ManagedChannel setupChannel(
       CredentialProvider credentialProvider, Configuration configuration) {
-      final NettyChannelBuilder channelBuilder;
+    final NettyChannelBuilder channelBuilder;
     if (credentialProvider.isCacheEndpointSecure()) {
-      channelBuilder =
-              NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
+      channelBuilder = NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
     } else {
-      channelBuilder =
-              NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 8080);
+      channelBuilder = NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 8080);
     }
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder, credentialProvider.isCacheEndpointSecure());
+        configuration.getTransportStrategy().getGrpcConfiguration(),
+        channelBuilder,
+        credentialProvider.isCacheEndpointSecure());
 
     final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
     if (configuration.getReadConcern() != ReadConcern.BALANCED) {

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -190,7 +190,7 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
         configuration.getTransportStrategy().getGrpcConfiguration(),
         channelBuilder,
-        credentialProvider.isEndpointSecure(credentialProvider.getCacheEndpoint()));
+        credentialProvider.isEndpointSecure());
 
     final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
     if (configuration.getReadConcern() != ReadConcern.BALANCED) {

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -182,12 +182,9 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
 
   private ManagedChannel setupChannel(
       CredentialProvider credentialProvider, Configuration configuration) {
-    final NettyChannelBuilder channelBuilder;
-    if (credentialProvider.isCacheEndpointSecure()) {
-      channelBuilder = NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
-    } else {
-      channelBuilder = NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 8080);
-    }
+    int port = credentialProvider.getPort();
+    final NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), port);
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(

--- a/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsDataGrpcStubsManager.java
@@ -182,12 +182,18 @@ final class ScsDataGrpcStubsManager implements AutoCloseable {
 
   private ManagedChannel setupChannel(
       CredentialProvider credentialProvider, Configuration configuration) {
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
+      final NettyChannelBuilder channelBuilder;
+    if (credentialProvider.isCacheEndpointSecure()) {
+      channelBuilder =
+              NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 443);
+    } else {
+      channelBuilder =
+              NettyChannelBuilder.forAddress(credentialProvider.getCacheEndpoint(), 8080);
+    }
 
     // set additional channel options (message size, keepalive, auth, etc)
     GrpcChannelOptions.applyGrpcConfigurationToChannelBuilder(
-        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder);
+        configuration.getTransportStrategy().getGrpcConfiguration(), channelBuilder, credentialProvider.isCacheEndpointSecure());
 
     final Map<Metadata.Key<String>, String> extraHeaders = new HashMap<>();
     if (configuration.getReadConcern() != ReadConcern.BALANCED) {

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -34,9 +34,7 @@ public abstract class CredentialProvider {
    * @return The Momento local provider.
    */
   public static CredentialProvider forMomentoLocal() {
-    String defaultHostname = "127.0.0.1";
-    int defaultPort = 8080;
-    return new MomentoLocalProvider(defaultHostname, defaultPort);
+    return new MomentoLocalProvider();
   }
 
   /**

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -78,7 +78,7 @@ public abstract class CredentialProvider {
    *
    * @return true if connecting to the endpoint connection with TLS; false if not using TLS
    */
-  public abstract boolean isEndpointSecure(String endpoint);
+  public abstract boolean isEndpointSecure();
 
   /**
    * Gets the port with which the Momento client will connect to the Momento local.

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -30,6 +30,7 @@ public abstract class CredentialProvider {
 
   /**
    * Creates a CredentialProvider using the provided MomentoLocalProviderProps.
+   *
    * @return The Momento local provider.
    */
   public static CredentialProvider forMomentoLocal() {
@@ -55,7 +56,8 @@ public abstract class CredentialProvider {
   /**
    * Gets whether the control plane endpoint connection is secure.
    *
-   * @return true if connecting to the control plane endpoint connection with TLS; false if not using TLS
+   * @return true if connecting to the control plane endpoint connection with TLS; false if not
+   *     using TLS
    */
   public abstract boolean isControlEndpointSecure();
 
@@ -66,11 +68,11 @@ public abstract class CredentialProvider {
    */
   public abstract String getCacheEndpoint();
 
-
   /**
    * Gets whether the data plane endpoint connection is secure.
    *
-   * @return true if connecting to the data plane endpoint connection with TLS; false if not using TLS
+   * @return true if connecting to the data plane endpoint connection with TLS; false if not using
+   *     TLS
    */
   public abstract boolean isCacheEndpointSecure();
 

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -104,7 +104,7 @@ public abstract class CredentialProvider {
   public abstract boolean isTokenEndpointSecure();
 
   /**
-   * Gets the port with which the Momento client will connect to the Momento control plane.
+   * Gets the port with which the Momento client will connect to the Momento local.
    *
    * @return The port.
    */

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -29,6 +29,16 @@ public abstract class CredentialProvider {
   }
 
   /**
+   * Creates a CredentialProvider using the provided MomentoLocalProviderProps.
+   * @return The Momento local provider.
+   */
+  public static CredentialProvider forMomentoLocal() {
+    String defaultHostname = "127.0.0.1";
+    int defaultPort = 8080;
+    return new MomentoLocalProvider(defaultHostname, defaultPort);
+  }
+
+  /**
    * Gets the token used to authenticate to Momento.
    *
    * @return The token.
@@ -43,11 +53,26 @@ public abstract class CredentialProvider {
   public abstract String getControlEndpoint();
 
   /**
+   * Gets whether the control plane endpoint connection is secure.
+   *
+   * @return true if connecting to the control plane endpoint connection with TLS; false if not using TLS
+   */
+  public abstract boolean isControlEndpointSecure();
+
+  /**
    * Gets the endpoint with which the Momento client will connect to the Momento data plane.
    *
    * @return The endpoint.
    */
   public abstract String getCacheEndpoint();
+
+
+  /**
+   * Gets whether the data plane endpoint connection is secure.
+   *
+   * @return true if connecting to the data plane endpoint connection with TLS; false if not using TLS
+   */
+  public abstract boolean isCacheEndpointSecure();
 
   /**
    * Gets the endpoint with which the Momento client will connect to the Momento storage service.
@@ -57,10 +82,24 @@ public abstract class CredentialProvider {
   public abstract String getStorageEndpoint();
 
   /**
+   * Gets whether the storage endpoint connection is secure.
+   *
+   * @return true if connecting to the storage endpoint connection with TLS; false if not using TLS
+   */
+  public abstract boolean isStorageEndpointSecure();
+
+  /**
    * Gets the token endpoint with which the Momento client will connect to the Momento token
    * service.
    *
    * @return The token endpoint.
    */
   public abstract String getTokenEndpoint();
+
+  /**
+   * Gets whether the token endpoint connection is secure.
+   *
+   * @return true if connecting to the token endpoint connection with TLS; false if not using TLS
+   */
+  public abstract boolean isTokenEndpointSecure();
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -102,4 +102,11 @@ public abstract class CredentialProvider {
    * @return true if connecting to the token endpoint connection with TLS; false if not using TLS
    */
   public abstract boolean isTokenEndpointSecure();
+
+  /**
+   * Gets the port with which the Momento client will connect to the Momento control plane.
+   *
+   * @return The port.
+   */
+  public abstract int getPort();
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -52,14 +52,6 @@ public abstract class CredentialProvider {
   public abstract String getControlEndpoint();
 
   /**
-   * Gets whether the control plane endpoint connection is secure.
-   *
-   * @return true if connecting to the control plane endpoint connection with TLS; false if not
-   *     using TLS
-   */
-  public abstract boolean isControlEndpointSecure();
-
-  /**
    * Gets the endpoint with which the Momento client will connect to the Momento data plane.
    *
    * @return The endpoint.
@@ -67,26 +59,11 @@ public abstract class CredentialProvider {
   public abstract String getCacheEndpoint();
 
   /**
-   * Gets whether the data plane endpoint connection is secure.
-   *
-   * @return true if connecting to the data plane endpoint connection with TLS; false if not using
-   *     TLS
-   */
-  public abstract boolean isCacheEndpointSecure();
-
-  /**
    * Gets the endpoint with which the Momento client will connect to the Momento storage service.
    *
    * @return The endpoint.
    */
   public abstract String getStorageEndpoint();
-
-  /**
-   * Gets whether the storage endpoint connection is secure.
-   *
-   * @return true if connecting to the storage endpoint connection with TLS; false if not using TLS
-   */
-  public abstract boolean isStorageEndpointSecure();
 
   /**
    * Gets the token endpoint with which the Momento client will connect to the Momento token
@@ -97,11 +74,12 @@ public abstract class CredentialProvider {
   public abstract String getTokenEndpoint();
 
   /**
-   * Gets whether the token endpoint connection is secure.
+   * Gets whether the endpoint connection is secure.
    *
-   * @return true if connecting to the token endpoint connection with TLS; false if not using TLS
+   * @return true if connecting to the endpoint connection with TLS; false if not
+   *     using TLS
    */
-  public abstract boolean isTokenEndpointSecure();
+  public abstract boolean isEndpointSecure();
 
   /**
    * Gets the port with which the Momento client will connect to the Momento local.

--- a/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/CredentialProvider.java
@@ -76,10 +76,9 @@ public abstract class CredentialProvider {
   /**
    * Gets whether the endpoint connection is secure.
    *
-   * @return true if connecting to the endpoint connection with TLS; false if not
-   *     using TLS
+   * @return true if connecting to the endpoint connection with TLS; false if not using TLS
    */
-  public abstract boolean isEndpointSecure();
+  public abstract boolean isEndpointSecure(String endpoint);
 
   /**
    * Gets the port with which the Momento client will connect to the Momento local.

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -75,12 +75,12 @@ public class MomentoLocalProvider extends CredentialProvider {
     return isSecureConnection(storageEndpoint);
   }
 
-  private boolean isSecureConnection(String endpoint) {
-    return endpoint.startsWith("https://");
-  }
-
-  /** Returns the port used by this credential provider. */
+  @Override
   public int getPort() {
     return port;
+  }
+
+  private boolean isSecureConnection(String endpoint) {
+    return endpoint.startsWith("https://");
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -56,8 +56,8 @@ public class MomentoLocalProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isEndpointSecure() {
-    return isSecureConnection(DEFAULT_HOSTNAME);
+  public boolean isEndpointSecure(String endpoint) {
+    return isSecureConnection(endpoint);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -18,6 +18,14 @@ public class MomentoLocalProvider extends CredentialProvider {
     this.port = port;
   }
 
+  public MomentoLocalProvider(String hostname) {
+    this(hostname, DEFAULT_PORT);
+  }
+
+  public MomentoLocalProvider(int port) {
+    this(DEFAULT_HOSTNAME, port);
+  }
+
   public MomentoLocalProvider() {
     this(DEFAULT_HOSTNAME, DEFAULT_PORT);
   }

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -56,16 +56,12 @@ public class MomentoLocalProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isEndpointSecure(String endpoint) {
-    return isSecureConnection(endpoint);
+  public boolean isEndpointSecure() {
+    return false;
   }
 
   @Override
   public int getPort() {
     return port;
-  }
-
-  private boolean isSecureConnection(String endpoint) {
-    return endpoint.startsWith("https://");
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -1,0 +1,80 @@
+package momento.sdk.auth;
+
+public class MomentoLocalProvider extends CredentialProvider {
+    private final String cacheEndpoint;
+    private final String controlEndpoint;
+    private final String tokenEndpoint;
+    private final String storageEndpoint;
+    private final int port;
+
+    private static final String DEFAULT_HOSTNAME = "127.0.0.1";
+    private static final int DEFAULT_PORT = 8080;
+
+    public MomentoLocalProvider(String hostname, int port) {
+        this.cacheEndpoint = hostname;
+        this.controlEndpoint = hostname;
+        this.tokenEndpoint = hostname;
+        this.storageEndpoint = hostname;
+        this.port = port;
+    }
+
+    public MomentoLocalProvider() {
+        this(DEFAULT_HOSTNAME, DEFAULT_PORT);
+    }
+
+    @Override
+    public String getAuthToken() {
+        return "";
+    }
+
+    @Override
+    public String getCacheEndpoint() {
+        return cacheEndpoint;
+    }
+
+    @Override
+    public boolean isCacheEndpointSecure() {
+        return isSecureConnection(cacheEndpoint);
+    }
+
+    @Override
+    public String getControlEndpoint() {
+        return controlEndpoint;
+    }
+
+    @Override
+    public boolean isControlEndpointSecure() {
+        return isSecureConnection(controlEndpoint);
+    }
+
+    @Override
+    public String getTokenEndpoint() {
+        return tokenEndpoint;
+    }
+
+    @Override
+    public boolean isTokenEndpointSecure() {
+        return isSecureConnection(tokenEndpoint);
+    }
+
+    @Override
+    public String getStorageEndpoint() {
+        return storageEndpoint;
+    }
+
+    @Override
+    public boolean isStorageEndpointSecure() {
+        return isSecureConnection(storageEndpoint);
+    }
+
+    private boolean isSecureConnection(String endpoint) {
+        return endpoint.startsWith("https://");
+    }
+
+    /**
+     * Returns the port used by this credential provider.
+     */
+    public int getPort() {
+        return port;
+    }
+}

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -1,80 +1,78 @@
 package momento.sdk.auth;
 
 public class MomentoLocalProvider extends CredentialProvider {
-    private final String cacheEndpoint;
-    private final String controlEndpoint;
-    private final String tokenEndpoint;
-    private final String storageEndpoint;
-    private final int port;
+  private final String cacheEndpoint;
+  private final String controlEndpoint;
+  private final String tokenEndpoint;
+  private final String storageEndpoint;
+  private final int port;
 
-    private static final String DEFAULT_HOSTNAME = "127.0.0.1";
-    private static final int DEFAULT_PORT = 8080;
+  private static final String DEFAULT_HOSTNAME = "127.0.0.1";
+  private static final int DEFAULT_PORT = 8080;
 
-    public MomentoLocalProvider(String hostname, int port) {
-        this.cacheEndpoint = hostname;
-        this.controlEndpoint = hostname;
-        this.tokenEndpoint = hostname;
-        this.storageEndpoint = hostname;
-        this.port = port;
-    }
+  public MomentoLocalProvider(String hostname, int port) {
+    this.cacheEndpoint = hostname;
+    this.controlEndpoint = hostname;
+    this.tokenEndpoint = hostname;
+    this.storageEndpoint = hostname;
+    this.port = port;
+  }
 
-    public MomentoLocalProvider() {
-        this(DEFAULT_HOSTNAME, DEFAULT_PORT);
-    }
+  public MomentoLocalProvider() {
+    this(DEFAULT_HOSTNAME, DEFAULT_PORT);
+  }
 
-    @Override
-    public String getAuthToken() {
-        return "";
-    }
+  @Override
+  public String getAuthToken() {
+    return "";
+  }
 
-    @Override
-    public String getCacheEndpoint() {
-        return cacheEndpoint;
-    }
+  @Override
+  public String getCacheEndpoint() {
+    return cacheEndpoint;
+  }
 
-    @Override
-    public boolean isCacheEndpointSecure() {
-        return isSecureConnection(cacheEndpoint);
-    }
+  @Override
+  public boolean isCacheEndpointSecure() {
+    return isSecureConnection(cacheEndpoint);
+  }
 
-    @Override
-    public String getControlEndpoint() {
-        return controlEndpoint;
-    }
+  @Override
+  public String getControlEndpoint() {
+    return controlEndpoint;
+  }
 
-    @Override
-    public boolean isControlEndpointSecure() {
-        return isSecureConnection(controlEndpoint);
-    }
+  @Override
+  public boolean isControlEndpointSecure() {
+    return isSecureConnection(controlEndpoint);
+  }
 
-    @Override
-    public String getTokenEndpoint() {
-        return tokenEndpoint;
-    }
+  @Override
+  public String getTokenEndpoint() {
+    return tokenEndpoint;
+  }
 
-    @Override
-    public boolean isTokenEndpointSecure() {
-        return isSecureConnection(tokenEndpoint);
-    }
+  @Override
+  public boolean isTokenEndpointSecure() {
+    return isSecureConnection(tokenEndpoint);
+  }
 
-    @Override
-    public String getStorageEndpoint() {
-        return storageEndpoint;
-    }
+  @Override
+  public String getStorageEndpoint() {
+    return storageEndpoint;
+  }
 
-    @Override
-    public boolean isStorageEndpointSecure() {
-        return isSecureConnection(storageEndpoint);
-    }
+  @Override
+  public boolean isStorageEndpointSecure() {
+    return isSecureConnection(storageEndpoint);
+  }
 
-    private boolean isSecureConnection(String endpoint) {
-        return endpoint.startsWith("https://");
-    }
+  private boolean isSecureConnection(String endpoint) {
+    return endpoint.startsWith("https://");
+  }
 
-    /**
-     * Returns the port used by this credential provider.
-     */
-    public int getPort() {
-        return port;
-    }
+  /** Returns the port used by this credential provider. */
+  public int getPort() {
+    return port;
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/MomentoLocalProvider.java
@@ -41,18 +41,8 @@ public class MomentoLocalProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isCacheEndpointSecure() {
-    return isSecureConnection(cacheEndpoint);
-  }
-
-  @Override
   public String getControlEndpoint() {
     return controlEndpoint;
-  }
-
-  @Override
-  public boolean isControlEndpointSecure() {
-    return isSecureConnection(controlEndpoint);
   }
 
   @Override
@@ -61,18 +51,13 @@ public class MomentoLocalProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isTokenEndpointSecure() {
-    return isSecureConnection(tokenEndpoint);
-  }
-
-  @Override
   public String getStorageEndpoint() {
     return storageEndpoint;
   }
 
   @Override
-  public boolean isStorageEndpointSecure() {
-    return isSecureConnection(storageEndpoint);
+  public boolean isEndpointSecure() {
+    return isSecureConnection(DEFAULT_HOSTNAME);
   }
 
   @Override

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -189,4 +189,9 @@ public class StringCredentialProvider extends CredentialProvider {
   public boolean isTokenEndpointSecure() {
     return true;
   }
+
+  @Override
+  public int getPort() {
+    return 443;
+  }
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -167,7 +167,7 @@ public class StringCredentialProvider extends CredentialProvider {
 
   @Override
   public boolean isCacheEndpointSecure() {
-      return true;
+    return true;
   }
 
   @Override
@@ -187,6 +187,6 @@ public class StringCredentialProvider extends CredentialProvider {
 
   @Override
   public boolean isTokenEndpointSecure() {
-      return true;
+    return true;
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -171,7 +171,7 @@ public class StringCredentialProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isEndpointSecure() {
+  public boolean isEndpointSecure(String endpoint) {
     return true;
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -171,7 +171,7 @@ public class StringCredentialProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isEndpointSecure(String endpoint) {
+  public boolean isEndpointSecure() {
     return true;
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -156,8 +156,18 @@ public class StringCredentialProvider extends CredentialProvider {
   }
 
   @Override
+  public boolean isControlEndpointSecure() {
+    return true;
+  }
+
+  @Override
   public String getCacheEndpoint() {
     return cacheEndpoint;
+  }
+
+  @Override
+  public boolean isCacheEndpointSecure() {
+      return true;
   }
 
   @Override
@@ -166,7 +176,17 @@ public class StringCredentialProvider extends CredentialProvider {
   }
 
   @Override
+  public boolean isStorageEndpointSecure() {
+    return true;
+  }
+
+  @Override
   public String getTokenEndpoint() {
     return tokenEndpoint;
+  }
+
+  @Override
+  public boolean isTokenEndpointSecure() {
+      return true;
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
+++ b/momento-sdk/src/main/java/momento/sdk/auth/StringCredentialProvider.java
@@ -156,18 +156,8 @@ public class StringCredentialProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isControlEndpointSecure() {
-    return true;
-  }
-
-  @Override
   public String getCacheEndpoint() {
     return cacheEndpoint;
-  }
-
-  @Override
-  public boolean isCacheEndpointSecure() {
-    return true;
   }
 
   @Override
@@ -176,17 +166,12 @@ public class StringCredentialProvider extends CredentialProvider {
   }
 
   @Override
-  public boolean isStorageEndpointSecure() {
-    return true;
-  }
-
-  @Override
   public String getTokenEndpoint() {
     return tokenEndpoint;
   }
 
   @Override
-  public boolean isTokenEndpointSecure() {
+  public boolean isEndpointSecure() {
     return true;
   }
 

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -34,6 +34,8 @@ public class GrpcChannelOptions {
       channelBuilder.disableRetry();
     } else {
       channelBuilder.usePlaintext();
+      channelBuilder.enableRetry();
+      channelBuilder.maxRetryAttempts(3);
     }
 
     grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -34,8 +34,6 @@ public class GrpcChannelOptions {
       channelBuilder.disableRetry();
     } else {
       channelBuilder.usePlaintext();
-      channelBuilder.enableRetry();
-      channelBuilder.maxRetryAttempts(3);
     }
 
     grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -23,9 +23,20 @@ public class GrpcChannelOptions {
       Duration.ofMillis(DEFAULT_KEEPALIVE_TIMEOUT_MS);
 
   public static void applyGrpcConfigurationToChannelBuilder(
-      IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
-    channelBuilder.useTransportSecurity();
-    channelBuilder.disableRetry();
+          IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
+    applyGrpcConfigurationToChannelBuilder(grpcConfig, channelBuilder, true);
+  }
+
+  public static void applyGrpcConfigurationToChannelBuilder(
+      IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder, boolean isSecure) {
+    if (isSecure) {
+      channelBuilder.useTransportSecurity();
+      channelBuilder.disableRetry();
+    } else {
+      channelBuilder.usePlaintext();
+      channelBuilder.enableRetry();
+      channelBuilder.maxRetryAttempts(3);
+    }
 
     grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);
 

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -29,9 +29,10 @@ public class GrpcChannelOptions {
 
   public static void applyGrpcConfigurationToChannelBuilder(
       IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder, boolean isSecure) {
+    channelBuilder.disableRetry();
+
     if (isSecure) {
       channelBuilder.useTransportSecurity();
-      channelBuilder.disableRetry();
     } else {
       channelBuilder.usePlaintext();
     }

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -23,7 +23,7 @@ public class GrpcChannelOptions {
       Duration.ofMillis(DEFAULT_KEEPALIVE_TIMEOUT_MS);
 
   public static void applyGrpcConfigurationToChannelBuilder(
-          IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
+      IGrpcConfiguration grpcConfig, NettyChannelBuilder channelBuilder) {
     applyGrpcConfigurationToChannelBuilder(grpcConfig, channelBuilder, true);
   }
 
@@ -35,7 +35,6 @@ public class GrpcChannelOptions {
     } else {
       channelBuilder.usePlaintext();
       channelBuilder.enableRetry();
-      channelBuilder.maxRetryAttempts(3);
     }
 
     grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);

--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -34,7 +34,6 @@ public class GrpcChannelOptions {
       channelBuilder.disableRetry();
     } else {
       channelBuilder.usePlaintext();
-      channelBuilder.enableRetry();
     }
 
     grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);

--- a/momento-sdk/src/test/java/momento/sdk/auth/MomentoLocalProviderTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/auth/MomentoLocalProviderTest.java
@@ -10,17 +10,15 @@ class MomentoLocalProviderTest {
 
   @Test
   void testDefaultConstructor() {
+    String hostname = "127.0.0.1";
     MomentoLocalProvider provider = new MomentoLocalProvider();
 
-    assertEquals("127.0.0.1", provider.getCacheEndpoint());
-    assertEquals("127.0.0.1", provider.getControlEndpoint());
-    assertEquals("127.0.0.1", provider.getTokenEndpoint());
-    assertEquals("127.0.0.1", provider.getStorageEndpoint());
+    assertEquals(hostname, provider.getCacheEndpoint());
+    assertEquals(hostname, provider.getControlEndpoint());
+    assertEquals(hostname, provider.getTokenEndpoint());
+    assertEquals(hostname, provider.getStorageEndpoint());
     assertEquals(8080, provider.getPort());
-    assertFalse(provider.isCacheEndpointSecure());
-    assertFalse(provider.isControlEndpointSecure());
-    assertFalse(provider.isTokenEndpointSecure());
-    assertFalse(provider.isStorageEndpointSecure());
+    assertFalse(provider.isEndpointSecure(hostname));
     assertEquals("", provider.getAuthToken());
   }
 
@@ -33,7 +31,7 @@ class MomentoLocalProviderTest {
     assertEquals("localhost", provider.getTokenEndpoint());
     assertEquals("localhost", provider.getStorageEndpoint());
     assertEquals(9090, provider.getPort());
-    assertFalse(provider.isCacheEndpointSecure());
+    assertFalse(provider.isEndpointSecure("localhost"));
   }
 
   @Test
@@ -60,21 +58,15 @@ class MomentoLocalProviderTest {
 
   @Test
   void testSecureEndpointDetection() {
-    MomentoLocalProvider provider = new MomentoLocalProvider("https://secure-host");
-
-    assertTrue(provider.isCacheEndpointSecure());
-    assertTrue(provider.isControlEndpointSecure());
-    assertTrue(provider.isTokenEndpointSecure());
-    assertTrue(provider.isStorageEndpointSecure());
+    String secureHost = "https://secure-host";
+    MomentoLocalProvider provider = new MomentoLocalProvider(secureHost);
+    assertTrue(provider.isEndpointSecure(secureHost));
   }
 
   @Test
   void testInsecureEndpointDetection() {
-    MomentoLocalProvider provider = new MomentoLocalProvider("http://insecure-host");
-
-    assertFalse(provider.isCacheEndpointSecure());
-    assertFalse(provider.isControlEndpointSecure());
-    assertFalse(provider.isTokenEndpointSecure());
-    assertFalse(provider.isStorageEndpointSecure());
+    String insecureHost = "http://insecure-host";
+    MomentoLocalProvider provider = new MomentoLocalProvider(insecureHost);
+    assertFalse(provider.isEndpointSecure(insecureHost));
   }
 }

--- a/momento-sdk/src/test/java/momento/sdk/auth/MomentoLocalProviderTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/auth/MomentoLocalProviderTest.java
@@ -1,0 +1,80 @@
+package momento.sdk.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MomentoLocalProviderTest {
+
+  @Test
+  void testDefaultConstructor() {
+    MomentoLocalProvider provider = new MomentoLocalProvider();
+
+    assertEquals("127.0.0.1", provider.getCacheEndpoint());
+    assertEquals("127.0.0.1", provider.getControlEndpoint());
+    assertEquals("127.0.0.1", provider.getTokenEndpoint());
+    assertEquals("127.0.0.1", provider.getStorageEndpoint());
+    assertEquals(8080, provider.getPort());
+    assertFalse(provider.isCacheEndpointSecure());
+    assertFalse(provider.isControlEndpointSecure());
+    assertFalse(provider.isTokenEndpointSecure());
+    assertFalse(provider.isStorageEndpointSecure());
+    assertEquals("", provider.getAuthToken());
+  }
+
+  @Test
+  void testConstructorWithHostnameAndPort() {
+    MomentoLocalProvider provider = new MomentoLocalProvider("localhost", 9090);
+
+    assertEquals("localhost", provider.getCacheEndpoint());
+    assertEquals("localhost", provider.getControlEndpoint());
+    assertEquals("localhost", provider.getTokenEndpoint());
+    assertEquals("localhost", provider.getStorageEndpoint());
+    assertEquals(9090, provider.getPort());
+    assertFalse(provider.isCacheEndpointSecure());
+  }
+
+  @Test
+  void testConstructorWithHostnameOnly() {
+    MomentoLocalProvider provider = new MomentoLocalProvider("custom-host");
+
+    assertEquals("custom-host", provider.getCacheEndpoint());
+    assertEquals("custom-host", provider.getControlEndpoint());
+    assertEquals("custom-host", provider.getTokenEndpoint());
+    assertEquals("custom-host", provider.getStorageEndpoint());
+    assertEquals(8080, provider.getPort());
+  }
+
+  @Test
+  void testConstructorWithPortOnly() {
+    MomentoLocalProvider provider = new MomentoLocalProvider(7070);
+
+    assertEquals("127.0.0.1", provider.getCacheEndpoint());
+    assertEquals("127.0.0.1", provider.getControlEndpoint());
+    assertEquals("127.0.0.1", provider.getTokenEndpoint());
+    assertEquals("127.0.0.1", provider.getStorageEndpoint());
+    assertEquals(7070, provider.getPort());
+  }
+
+  @Test
+  void testSecureEndpointDetection() {
+    MomentoLocalProvider provider = new MomentoLocalProvider("https://secure-host");
+
+    assertTrue(provider.isCacheEndpointSecure());
+    assertTrue(provider.isControlEndpointSecure());
+    assertTrue(provider.isTokenEndpointSecure());
+    assertTrue(provider.isStorageEndpointSecure());
+  }
+
+  @Test
+  void testInsecureEndpointDetection() {
+    MomentoLocalProvider provider = new MomentoLocalProvider("http://insecure-host");
+
+    assertFalse(provider.isCacheEndpointSecure());
+    assertFalse(provider.isControlEndpointSecure());
+    assertFalse(provider.isTokenEndpointSecure());
+    assertFalse(provider.isStorageEndpointSecure());
+  }
+}

--- a/momento-sdk/src/test/java/momento/sdk/auth/MomentoLocalProviderTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/auth/MomentoLocalProviderTest.java
@@ -2,7 +2,6 @@ package momento.sdk.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +17,7 @@ class MomentoLocalProviderTest {
     assertEquals(hostname, provider.getTokenEndpoint());
     assertEquals(hostname, provider.getStorageEndpoint());
     assertEquals(8080, provider.getPort());
-    assertFalse(provider.isEndpointSecure(hostname));
+    assertFalse(provider.isEndpointSecure());
     assertEquals("", provider.getAuthToken());
   }
 
@@ -31,7 +30,7 @@ class MomentoLocalProviderTest {
     assertEquals("localhost", provider.getTokenEndpoint());
     assertEquals("localhost", provider.getStorageEndpoint());
     assertEquals(9090, provider.getPort());
-    assertFalse(provider.isEndpointSecure("localhost"));
+    assertFalse(provider.isEndpointSecure());
   }
 
   @Test
@@ -57,16 +56,9 @@ class MomentoLocalProviderTest {
   }
 
   @Test
-  void testSecureEndpointDetection() {
-    String secureHost = "https://secure-host";
-    MomentoLocalProvider provider = new MomentoLocalProvider(secureHost);
-    assertTrue(provider.isEndpointSecure(secureHost));
-  }
-
-  @Test
   void testInsecureEndpointDetection() {
     String insecureHost = "http://insecure-host";
     MomentoLocalProvider provider = new MomentoLocalProvider(insecureHost);
-    assertFalse(provider.isEndpointSecure(insecureHost));
+    assertFalse(provider.isEndpointSecure());
   }
 }


### PR DESCRIPTION
## PR Description:
- Implement `MomentoLocalProvider`for momento local. 

## Testing:


<details close>
  <summary>Tested using the following Java program:</summary>
  
```
public class Program {
  public static void main(String[] args) {
    String cacheName = "test-cache-java";
    CredentialProvider credentialProvider = new MomentoLocalProvider("0.0.0.0", 8080);

    Configuration configuration = Configurations.Laptop.latest();
    CacheClient cacheClient =
        new CacheClientBuilder(credentialProvider, configuration, Duration.ofMinutes(1)).build();

    CacheCreateResponse createResponse = cacheClient.createCache(cacheName).join();
    if (createResponse instanceof CacheCreateResponse.Success) {
      System.out.println("Cache created successfully");
    } else {
      System.out.println("Failed to create cache" + createResponse.toString());
      CacheCreateResponse.Error error = (CacheCreateResponse.Error) createResponse;
      System.out.println("Failed to create cache: " + error.getErrorCode());
    }

    SetResponse setResponse = cacheClient.set(cacheName, "key", "value").join();
    if (setResponse instanceof SetResponse.Success) {
      System.out.println("Set key successfully");
    } else {
      System.out.println("Failed to set key" + setResponse.toString());
      SetResponse.Error error = (SetResponse.Error) setResponse;
      System.out.println("Failed to set key: " + error.getErrorCode());
      cacheClient.close();
    }

    GetResponse getResponse = cacheClient.get(cacheName, "key").join();
    if (getResponse instanceof GetResponse.Hit) {
      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
      System.out.println("Got value: " + hit.value());
    } else {
      System.out.println("Failed to get key" + getResponse.toString());
    }
  }
}
```

</details>

**Result from The Java test:**
```
> Task :momento-sdk:momento.sdk.Program.main()
Cache created successfully
Set key successfully
Got value: value
```

**Result from momento-local:**
```
[2025-01-21T20:34:36Z INFO  momento_local] Server listening on 0.0.0.0:8080
[2025-01-21T20:34:43Z INFO  momento_local::cache::service::local_cache_service] Processing Set request for cache: test-cache-java and key: [107, 101, 121]
[2025-01-21T20:34:43Z INFO  momento_local::cache::service::local_cache_service] Set request processed successfully for cache: test-cache-java
[2025-01-21T20:34:43Z INFO  momento_local::cache::service::local_cache_service] Processing Get request for cache: test-cache-java and key: [107, 101, 121]
[2025-01-21T20:34:43Z DEBUG momento_local::cache::service::local_cache_service] Cache hit for cache: test-cache-java and key: [107, 101, 121]
```

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1104
