### PR TITLE
feat: add middleware

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/retry/BaseCacheRetryTestClass.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/BaseCacheRetryTestClass.java
@@ -1,0 +1,68 @@
+package momento.sdk.retry;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.time.Duration;
+import java.util.UUID;
+import momento.sdk.CacheClient;
+import momento.sdk.auth.CredentialProvider;
+import momento.sdk.config.Configuration;
+import momento.sdk.config.Configurations;
+import momento.sdk.responses.cache.control.CacheCreateResponse;
+import momento.sdk.responses.cache.control.CacheDeleteResponse;
+import momento.sdk.retry.utils.TestRetryMetricsCollector;
+import momento.sdk.retry.utils.TestRetryMetricsMiddleware;
+import momento.sdk.retry.utils.TestRetryMetricsMiddlewareArgs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+
+public class BaseCacheRetryTestClass {
+  protected static final Duration DEFAULT_TTL_SECONDS = Duration.ofSeconds(60);
+  protected static CacheClient cacheClient;
+  protected static CredentialProvider credentialProvider;
+  protected static TestRetryMetricsCollector testRetryMetricsCollector;
+  protected static TestRetryMetricsMiddlewareArgs testRetryMetricsMiddlewareArgs;
+  protected static TestRetryMetricsMiddleware testRetryMetricsMiddleware;
+  protected static Logger logger;
+
+  @BeforeEach
+  void beforeEach() {
+    testRetryMetricsCollector = new TestRetryMetricsCollector();
+    logger = getLogger(BaseCacheRetryTestClass.class);
+    credentialProvider = CredentialProvider.fromEnvVar("MOMENTO_API_KEY");
+    testRetryMetricsMiddlewareArgs =
+        new TestRetryMetricsMiddlewareArgs.Builder(
+                logger, testRetryMetricsCollector, UUID.randomUUID().toString())
+            .build();
+    testRetryMetricsMiddleware = new TestRetryMetricsMiddleware(testRetryMetricsMiddlewareArgs);
+    final Configuration config =
+        Configurations.Laptop.latest().withMiddleware(testRetryMetricsMiddleware);
+    cacheClient = CacheClient.builder(credentialProvider, config, DEFAULT_TTL_SECONDS).build();
+  }
+
+  @AfterEach
+  void afterEach() {
+    cacheClient.close();
+  }
+
+  protected static void ensureTestCacheExists(String cacheName) {
+    CacheCreateResponse response = cacheClient.createCache(cacheName).join();
+    if (response instanceof CacheCreateResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test create cache: " + ((CacheCreateResponse.Error) response).getMessage());
+    }
+  }
+
+  public static void cleanupTestCache(String cacheName) {
+    CacheDeleteResponse response = cacheClient.deleteCache(cacheName).join();
+    if (response instanceof CacheDeleteResponse.Error) {
+      throw new RuntimeException(
+          "Failed to test delete cache: " + ((CacheDeleteResponse.Error) response).getMessage());
+    }
+  }
+
+  public static String testCacheName() {
+    return "java-integration-test-default-" + UUID.randomUUID();
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/TestRetryMetricsCollectorTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/TestRetryMetricsCollectorTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
-import momento.sdk.TestRetryMetricsCollector;
+import momento.sdk.retry.utils.TestRetryMetricsCollector;
 import org.junit.jupiter.api.Test;
 
 public class TestRetryMetricsCollectorTest {

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/TestRetryMetricsMiddlewareTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/TestRetryMetricsMiddlewareTest.java
@@ -1,0 +1,126 @@
+package momento.sdk.retry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.grpc.Metadata;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import momento.sdk.config.middleware.MiddlewareMetadata;
+import momento.sdk.exceptions.MomentoErrorCode;
+import momento.sdk.exceptions.MomentoErrorCodeMetadataConverter;
+import momento.sdk.retry.utils.TestRetryMetricsMiddlewareArgs;
+import momento.sdk.retry.utils.TestRetryMetricsMiddlewareRequestHandler;
+import org.junit.jupiter.api.Test;
+
+public class TestRetryMetricsMiddlewareTest extends BaseCacheRetryTestClass {
+
+  @Test
+  public void shouldAddTimestampOnRequestBodyOnSingleCache() {
+    String cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
+    cacheClient.get(cacheName, "key").join();
+
+    Map<String, Map<MomentoRpcMethod, List<Long>>> allMetrics =
+        testRetryMetricsCollector.getAllMetrics();
+    assertEquals(1, allMetrics.size());
+    assertTrue(allMetrics.containsKey(cacheName));
+    assertTrue(allMetrics.get(cacheName).containsKey(MomentoRpcMethod.GET));
+    assertEquals(1, allMetrics.get(cacheName).get(MomentoRpcMethod.GET).size());
+    cleanupTestCache(cacheName);
+  }
+
+  @Test
+  public void shouldAddTimestampOnRequestBodyOnMultipleCaches() {
+    String cacheName1 = testCacheName();
+    String cacheName2 = testCacheName();
+    ensureTestCacheExists(cacheName1);
+    ensureTestCacheExists(cacheName2);
+    cacheClient.get(cacheName1, "key").join();
+    cacheClient.get(cacheName2, "key").join();
+
+    Map<String, Map<MomentoRpcMethod, List<Long>>> allMetrics =
+        testRetryMetricsCollector.getAllMetrics();
+    assertEquals(2, allMetrics.size());
+    assertTrue(allMetrics.containsKey(cacheName1));
+    assertTrue(allMetrics.containsKey(cacheName2));
+    assertTrue(allMetrics.get(cacheName1).containsKey(MomentoRpcMethod.GET));
+    assertTrue(allMetrics.get(cacheName2).containsKey(MomentoRpcMethod.GET));
+    assertEquals(1, allMetrics.get(cacheName1).get(MomentoRpcMethod.GET).size());
+    assertEquals(1, allMetrics.get(cacheName2).get(MomentoRpcMethod.GET).size());
+    cleanupTestCache(cacheName1);
+    cleanupTestCache(cacheName2);
+  }
+
+  @Test
+  public void shouldAddTimestampOnRequestBodyOnMultipleRequests() {
+    String cacheName = testCacheName();
+    ensureTestCacheExists(cacheName);
+    cacheClient.set(cacheName, "key", "value").join();
+    cacheClient.get(cacheName, "key").join();
+
+    Map<String, Map<MomentoRpcMethod, List<Long>>> allMetrics =
+        testRetryMetricsCollector.getAllMetrics();
+
+    System.out.println(allMetrics);
+
+    assertEquals(1, allMetrics.size());
+    assertTrue(allMetrics.containsKey(cacheName));
+    assertTrue(allMetrics.get(cacheName).containsKey(MomentoRpcMethod.SET));
+    assertTrue(allMetrics.get(cacheName).containsKey(MomentoRpcMethod.GET));
+    assertEquals(1, allMetrics.get(cacheName).get(MomentoRpcMethod.SET).size());
+    assertEquals(1, allMetrics.get(cacheName).get(MomentoRpcMethod.GET).size());
+    cleanupTestCache(cacheName);
+  }
+
+  @Test
+  public void shouldAddMetadataToGrpcMetadata() {
+    String requestId = UUID.randomUUID().toString();
+    String returnError = MomentoErrorCode.SERVER_UNAVAILABLE.name();
+    List<String> errorRpcList = List.of(MomentoRpcMethod.GET.getRequestName());
+    System.out.println(errorRpcList);
+    int errorCount = 3;
+    List<String> delayRpcList = List.of(MomentoRpcMethod.GET.getRequestName());
+    int delayMillis = 100;
+    int delayCount = 1;
+
+    Metadata metadata = new Metadata();
+    MiddlewareMetadata middlewareMetadata = new MiddlewareMetadata(metadata);
+    TestRetryMetricsMiddlewareArgs args =
+        new TestRetryMetricsMiddlewareArgs.Builder(logger, testRetryMetricsCollector, requestId)
+            .returnError(returnError)
+            .errorRpcList(errorRpcList)
+            .errorCount(errorCount)
+            .delayRpcList(delayRpcList)
+            .delayMillis(delayMillis)
+            .delayCount(delayCount)
+            .build();
+
+    TestRetryMetricsMiddlewareRequestHandler handler =
+        new TestRetryMetricsMiddlewareRequestHandler(args);
+    handler.onRequestMetadata(middlewareMetadata);
+
+    String expectedRpcList = MomentoRpcMethodMetadataConverter.convert(MomentoRpcMethod.GET);
+    assertEquals(
+        requestId, metadata.get(Metadata.Key.of("request-id", Metadata.ASCII_STRING_MARSHALLER)));
+    assertEquals(
+        MomentoErrorCodeMetadataConverter.convert(returnError),
+        metadata.get(Metadata.Key.of("return-error", Metadata.ASCII_STRING_MARSHALLER)));
+    assertEquals(
+        expectedRpcList,
+        metadata.get(Metadata.Key.of("error-rpcs", Metadata.ASCII_STRING_MARSHALLER)));
+    assertEquals(
+        String.valueOf(errorCount),
+        metadata.get(Metadata.Key.of("error-count", Metadata.ASCII_STRING_MARSHALLER)));
+    assertEquals(
+        expectedRpcList,
+        metadata.get(Metadata.Key.of("delay-rpcs", Metadata.ASCII_STRING_MARSHALLER)));
+    assertEquals(
+        String.valueOf(delayMillis),
+        metadata.get(Metadata.Key.of("delay-ms", Metadata.ASCII_STRING_MARSHALLER)));
+    assertEquals(
+        String.valueOf(delayCount),
+        metadata.get(Metadata.Key.of("delay-count", Metadata.ASCII_STRING_MARSHALLER)));
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsCollector.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsCollector.java
@@ -1,4 +1,4 @@
-package momento.sdk;
+package momento.sdk.retry.utils;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsMiddleware.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsMiddleware.java
@@ -1,0 +1,18 @@
+package momento.sdk.retry.utils;
+
+import momento.sdk.config.middleware.Middleware;
+import momento.sdk.config.middleware.MiddlewareRequestHandler;
+import momento.sdk.config.middleware.MiddlewareRequestHandlerContext;
+
+public class TestRetryMetricsMiddleware implements Middleware {
+  private final TestRetryMetricsMiddlewareArgs testRetryMetricsMiddlewareArgs;
+
+  public TestRetryMetricsMiddleware(TestRetryMetricsMiddlewareArgs testRetryMetricsMiddlewareArgs) {
+    this.testRetryMetricsMiddlewareArgs = testRetryMetricsMiddlewareArgs;
+  }
+
+  @Override
+  public MiddlewareRequestHandler onNewRequest(MiddlewareRequestHandlerContext context) {
+    return new TestRetryMetricsMiddlewareRequestHandler(testRetryMetricsMiddlewareArgs);
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsMiddlewareArgs.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsMiddlewareArgs.java
@@ -1,0 +1,135 @@
+package momento.sdk.retry.utils;
+
+import java.util.List;
+import org.slf4j.Logger;
+
+public class TestRetryMetricsMiddlewareArgs {
+  private final Logger logger;
+  private final TestRetryMetricsCollector testMetricsCollector;
+  private final String requestId;
+  private final String returnError;
+  private final List<String> errorRpcList;
+  private final Integer errorCount;
+  private final List<String> delayRpcList;
+  private final Integer delayMillis;
+  private final Integer delayCount;
+
+  private TestRetryMetricsMiddlewareArgs(
+      Logger logger,
+      TestRetryMetricsCollector testMetricsCollector,
+      String requestId,
+      String returnError,
+      List<String> errorRpcList,
+      Integer errorCount,
+      List<String> delayRpcList,
+      Integer delayMillis,
+      Integer delayCount) {
+    this.logger = logger;
+    this.testMetricsCollector = testMetricsCollector;
+    this.requestId = requestId;
+    this.returnError = returnError;
+    this.errorRpcList = errorRpcList;
+    this.errorCount = errorCount;
+    this.delayRpcList = delayRpcList;
+    this.delayMillis = delayMillis;
+    this.delayCount = delayCount;
+  }
+
+  public static class Builder {
+    private final Logger logger;
+    private final TestRetryMetricsCollector testMetricsCollector;
+    private final String requestId;
+    private String returnError = null;
+    private List<String> errorRpcList = null;
+    private Integer errorCount = null;
+    private List<String> delayRpcList = null;
+    private Integer delayMillis = null;
+    private Integer delayCount = null;
+
+    public Builder(
+        Logger logger, TestRetryMetricsCollector testMetricsCollector, String requestId) {
+      this.logger = logger;
+      this.testMetricsCollector = testMetricsCollector;
+      this.requestId = requestId;
+    }
+
+    public Builder returnError(String returnError) {
+      this.returnError = returnError;
+      return this;
+    }
+
+    public Builder errorRpcList(List<String> errorRpcList) {
+      this.errorRpcList = errorRpcList;
+      return this;
+    }
+
+    public Builder errorCount(Integer errorCount) {
+      this.errorCount = errorCount;
+      return this;
+    }
+
+    public Builder delayRpcList(List<String> delayRpcList) {
+      this.delayRpcList = delayRpcList;
+      return this;
+    }
+
+    public Builder delayMillis(Integer delayMillis) {
+      this.delayMillis = delayMillis;
+      return this;
+    }
+
+    public Builder delayCount(Integer delayCount) {
+      this.delayCount = delayCount;
+      return this;
+    }
+
+    public TestRetryMetricsMiddlewareArgs build() {
+      return new TestRetryMetricsMiddlewareArgs(
+          logger,
+          testMetricsCollector,
+          requestId,
+          returnError,
+          errorRpcList,
+          errorCount,
+          delayRpcList,
+          delayMillis,
+          delayCount);
+    }
+  }
+
+  public Logger getLogger() {
+    return logger;
+  }
+
+  public TestRetryMetricsCollector getTestMetricsCollector() {
+    return testMetricsCollector;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  public String getReturnError() {
+    return returnError;
+  }
+
+  public List<String> getErrorRpcList() {
+    return errorRpcList;
+  }
+
+  public Integer getErrorCount() {
+    return errorCount;
+  }
+
+  public List<String> getDelayRpcList() {
+    return delayRpcList;
+  }
+
+  public Integer getDelayMillis() {
+    return delayMillis;
+  }
+
+  public Integer getDelayCount() {
+    return delayCount;
+  }
+}

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsMiddlewareRequestHandler.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/utils/TestRetryMetricsMiddlewareRequestHandler.java
@@ -1,0 +1,111 @@
+package momento.sdk.retry.utils;
+
+import io.grpc.Metadata;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import momento.sdk.config.middleware.MiddlewareMessage;
+import momento.sdk.config.middleware.MiddlewareMetadata;
+import momento.sdk.config.middleware.MiddlewareRequestHandler;
+import momento.sdk.config.middleware.MiddlewareStatus;
+import momento.sdk.exceptions.MomentoErrorCodeMetadataConverter;
+import momento.sdk.retry.MomentoRpcMethod;
+import momento.sdk.retry.MomentoRpcMethodMetadataConverter;
+
+public class TestRetryMetricsMiddlewareRequestHandler implements MiddlewareRequestHandler {
+  private String cacheName = null;
+  private final TestRetryMetricsMiddlewareArgs testRetryMetricsMiddlewareArgs;
+
+  public TestRetryMetricsMiddlewareRequestHandler(
+      TestRetryMetricsMiddlewareArgs testRetryMetricsMiddlewareArgs) {
+    this.testRetryMetricsMiddlewareArgs = testRetryMetricsMiddlewareArgs;
+  }
+
+  @Override
+  public CompletableFuture<MiddlewareMetadata> onRequestMetadata(MiddlewareMetadata metadata) {
+    Metadata grpcMetadata = metadata.getGrpcMetadata();
+    setGrpcMetadata(grpcMetadata, "request-id", testRetryMetricsMiddlewareArgs.getRequestId());
+    String returnError = testRetryMetricsMiddlewareArgs.getReturnError();
+    if (returnError != null) {
+      setGrpcMetadata(
+          grpcMetadata, "return-error", MomentoErrorCodeMetadataConverter.convert(returnError));
+    }
+    String errorRpcMethods =
+        (testRetryMetricsMiddlewareArgs.getErrorRpcList() != null)
+            ? testRetryMetricsMiddlewareArgs.getErrorRpcList().stream()
+                .map(
+                    rpcMethod ->
+                        MomentoRpcMethodMetadataConverter.convert(
+                            MomentoRpcMethod.fromString(rpcMethod)))
+                .collect(Collectors.joining(" "))
+            : "";
+    setGrpcMetadata(grpcMetadata, "error-rpcs", errorRpcMethods);
+    String delayRpcMethods =
+        (testRetryMetricsMiddlewareArgs.getDelayRpcList() != null)
+            ? testRetryMetricsMiddlewareArgs.getDelayRpcList().stream()
+                .map(
+                    rpcMethod ->
+                        MomentoRpcMethodMetadataConverter.convert(
+                            MomentoRpcMethod.fromString(rpcMethod)))
+                .collect(Collectors.joining(" "))
+            : "";
+    setGrpcMetadata(grpcMetadata, "delay-rpcs", delayRpcMethods);
+    Integer errorCount = testRetryMetricsMiddlewareArgs.getErrorCount();
+    if (errorCount != null) {
+      setGrpcMetadata(grpcMetadata, "error-count", String.valueOf(errorCount));
+    }
+    Integer delayMillis = testRetryMetricsMiddlewareArgs.getDelayMillis();
+    if (delayMillis != null) {
+      setGrpcMetadata(grpcMetadata, "delay-ms", String.valueOf(delayMillis));
+    }
+    Integer delayCount = testRetryMetricsMiddlewareArgs.getDelayCount();
+    if (delayCount != null) {
+      setGrpcMetadata(grpcMetadata, "delay-count", String.valueOf(delayCount));
+    }
+    String cacheName = grpcMetadata.get(Metadata.Key.of("cache", Metadata.ASCII_STRING_MARSHALLER));
+    if (cacheName != null) {
+      this.cacheName = cacheName;
+    } else {
+      testRetryMetricsMiddlewareArgs.getLogger().debug("No cache name found in metadata.");
+    }
+    return CompletableFuture.completedFuture(metadata);
+  }
+
+  @Override
+  public CompletableFuture<MiddlewareMessage> onRequestBody(MiddlewareMessage request) {
+    String requestType = request.getConstructorName();
+
+    if (cacheName != null) {
+      testRetryMetricsMiddlewareArgs
+          .getTestMetricsCollector()
+          .addTimestamp(
+              cacheName, MomentoRpcMethod.fromString(requestType), System.currentTimeMillis());
+    } else {
+      testRetryMetricsMiddlewareArgs
+          .getLogger()
+          .debug("No cache name available. Timestamp will not be collected.");
+    }
+
+    return CompletableFuture.completedFuture(request);
+  }
+
+  @Override
+  public CompletableFuture<MiddlewareMetadata> onResponseMetadata(MiddlewareMetadata metadata) {
+    return CompletableFuture.completedFuture(metadata);
+  }
+
+  @Override
+  public CompletableFuture<MiddlewareMessage> onResponseBody(MiddlewareMessage response) {
+    return CompletableFuture.completedFuture(response);
+  }
+
+  @Override
+  public CompletableFuture<MiddlewareStatus> onResponseStatus(MiddlewareStatus status) {
+    return CompletableFuture.completedFuture(status);
+  }
+
+  private void setGrpcMetadata(Metadata metadata, String key, String value) {
+    if (value != null) {
+      metadata.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+    }
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/GrpcMiddlewareInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/GrpcMiddlewareInterceptor.java
@@ -134,7 +134,7 @@ final class GrpcMiddlewareInterceptor implements ClientInterceptor {
 
     @Override
     public void onClose(final Status status, final Metadata trailers) {
-      if (status.getCode() == Status.Code.DEADLINE_EXCEEDED) {
+      if (status.getCode() == Status.Code.DEADLINE_EXCEEDED && channel instanceof ManagedChannel) {
         ConnectivityState connectionStatus = ((ManagedChannel) channel).getState(false);
         logger.warn(
             "gRPC Deadline Exceeded: {} - {} | Connection state: {} | Method: {}",

--- a/momento-sdk/src/main/java/momento/sdk/GrpcMiddlewareInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/GrpcMiddlewareInterceptor.java
@@ -1,0 +1,161 @@
+package momento.sdk;
+
+import com.google.protobuf.Message;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ConnectivityState;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import momento.sdk.config.middleware.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class GrpcMiddlewareInterceptor implements ClientInterceptor {
+
+  private final List<MiddlewareRequestHandler> middlewareHandlers;
+  private final Logger logger = LoggerFactory.getLogger(GrpcMiddlewareInterceptor.class);
+
+  public GrpcMiddlewareInterceptor(
+      List<Middleware> middlewares, MiddlewareRequestHandlerContext context) {
+    this.middlewareHandlers =
+        middlewares.stream()
+            .map(middleware -> middleware.onNewRequest(context))
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      final MethodDescriptor<ReqT, RespT> methodDescriptor,
+      final CallOptions callOptions,
+      final Channel channel) {
+
+    final ClientCall<ReqT, RespT> delegateCall = channel.newCall(methodDescriptor, callOptions);
+
+    return new ForwardingClientCall<ReqT, RespT>() {
+      @Override
+      public void start(
+          final ClientCall.Listener<RespT> responseListener, final Metadata metadata) {
+        processMiddleware(
+                new MiddlewareMetadata(metadata),
+                middlewareHandlers,
+                MiddlewareRequestHandler::onRequestMetadata)
+            .thenAccept(
+                updatedMetadata ->
+                    delegateCall.start(
+                        new MiddlewareResponseListener<>(
+                            responseListener, channel, methodDescriptor),
+                        updatedMetadata.getGrpcMetadata()));
+      }
+
+      @Override
+      public void sendMessage(final ReqT message) {
+        if (message instanceof Message) {
+          final Message protoMessage = (Message) message;
+          processMiddleware(
+                  new MiddlewareMessage(protoMessage),
+                  middlewareHandlers,
+                  MiddlewareRequestHandler::onRequestBody)
+              .thenAccept(
+                  updatedMessage -> delegateCall.sendMessage((ReqT) updatedMessage.getMessage()));
+        } else {
+          delegateCall.sendMessage(message);
+        }
+      }
+
+      @Override
+      protected ClientCall<ReqT, RespT> delegate() {
+        return delegateCall;
+      }
+    };
+  }
+
+  private static <T> CompletableFuture<T> processMiddleware(
+      T initial, List<MiddlewareRequestHandler> handlers, final MiddlewareProcessor<T> processor) {
+    CompletableFuture<T> future = CompletableFuture.completedFuture(initial);
+    for (final MiddlewareRequestHandler handler : handlers) {
+      future =
+          future.thenCompose(
+              (Function<T, CompletableFuture<T>>) input -> processor.apply(handler, input));
+    }
+    return future;
+  }
+
+  private class MiddlewareResponseListener<RespT>
+      extends ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT> {
+    private final Channel channel;
+    private final MethodDescriptor<?, ?> methodDescriptor;
+
+    protected MiddlewareResponseListener(
+        ClientCall.Listener<RespT> delegate,
+        Channel channel,
+        MethodDescriptor<?, ?> methodDescriptor) {
+      super(delegate);
+      this.channel = channel;
+      this.methodDescriptor = methodDescriptor;
+    }
+
+    @Override
+    public void onHeaders(final Metadata headers) {
+      processMiddleware(
+              new MiddlewareMetadata(headers),
+              middlewareHandlers,
+              (handler, input) -> handler.onResponseMetadata(input))
+          .thenAccept(
+              updatedHeaders ->
+                  MiddlewareResponseListener.super.onHeaders(updatedHeaders.getGrpcMetadata()));
+    }
+
+    @Override
+    public void onMessage(final RespT message) {
+      if (message instanceof Message) {
+        final Message protoMessage = (Message) message;
+        processMiddleware(
+                new MiddlewareMessage(protoMessage),
+                middlewareHandlers,
+                MiddlewareRequestHandler::onResponseBody)
+            .thenAccept(
+                updatedMessage ->
+                    MiddlewareResponseListener.super.onMessage(
+                        (RespT) updatedMessage.getMessage()));
+      } else {
+        super.onMessage(message);
+      }
+    }
+
+    @Override
+    public void onClose(final Status status, final Metadata trailers) {
+      if (status.getCode() == Status.Code.DEADLINE_EXCEEDED) {
+        ConnectivityState connectionStatus = ((ManagedChannel) channel).getState(false);
+        logger.warn(
+            "gRPC Deadline Exceeded: {} - {} | Connection state: {} | Method: {}",
+            status.getCode(),
+            status.getDescription(),
+            connectionStatus,
+            methodDescriptor.getFullMethodName());
+      }
+
+      processMiddleware(
+              new MiddlewareStatus(status),
+              middlewareHandlers,
+              MiddlewareRequestHandler::onResponseStatus)
+          .thenAccept(
+              updatedStatus ->
+                  MiddlewareResponseListener.super.onClose(
+                      updatedStatus.getGrpcStatus(), trailers));
+    }
+  }
+
+  private interface MiddlewareProcessor<T> {
+    CompletableFuture<T> apply(MiddlewareRequestHandler handler, T input);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/Configuration.java
@@ -1,7 +1,10 @@
 package momento.sdk.config;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
+import momento.sdk.config.middleware.Middleware;
 import momento.sdk.config.transport.GrpcConfiguration;
 import momento.sdk.config.transport.TransportStrategy;
 import momento.sdk.retry.RetryStrategy;
@@ -12,7 +15,7 @@ public class Configuration {
   private final TransportStrategy transportStrategy;
   private final RetryStrategy retryStrategy;
   private final ReadConcern readConcern;
-
+  private final List<Middleware> middlewares;
   /**
    * Creates a new configuration object.
    *
@@ -23,10 +26,12 @@ public class Configuration {
   public Configuration(
       @Nonnull TransportStrategy transportStrategy,
       @Nonnull RetryStrategy retryStrategy,
-      @Nonnull ReadConcern readConcern) {
+      @Nonnull ReadConcern readConcern,
+      @Nonnull List<Middleware> middlewares) {
     this.transportStrategy = transportStrategy;
     this.retryStrategy = retryStrategy;
     this.readConcern = readConcern;
+    this.middlewares = new ArrayList<>(middlewares);
   }
 
   /**
@@ -37,7 +42,7 @@ public class Configuration {
    */
   public Configuration(
       @Nonnull TransportStrategy transportStrategy, @Nonnull RetryStrategy retryStrategy) {
-    this(transportStrategy, retryStrategy, ReadConcern.BALANCED);
+    this(transportStrategy, retryStrategy, ReadConcern.BALANCED, new ArrayList<>());
   }
 
   /**
@@ -56,7 +61,8 @@ public class Configuration {
    * @return a new Configuration with the updated transport strategy
    */
   public Configuration withTransportStrategy(@Nonnull final TransportStrategy transportStrategy) {
-    return new Configuration(transportStrategy, this.retryStrategy, this.readConcern);
+    return new Configuration(
+        transportStrategy, this.retryStrategy, this.readConcern, this.middlewares);
   }
 
   /**
@@ -76,7 +82,8 @@ public class Configuration {
    * @return a new Configuration with the updated retry strategy
    */
   public Configuration withRetryStrategy(@Nonnull final RetryStrategy retryStrategy) {
-    return new Configuration(this.transportStrategy, retryStrategy, this.readConcern);
+    return new Configuration(
+        this.transportStrategy, retryStrategy, this.readConcern, this.middlewares);
   }
 
   /**
@@ -95,7 +102,8 @@ public class Configuration {
    * @return a new Configuration with the updated read concern
    */
   public Configuration withReadConcern(@Nonnull final ReadConcern readConcern) {
-    return new Configuration(this.transportStrategy, this.retryStrategy, readConcern);
+    return new Configuration(
+        this.transportStrategy, this.retryStrategy, readConcern, this.middlewares);
   }
 
   /**
@@ -109,6 +117,29 @@ public class Configuration {
         this.getTransportStrategy().getGrpcConfiguration().withDeadline(timeout);
     final TransportStrategy newTransportStrategy =
         this.getTransportStrategy().withGrpcConfiguration(newGrpcConfiguration);
-    return new Configuration(newTransportStrategy, this.retryStrategy, this.readConcern);
+    return new Configuration(
+        newTransportStrategy, this.retryStrategy, this.readConcern, this.middlewares);
+  }
+
+  /**
+   * Copy constructor that adds the middleware.
+   *
+   * @param middleware The new middleware.
+   * @return a new Configuration with the updated middleware.
+   */
+  public Configuration withMiddleware(@Nonnull final Middleware middleware) {
+    List<Middleware> newMiddlewares = new ArrayList<>(this.middlewares);
+    newMiddlewares.add(middleware);
+    return new Configuration(
+        this.transportStrategy, this.retryStrategy, this.readConcern, newMiddlewares);
+  }
+
+  /**
+   * The middlewares to be applied to the request.
+   *
+   * @return The middlewares
+   */
+  public List<Middleware> getMiddlewares() {
+    return middlewares;
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/config/middleware/Middleware.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/middleware/Middleware.java
@@ -1,0 +1,7 @@
+package momento.sdk.config.middleware;
+
+public interface Middleware {
+  MiddlewareRequestHandler onNewRequest(MiddlewareRequestHandlerContext context);
+
+  default void close() {}
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareMessage.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareMessage.java
@@ -1,0 +1,23 @@
+package momento.sdk.config.middleware;
+
+import com.google.protobuf.Message;
+
+public class MiddlewareMessage {
+  private final Message grpcMessage;
+
+  public MiddlewareMessage(Message message) {
+    this.grpcMessage = message;
+  }
+
+  public int getMessageLength() {
+    return grpcMessage != null ? grpcMessage.toByteArray().length : 0;
+  }
+
+  public String getConstructorName() {
+    return grpcMessage.getClass().getSimpleName();
+  }
+
+  public Message getMessage() {
+    return grpcMessage;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareMetadata.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareMetadata.java
@@ -1,0 +1,15 @@
+package momento.sdk.config.middleware;
+
+import io.grpc.Metadata;
+
+public class MiddlewareMetadata {
+  private final Metadata grpcMetadata;
+
+  public MiddlewareMetadata(Metadata metadata) {
+    this.grpcMetadata = metadata;
+  }
+
+  public Metadata getGrpcMetadata() {
+    return grpcMetadata;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareRequestHandler.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareRequestHandler.java
@@ -1,0 +1,15 @@
+package momento.sdk.config.middleware;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface MiddlewareRequestHandler {
+  CompletableFuture<MiddlewareMetadata> onRequestMetadata(MiddlewareMetadata metadata);
+
+  CompletableFuture<MiddlewareMessage> onRequestBody(MiddlewareMessage request);
+
+  CompletableFuture<MiddlewareMetadata> onResponseMetadata(MiddlewareMetadata metadata);
+
+  CompletableFuture<MiddlewareMessage> onResponseBody(MiddlewareMessage response);
+
+  CompletableFuture<MiddlewareStatus> onResponseStatus(MiddlewareStatus status);
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareRequestHandlerContext.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareRequestHandlerContext.java
@@ -1,0 +1,7 @@
+package momento.sdk.config.middleware;
+
+import java.util.Map;
+
+public interface MiddlewareRequestHandlerContext {
+  Map<String, String> getContext();
+}

--- a/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareStatus.java
+++ b/momento-sdk/src/main/java/momento/sdk/config/middleware/MiddlewareStatus.java
@@ -1,0 +1,19 @@
+package momento.sdk.config.middleware;
+
+import io.grpc.Status;
+
+public class MiddlewareStatus {
+  private final Status grpcStatus;
+
+  public MiddlewareStatus(Status status) {
+    this.grpcStatus = status;
+  }
+
+  public Status.Code getCode() {
+    return grpcStatus.getCode();
+  }
+
+  public Status getGrpcStatus() {
+    return grpcStatus;
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoErrorCodeMetadataConverter.java
+++ b/momento-sdk/src/main/java/momento/sdk/exceptions/MomentoErrorCodeMetadataConverter.java
@@ -1,0 +1,43 @@
+package momento.sdk.exceptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MomentoErrorCodeMetadataConverter {
+  private static final Map<MomentoErrorCode, String> momentoErrorCodeToMetadataMap =
+      new HashMap<>();
+
+  static {
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.INVALID_ARGUMENT_ERROR, "invalid-argument");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.ALREADY_EXISTS_ERROR, "already-exists");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.NOT_FOUND_ERROR, "not-found");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.INTERNAL_SERVER_ERROR, "internal");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.PERMISSION_ERROR, "permission-denied");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.AUTHENTICATION_ERROR, "unauthenticated");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.CANCELLED_ERROR, "cancelled");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.CONNECTION, "unavailable");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.LIMIT_EXCEEDED_ERROR, "deadline-exceeded");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.BAD_REQUEST_ERROR, "invalid-argument");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.TIMEOUT_ERROR, "deadline-exceeded");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.SERVER_UNAVAILABLE, "unavailable");
+    momentoErrorCodeToMetadataMap.put(
+        MomentoErrorCode.CLIENT_RESOURCE_EXHAUSTED, "resource-exhausted");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.UNKNOWN, "unknown");
+    momentoErrorCodeToMetadataMap.put(MomentoErrorCode.UNKNOWN_SERVICE_ERROR, "unknown");
+  }
+
+  /**
+   * Converts a Momento error code to its corresponding metadata type.
+   *
+   * @param errorCode The error code to convert.
+   * @return The corresponding metadata type.
+   * @throws IllegalArgumentException if the error code is not supported.
+   */
+  public static String convert(String errorCode) {
+    MomentoErrorCode momentoErrorCode = MomentoErrorCode.valueOf(errorCode);
+    if (!momentoErrorCodeToMetadataMap.containsKey(momentoErrorCode)) {
+      throw new IllegalArgumentException("Unsupported MomentoErrorCode: " + errorCode);
+    }
+    return momentoErrorCodeToMetadataMap.get(momentoErrorCode);
+  }
+}

--- a/momento-sdk/src/main/java/momento/sdk/retry/MomentoRpcMethod.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/MomentoRpcMethod.java
@@ -1,5 +1,8 @@
 package momento.sdk.retry;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum MomentoRpcMethod {
   GET("_GetRequest"),
   SET("_SetRequest"),
@@ -48,11 +51,39 @@ public enum MomentoRpcMethod {
 
   private final String requestName;
 
+  private static final Map<String, MomentoRpcMethod> lookup = new HashMap<>();
+
+  static {
+    for (MomentoRpcMethod method : MomentoRpcMethod.values()) {
+      lookup.put(method.getRequestName(), method);
+    }
+  }
+
+  /**
+   * Constructor for MomentoRpcMethod.
+   *
+   * @param requestName - The request name.
+   */
   MomentoRpcMethod(String requestName) {
     this.requestName = requestName;
   }
 
+  /**
+   * Returns the request name.
+   *
+   * @return The request name.
+   */
   public String getRequestName() {
     return requestName;
+  }
+
+  /**
+   * Returns the MomentoRpcMethod from the request name.
+   *
+   * @param requestName - The request name.
+   * @return The MomentoRpcMethod.
+   */
+  public static MomentoRpcMethod fromString(String requestName) {
+    return lookup.getOrDefault(requestName, null);
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/retry/MomentoRpcMethodMetadataConverter.java
+++ b/momento-sdk/src/main/java/momento/sdk/retry/MomentoRpcMethodMetadataConverter.java
@@ -1,0 +1,63 @@
+package momento.sdk.retry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MomentoRpcMethodMetadataConverter {
+  private static final Map<MomentoRpcMethod, String> rpcMethodToMetadataMap = new HashMap<>();
+
+  static {
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.GET, "get");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET, "set");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DELETE, "delete");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.INCREMENT, "increment");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_IF, "set-if");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_IF_NOT_EXISTS, "set-if");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.GET_BATCH, "get-batch");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_BATCH, "set-batch");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.KEYS_EXIST, "keys-exist");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.UPDATE_TTL, "update-ttl");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.ITEM_GET_TTL, "item-get-ttl");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.ITEM_GET_TYPE, "item-get-type");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DICTIONARY_SET, "dictionary-set");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DICTIONARY_GET, "dictionary-get");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DICTIONARY_FETCH, "dictionary-fetch");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DICTIONARY_INCREMENT, "dictionary-increment");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DICTIONARY_DELETE, "dictionary-delete");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.DICTIONARY_LENGTH, "dictionary-length");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_FETCH, "set-fetch");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_SAMPLE, "set-sample");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_UNION, "set-union");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_DIFFERENCE, "set-difference");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_CONTAINS, "set-contains");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_LENGTH, "set-length");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SET_POP, "set-pop");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_PUSH_FRONT, "list-push-front");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_PUSH_BACK, "list-push-back");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_POP_FRONT, "list-pop-front");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_POP_BACK, "list-pop-back");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_ERASE, "list-remove"); // Alias for list-remove
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_REMOVE, "list-remove");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_FETCH, "list-fetch");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_LENGTH, "list-length");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_CONCATENATE_FRONT, "list-concatenate-front");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_CONCATENATE_BACK, "list-concatenate-back");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.LIST_RETAIN, "list-retain");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_PUT, "sorted-set-put");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_FETCH, "sorted-set-fetch");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_GET_SCORE, "sorted-set-get-score");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_REMOVE, "sorted-set-remove");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_INCREMENT, "sorted-set-increment");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_GET_RANK, "sorted-set-get-rank");
+    rpcMethodToMetadataMap.put(MomentoRpcMethod.SORTED_SET_LENGTH, "sorted-set-length");
+    rpcMethodToMetadataMap.put(
+        MomentoRpcMethod.SORTED_SET_LENGTH_BY_SCORE, "sorted-set-length-by-score");
+  }
+
+  public static String convert(MomentoRpcMethod rpcMethod) {
+    if (!rpcMethodToMetadataMap.containsKey(rpcMethod)) {
+      throw new IllegalArgumentException("Unsupported MomentoRpcMethod: " + rpcMethod);
+    }
+    return rpcMethodToMetadataMap.get(rpcMethod);
+  }
+}


### PR DESCRIPTION
## PR Description:  
This commit introduces a middleware interface using `GrpcMiddlewareInterceptor`, enabling custom middleware implementations for enhanced request and response handling.  

### Key Changes:  
- Added `Middleware` interface to allow users to intercept and modify gRPC request and response data.  
- Implemented `GrpcMiddlewareInterceptor` to integrate middleware into the request pipeline.  

### Testing:  
To validate this feature, a custom middleware (`MyCustomMiddleware`) was created and tested using a sample program (`Program.java`). The test includes:  
- Creating a cache using `CacheClient`  
- Setting and retrieving a key-value pair  
- Verifying that the middleware correctly logs request and response metadata, payloads, and statuses  

<details>
  <summary>MyCustomMiddleware.java</summary>

```java
package momento.sdk;

import java.util.concurrent.CompletableFuture;
import momento.sdk.config.middleware.*;

public class MyCustomMiddleware implements Middleware {

  @Override
  public MiddlewareRequestHandler onNewRequest(MiddlewareRequestHandlerContext context) {
    return new MiddlewareRequestHandler() {
      @Override
      public CompletableFuture<MiddlewareMetadata> onRequestMetadata(MiddlewareMetadata metadata) {
        System.out.println("Request metadata: " + metadata.getGrpcMetadata());
        return CompletableFuture.completedFuture(metadata);
      }

      @Override
      public CompletableFuture<MiddlewareMessage> onRequestBody(MiddlewareMessage request) {
        System.out.println("Request body: " + request.getMessage());
        return CompletableFuture.completedFuture(request);
      }

      @Override
      public CompletableFuture<MiddlewareMetadata> onResponseMetadata(MiddlewareMetadata metadata) {
        System.out.println("Response metadata: " + metadata.getGrpcMetadata());
        return CompletableFuture.completedFuture(metadata);
      }

      @Override
      public CompletableFuture<MiddlewareMessage> onResponseBody(MiddlewareMessage response) {
        System.out.println("Response body: " + response.getMessage());
        return CompletableFuture.completedFuture(response);
      }

      @Override
      public CompletableFuture<MiddlewareStatus> onResponseStatus(MiddlewareStatus status) {
        System.out.println("Response status: " + status.getGrpcStatus());
        return CompletableFuture.completedFuture(status);
      }
    };
  }
}
```
</details>


<details>
  <summary>Program.java</summary>

```java
package momento.sdk;

import java.time.Duration;
import momento.sdk.auth.CredentialProvider;
import momento.sdk.auth.MomentoLocalProvider;
import momento.sdk.config.Configuration;
import momento.sdk.config.Configurations;
import momento.sdk.config.middleware.Middleware;
import momento.sdk.responses.cache.GetResponse;
import momento.sdk.responses.cache.SetResponse;
import momento.sdk.responses.cache.control.CacheCreateResponse;

public class Program {
  public static void main(String[] args) {
    String cacheName = "test-cache-java";
    CredentialProvider credentialProvider = new MomentoLocalProvider();

    Middleware customMiddleware = new MyCustomMiddleware();
    Configuration configuration = Configurations.Laptop.latest().withMiddleware(customMiddleware);

    CacheClient cacheClient =
        new CacheClientBuilder(credentialProvider, configuration, Duration.ofMinutes(1)).build();

    CacheCreateResponse createResponse = cacheClient.createCache(cacheName).join();
    if (createResponse instanceof CacheCreateResponse.Success) {
      System.out.println("Cache created successfully");
    } else {
      System.out.println("Failed to create cache" + createResponse.toString());
      CacheCreateResponse.Error error = (CacheCreateResponse.Error) createResponse;
      System.out.println("Failed to create cache: " + error.getErrorCode());
    }

    SetResponse setResponse = cacheClient.set(cacheName, "key", "value").join();
    if (setResponse instanceof SetResponse.Success) {
      System.out.println("Set key successfully");
    } else {
      System.out.println("Failed to set key" + setResponse.toString());
      SetResponse.Error error = (SetResponse.Error) setResponse;
      System.out.println("Failed to set key: " + error.getErrorCode());
      cacheClient.close();
    }

    GetResponse getResponse = cacheClient.get(cacheName, "key").join();
    if (getResponse instanceof GetResponse.Hit) {
      GetResponse.Hit hit = (GetResponse.Hit) getResponse;
      System.out.println("Got value: " + hit.value());
    } else if (getResponse instanceof GetResponse.Miss) {
      System.out.println("Key not found");
    } else {
      System.out.println("Failed to get key" + getResponse.toString());
      GetResponse.Error error = (GetResponse.Error) getResponse;
      System.out.println("Failed to get key: " + error.getErrorCode());
      cacheClient.close();
    }

    cacheClient.close();
  }
}

```
</details>


## Testing Result:

```
> Task :momento-sdk:momento.sdk.Program.main()
Failed to create cachemomento.sdk.responses.cache.control.CacheCreateResponse$Error: A cache with the specified name already exists. To resolve this error, either delete the existing cache and make a new one, or use a different name.
Failed to create cache: ALREADY_EXISTS_ERROR
Request metadata: Metadata(cache=test-cache-java)
Request body: cache_key: "key"
cache_body: "value"
ttl_milliseconds: 60000

Response metadata: Metadata(content-type=application/grpc,date=Tue, 04 Feb 2025 23:47:18 GMT)
Response body: result: Ok

Response status: Status{code=OK, description=null, cause=null}
Set key successfully
Request metadata: Metadata(cache=test-cache-java)
Request body: cache_key: "key"

Response metadata: Metadata(content-type=application/grpc,date=Tue, 04 Feb 2025 23:47:18 GMT)
Response body: result: Hit
cache_body: "value"

Response status: Status{code=OK, description=null, cause=null}
Got value: value

BUILD SUCCESSFUL in 1s
```



### Related Issue:  
[Issue #1126](https://github.com/momentohq/dev-eco-issue-tracker/issues/1126)  
