### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
+++ b/momento-sdk/src/main/java/momento/sdk/internal/GrpcChannelOptions.java
@@ -37,6 +37,8 @@ public class GrpcChannelOptions {
       channelBuilder.usePlaintext();
     }
 
+    channelBuilder.disableServiceConfigLookUp();
+
     grpcConfig.getMaxReceivedMessageSize().ifPresent(channelBuilder::maxInboundMessageSize);
 
     // no equivalent for maxOutboundMessageSize


### PR DESCRIPTION
## PR Description:
- Based on the commit [here](https://github.com/googleapis/gax-java/pull/731), dynamic txt lookup for dns resolution flag is disabled by default in grpc-java. 
- This commit explicitly disables it too. 

### tcpdump when running existing example without adding the flag explicitly:
```
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    10.0.0.249.52040 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 30203+ A? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    10.0.0.249.55920 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 62892+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.52040: [udp sum ok] 30203 q: A? cache.cell-alpha-dev.preprod.a.momentohq.com. 1/0/0 cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (78)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.55920: [udp sum ok] 62892 q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.58622: [udp sum ok] 37935 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.60876: [udp sum ok] 15947 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
```
You can observe that there are no TXT record lookups with existing sdk version [v1.21.0](https://github.com/momentohq/client-sdk-java/releases/tag/v1.21.0)

### Relevant Research Link:
https://github.com/googleapis/gapic-generator/issues/2778
https://github.com/googleapis/gax-java/pull/731

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1132