### PR TITLE
feat: add topic subscribe timeout

### DIFF
--- a/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
@@ -164,7 +164,19 @@ public class ScsTopicClient extends ScsClientBase {
           }
         };
 
-    subscriptionWrapper = new SubscriptionWrapper(connection, sendSubscribeOptions);
+    long configuredTimeoutSeconds =
+        topicGrpcStubsManager
+            .getConfiguration()
+            .getTransportStrategy()
+            .getGrpcConfiguration()
+            .getDeadline()
+            .getSeconds();
+    long firstMessageSubscribeTimeoutSeconds =
+        configuredTimeoutSeconds > 0 ? configuredTimeoutSeconds : 5;
+
+    subscriptionWrapper =
+        new SubscriptionWrapper(
+            connection, sendSubscribeOptions, firstMessageSubscribeTimeoutSeconds);
     final CompletableFuture<Void> subscribeFuture = subscriptionWrapper.subscribeWithRetry();
     return subscribeFuture.handle(
         (v, ex) -> {

--- a/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
+++ b/momento-sdk/src/main/java/momento/sdk/ScsTopicClient.java
@@ -22,6 +22,7 @@ public class ScsTopicClient extends ScsClientBase {
 
   private final Logger logger = LoggerFactory.getLogger(ScsTopicClient.class);
   private final ScsTopicGrpcStubsManager topicGrpcStubsManager;
+  private final long DEFAULT_REQUEST_TIMEOUT_SECONDS = 5;
 
   public ScsTopicClient(
       @Nonnull CredentialProvider credentialProvider, @Nonnull TopicConfiguration configuration) {
@@ -172,7 +173,7 @@ public class ScsTopicClient extends ScsClientBase {
             .getDeadline()
             .getSeconds();
     long firstMessageSubscribeTimeoutSeconds =
-        configuredTimeoutSeconds > 0 ? configuredTimeoutSeconds : 5;
+        configuredTimeoutSeconds > 0 ? configuredTimeoutSeconds : DEFAULT_REQUEST_TIMEOUT_SECONDS;
 
     subscriptionWrapper =
         new SubscriptionWrapper(

--- a/momento-sdk/src/main/java/momento/sdk/SubscriptionWrapper.java
+++ b/momento-sdk/src/main/java/momento/sdk/SubscriptionWrapper.java
@@ -12,6 +12,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import momento.sdk.exceptions.CacheServiceExceptionMapper;
 import momento.sdk.exceptions.InternalServerException;
+import momento.sdk.exceptions.TimeoutException;
+import momento.sdk.internal.MomentoGrpcErrorDetails;
+import momento.sdk.internal.MomentoTransportErrorDetails;
 import momento.sdk.responses.topic.TopicDiscontinuity;
 import momento.sdk.responses.topic.TopicMessage;
 import momento.sdk.responses.topic.TopicSubscribeResponse;
@@ -22,6 +25,7 @@ class SubscriptionWrapper implements AutoCloseable {
   private final Logger logger = LoggerFactory.getLogger(SubscriptionWrapper.class);
   private final IScsTopicConnection connection;
   private final SendSubscribeOptions options;
+  private final long requestTimeoutSeconds;
   private boolean firstMessage = true;
   private boolean isConnectionLost = false;
 
@@ -29,25 +33,66 @@ class SubscriptionWrapper implements AutoCloseable {
 
   private CancelableClientCallStreamObserver<_SubscriptionItem> subscription;
 
-  SubscriptionWrapper(IScsTopicConnection connection, SendSubscribeOptions options) {
+  private volatile CompletableFuture<Void> firstMessageTimeoutFuture = null;
+
+  SubscriptionWrapper(
+      IScsTopicConnection connection, SendSubscribeOptions options, long requestTimeoutSeconds) {
     this.connection = connection;
     this.options = options;
+    this.requestTimeoutSeconds = requestTimeoutSeconds;
   }
 
-  /**
-   * Public method for testing purposes only. Do not call this method in production code or any
-   * context other than testing the topic client.
-   *
-   * <p>This method returns a CompletableFuture that represents the asynchronous execution of the
-   * internal subscription logic with retry mechanism.
-   *
-   * @return A CompletableFuture representing the asynchronous execution of the internal
-   *     subscription logic with retry mechanism.
-   */
   public CompletableFuture<Void> subscribeWithRetry() {
     CompletableFuture<Void> future = new CompletableFuture<>();
+    firstMessageTimeoutFuture = new CompletableFuture<>();
+
+    scheduler.schedule(
+        () -> {
+          if (!firstMessageTimeoutFuture.isDone()) {
+            logger.warn(
+                "First message timeout exceeded for topic {} on cache {}",
+                options.getTopicName(),
+                options.getCacheName());
+
+            if (subscription != null) {
+              subscription.cancel("Timed out waiting for first message", null);
+            }
+
+            firstMessageTimeoutFuture.completeExceptionally(
+                new TimeoutException(
+                    new RuntimeException(
+                        "Timed out waiting for first message (heartbeat) for topic "
+                            + options.getTopicName()
+                            + " on cache "
+                            + options.getCacheName()),
+                    new MomentoTransportErrorDetails(
+                        new MomentoGrpcErrorDetails(
+                            Status.Code.DEADLINE_EXCEEDED,
+                            "Timed out waiting for first message (heartbeat)",
+                            null))));
+          }
+        },
+        requestTimeoutSeconds,
+        TimeUnit.SECONDS);
+
     subscribeWithRetryInternal(future);
-    return future;
+
+    // Ensure that timeout error takes precedence
+    CompletableFuture<Void> result = new CompletableFuture<>();
+    CompletableFuture.anyOf(future, firstMessageTimeoutFuture)
+        .whenComplete(
+            (ignored, throwable) -> {
+              if (firstMessageTimeoutFuture.isCompletedExceptionally()) {
+                firstMessageTimeoutFuture.whenComplete(
+                    (__, ex) -> result.completeExceptionally(ex));
+              } else if (future.isCompletedExceptionally()) {
+                future.whenComplete((__, ex) -> result.completeExceptionally(ex));
+              } else {
+                result.complete(null);
+              }
+            });
+
+    return result;
   }
 
   private void subscribeWithRetryInternal(CompletableFuture<Void> future) {
@@ -56,6 +101,11 @@ class SubscriptionWrapper implements AutoCloseable {
           @Override
           public void onNext(_SubscriptionItem item) {
             if (firstMessage) {
+              firstMessage = false;
+              if (firstMessageTimeoutFuture != null) {
+                firstMessageTimeoutFuture.complete(null);
+              }
+
               if (item.getKindCase() != _SubscriptionItem.KindCase.HEARTBEAT) {
                 future.completeExceptionally(
                     new InternalServerException(
@@ -66,8 +116,8 @@ class SubscriptionWrapper implements AutoCloseable {
                             + ". Got: "
                             + item.getKindCase()));
               }
-              firstMessage = false;
               future.complete(null);
+              return;
             }
             if (isConnectionLost) {
               isConnectionLost = false;
@@ -80,7 +130,13 @@ class SubscriptionWrapper implements AutoCloseable {
           public void onError(Throwable t) {
             if (firstMessage) {
               firstMessage = false;
-              future.completeExceptionally(t);
+              if (firstMessageTimeoutFuture != null && !firstMessageTimeoutFuture.isDone()) {
+                firstMessageTimeoutFuture.completeExceptionally(t);
+              }
+              if (!future.isDone()) {
+                future.completeExceptionally(t);
+              }
+
             } else {
               logger.debug("Subscription failed, retrying...");
               if (!isConnectionLost) {

--- a/momento-sdk/src/test/java/momento/sdk/SubscriptionWrapperTest.java
+++ b/momento-sdk/src/test/java/momento/sdk/SubscriptionWrapperTest.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 public class SubscriptionWrapperTest {
   private final Logger logger = LoggerFactory.getLogger(SubscriptionWrapperTest.class);
+  private final long requestTimeoutSeconds = 5;
 
   @BeforeEach
   public void setUp() {
@@ -94,7 +95,8 @@ public class SubscriptionWrapperTest {
           }
         };
 
-    SubscriptionWrapper subscriptionWrapper = new SubscriptionWrapper(connection, options);
+    SubscriptionWrapper subscriptionWrapper =
+        new SubscriptionWrapper(connection, options, requestTimeoutSeconds);
     CompletableFuture<Void> subscribeWithRetryResult = subscriptionWrapper.subscribeWithRetry();
     subscribeWithRetryResult.join();
 


### PR DESCRIPTION
## PR Description:
- Enforces deadline on subscribe: Sets a deadline for receiving the first message when subscribing to a topic.

## Testing
Adds a test case that intentionally delays the subscribe response beyond the client timeout to verify that a TIMEOUT_ERROR is correctly returned.

## Issue
closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1147