### PR TITLE
fix: reduce client timeout in topic client momento-local test

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/retry/TopicClientLocalTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/TopicClientLocalTest.java
@@ -203,10 +203,11 @@ public class TopicClientLocalTest {
   @Timeout(10)
   void topicSubscribe_ReturnsTimeoutError_IfFirstMessageNotReceivedBeforeDeadline()
       throws Exception {
+    final Duration CLIENT_TIMEOUT_MILLIS = Duration.ofMillis(1000);
     final MomentoLocalMiddlewareArgs momentoLocalMiddlewareArgs =
         new MomentoLocalMiddlewareArgs.Builder(logger, UUID.randomUUID().toString())
             .delayRpcList(Collections.singletonList(MomentoRpcMethod.TOPIC_SUBSCRIBE))
-            .delayMillis(4000) // Greater than the client timeout of 3000 ms
+            .delayMillis(2000) // Greater than the client timeout of 1000 ms
             .build();
 
     final ISubscriptionCallbacks callbacks =
@@ -233,7 +234,7 @@ public class TopicClientLocalTest {
         };
 
     withCacheAndTopicClient(
-        config -> config.withTimeout(Duration.ofMillis(3000)),
+        config -> config.withTimeout(CLIENT_TIMEOUT_MILLIS),
         momentoLocalMiddlewareArgs,
         (topicClient, cacheName) -> {
           final String topicName = "topic";


### PR DESCRIPTION
Reduce the client-timeout configuration for the test suite to run faster. 
Follow-up for https://github.com/momentohq/client-sdk-java/pull/437