### PR TITLE
fix: minor fixes for retry tests

### DIFF
--- a/momento-sdk/src/intTest/java/momento/sdk/retry/FixedTimeoutRetryStrategyIntegTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/FixedTimeoutRetryStrategyIntegTest.java
@@ -130,7 +130,7 @@ public class FixedTimeoutRetryStrategyIntegTest {
 
   @Test
   void
-      testRetryEligibleApi_shouldMakeNoRetries_WhenRetryDelayIntervalMillisIsGreaterThanClientMaxDelayMillis()
+      testRetryEligibleApi_shouldTimeoutRetry_WhenRetryDelayIntervalMillisIsGreaterThanClientMaxDelayMillis()
           throws Exception {
     long retryDelayIntervalMillis = 4000;
     RetryEligibilityStrategy eligibilityStrategy = (status, methodName) -> true;
@@ -157,7 +157,7 @@ public class FixedTimeoutRetryStrategyIntegTest {
               .isEqualTo(MomentoErrorCode.TIMEOUT_ERROR);
 
           assertThat(testRetryMetricsCollector.getTotalRetryCount(cacheName, MomentoRpcMethod.GET))
-              .isEqualTo(0);
+              .isEqualTo(1);
         });
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/FixedTimeoutRetryStrategyIntegTest.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/FixedTimeoutRetryStrategyIntegTest.java
@@ -157,7 +157,7 @@ public class FixedTimeoutRetryStrategyIntegTest {
               .isEqualTo(MomentoErrorCode.TIMEOUT_ERROR);
 
           assertThat(testRetryMetricsCollector.getTotalRetryCount(cacheName, MomentoRpcMethod.GET))
-              .isEqualTo(1);
+              .isLessThanOrEqualTo(1);
         });
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/utils/MomentoLocalMiddlewareArgs.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/utils/MomentoLocalMiddlewareArgs.java
@@ -2,36 +2,39 @@ package momento.sdk.retry.utils;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import momento.sdk.exceptions.MomentoErrorCode;
+import momento.sdk.exceptions.MomentoErrorCodeMetadataConverter;
 import momento.sdk.retry.MomentoRpcMethod;
+import momento.sdk.retry.MomentoRpcMethodMetadataConverter;
 import org.slf4j.Logger;
 
 public class MomentoLocalMiddlewareArgs {
   private final Logger logger;
   private final TestRetryMetricsCollector testMetricsCollector;
   private final String requestId;
-  private final MomentoErrorCode returnError;
-  private final List<MomentoRpcMethod> errorRpcList;
+  private final String returnError;
+  private final List<String> errorRpcList;
   private final Integer errorCount;
-  private final List<MomentoRpcMethod> delayRpcList;
+  private final List<String> delayRpcList;
   private final Integer delayMillis;
   private final Integer delayCount;
-  private final List<MomentoRpcMethod> streamErrorRpcList;
-  private final MomentoErrorCode streamError;
+  private final List<String> streamErrorRpcList;
+  private final String streamError;
   private final Integer streamErrorMessageLimit;
 
   private MomentoLocalMiddlewareArgs(
       Logger logger,
       TestRetryMetricsCollector testMetricsCollector,
       String requestId,
-      MomentoErrorCode returnError,
-      List<MomentoRpcMethod> errorRpcList,
+      String returnError,
+      List<String> errorRpcList,
       Integer errorCount,
-      List<MomentoRpcMethod> delayRpcList,
+      List<String> delayRpcList,
       Integer delayMillis,
       Integer delayCount,
-      List<MomentoRpcMethod> streamErrorRpcList,
-      MomentoErrorCode streamError,
+      List<String> streamErrorRpcList,
+      String streamError,
       Integer streamErrorMessageLimit) {
     this.logger = logger;
     this.testMetricsCollector = testMetricsCollector;
@@ -51,14 +54,14 @@ public class MomentoLocalMiddlewareArgs {
     private final Logger logger;
     private final String requestId;
     private TestRetryMetricsCollector testMetricsCollector;
-    private MomentoErrorCode returnError = null;
-    private List<MomentoRpcMethod> errorRpcList = null;
+    private String returnError = null;
+    private List<String> errorRpcList = null;
     private Integer errorCount = null;
-    private List<MomentoRpcMethod> delayRpcList = null;
+    private List<String> delayRpcList = null;
     private Integer delayMillis = null;
     private Integer delayCount = null;
-    private List<MomentoRpcMethod> streamErrorRpcList = null;
-    private MomentoErrorCode streamError = null;
+    private List<String> streamErrorRpcList = null;
+    private String streamError = null;
     private Integer streamErrorMessageLimit = null;
 
     public Builder(Logger logger, String requestId) {
@@ -72,12 +75,12 @@ public class MomentoLocalMiddlewareArgs {
     }
 
     public Builder returnError(MomentoErrorCode returnError) {
-      this.returnError = returnError;
+      this.returnError = MomentoErrorCodeMetadataConverter.convert(returnError);
       return this;
     }
 
     public Builder errorRpcList(List<MomentoRpcMethod> errorRpcList) {
-      this.errorRpcList = errorRpcList;
+      this.errorRpcList = this.convertRPCs(errorRpcList);
       return this;
     }
 
@@ -87,7 +90,7 @@ public class MomentoLocalMiddlewareArgs {
     }
 
     public Builder delayRpcList(List<MomentoRpcMethod> delayRpcList) {
-      this.delayRpcList = delayRpcList;
+      this.delayRpcList = this.convertRPCs(delayRpcList);
       return this;
     }
 
@@ -102,12 +105,12 @@ public class MomentoLocalMiddlewareArgs {
     }
 
     public Builder streamErrorRpcList(List<MomentoRpcMethod> errorRpcList) {
-      this.streamErrorRpcList = errorRpcList;
+      this.streamErrorRpcList = this.convertRPCs(errorRpcList);
       return this;
     }
 
     public Builder streamError(MomentoErrorCode streamError) {
-      this.streamError = streamError;
+      this.streamError = MomentoErrorCodeMetadataConverter.convert(streamError);
       return this;
     }
 
@@ -131,6 +134,12 @@ public class MomentoLocalMiddlewareArgs {
           streamError,
           streamErrorMessageLimit);
     }
+
+    private List<String> convertRPCs(List<MomentoRpcMethod> RPCs) {
+      return RPCs.stream()
+          .map(MomentoRpcMethodMetadataConverter::convert)
+          .collect(Collectors.toList());
+    }
   }
 
   public Logger getLogger() {
@@ -145,11 +154,11 @@ public class MomentoLocalMiddlewareArgs {
     return Optional.ofNullable(testMetricsCollector);
   }
 
-  public Optional<MomentoErrorCode> getReturnError() {
+  public Optional<String> getReturnError() {
     return Optional.ofNullable(returnError);
   }
 
-  public Optional<List<MomentoRpcMethod>> getErrorRpcList() {
+  public Optional<List<String>> getErrorRpcList() {
     return Optional.ofNullable(errorRpcList);
   }
 
@@ -157,7 +166,7 @@ public class MomentoLocalMiddlewareArgs {
     return Optional.ofNullable(errorCount);
   }
 
-  public Optional<List<MomentoRpcMethod>> getDelayRpcList() {
+  public Optional<List<String>> getDelayRpcList() {
     return Optional.ofNullable(delayRpcList);
   }
 
@@ -169,11 +178,11 @@ public class MomentoLocalMiddlewareArgs {
     return Optional.ofNullable(delayCount);
   }
 
-  public Optional<List<MomentoRpcMethod>> getStreamErrorRpcList() {
+  public Optional<List<String>> getStreamErrorRpcList() {
     return Optional.ofNullable(streamErrorRpcList);
   }
 
-  public Optional<MomentoErrorCode> getStreamError() {
+  public Optional<String> getStreamError() {
     return Optional.ofNullable(streamError);
   }
 

--- a/momento-sdk/src/intTest/java/momento/sdk/retry/utils/MomentoLocalMiddlewareRequestHandler.java
+++ b/momento-sdk/src/intTest/java/momento/sdk/retry/utils/MomentoLocalMiddlewareRequestHandler.java
@@ -8,9 +8,7 @@ import momento.sdk.config.middleware.MiddlewareMessage;
 import momento.sdk.config.middleware.MiddlewareMetadata;
 import momento.sdk.config.middleware.MiddlewareRequestHandler;
 import momento.sdk.config.middleware.MiddlewareStatus;
-import momento.sdk.exceptions.MomentoErrorCodeMetadataConverter;
 import momento.sdk.retry.MomentoRpcMethod;
-import momento.sdk.retry.MomentoRpcMethodMetadataConverter;
 
 public class MomentoLocalMiddlewareRequestHandler implements MiddlewareRequestHandler {
   private String cacheName = null;
@@ -28,7 +26,6 @@ public class MomentoLocalMiddlewareRequestHandler implements MiddlewareRequestHa
 
     momentoLocalMiddlewareArgs
         .getReturnError()
-        .map(MomentoErrorCodeMetadataConverter::convert)
         .ifPresent(e -> setGrpcMetadata(grpcMetadata, "return-error", e));
 
     momentoLocalMiddlewareArgs
@@ -63,7 +60,6 @@ public class MomentoLocalMiddlewareRequestHandler implements MiddlewareRequestHa
 
     momentoLocalMiddlewareArgs
         .getStreamError()
-        .map(MomentoErrorCodeMetadataConverter::convert)
         .ifPresent(e -> setGrpcMetadata(grpcMetadata, "stream-error", e));
 
     momentoLocalMiddlewareArgs
@@ -125,9 +121,7 @@ public class MomentoLocalMiddlewareRequestHandler implements MiddlewareRequestHa
     }
   }
 
-  private String concatenateRPCs(List<MomentoRpcMethod> RPCs) {
-    return RPCs.stream()
-        .map(MomentoRpcMethodMetadataConverter::convert)
-        .collect(Collectors.joining(" "));
+  private String concatenateRPCs(List<String> RPCs) {
+    return RPCs.stream().collect(Collectors.joining(" "));
   }
 }

--- a/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
@@ -134,14 +134,6 @@ final class RetryClientInterceptor implements ClientInterceptor {
                   return;
                 }
 
-                // If the retry delay is greater than the overall deadline, we don't need to retry
-                if (retryDelay.get().toMillis()
-                    > overallDeadline.timeRemaining(TimeUnit.MILLISECONDS)) {
-                  cancelAttempt();
-                  super.onClose(Status.DEADLINE_EXCEEDED, trailers);
-                  return;
-                }
-
                 logger.debug(
                     "Retrying request {} on error code {} with delay {} milliseconds",
                     method.getFullMethodName(),

--- a/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
@@ -147,10 +147,16 @@ final class RetryClientInterceptor implements ClientInterceptor {
                               Optional<Long> responseTimeout =
                                   retryStrategy.getResponseDataReceivedTimeoutMillis();
 
-                              // Set responseTimeout to the min(retry timeout, overall deadline time remaining) to ensure we
-                              // don't exceed the overall deadline while making use of the entire overall client timeout.
-                              if (responseTimeout.isPresent() && overallDeadline.timeRemaining(TimeUnit.MILLISECONDS) <= responseTimeout.get()) {
-                                responseTimeout = Optional.of(overallDeadline.timeRemaining(TimeUnit.MILLISECONDS));
+                              // Set responseTimeout to the min(retry timeout, overall deadline time
+                              // remaining) to ensure we
+                              // don't exceed the overall deadline while making use of the entire
+                              // overall client timeout.
+                              if (responseTimeout.isPresent()
+                                  && overallDeadline.timeRemaining(TimeUnit.MILLISECONDS)
+                                      <= responseTimeout.get()) {
+                                responseTimeout =
+                                    Optional.of(
+                                        overallDeadline.timeRemaining(TimeUnit.MILLISECONDS));
                               }
 
                               // Proceed with the retry if everything is valid

--- a/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
+++ b/momento-sdk/src/main/java/momento/sdk/RetryClientInterceptor.java
@@ -134,6 +134,14 @@ final class RetryClientInterceptor implements ClientInterceptor {
                   return;
                 }
 
+                // If the retry delay is greater than the overall deadline, we don't need to retry
+                if (retryDelay.get().toMillis()
+                    > overallDeadline.timeRemaining(TimeUnit.MILLISECONDS)) {
+                  cancelAttempt();
+                  super.onClose(Status.DEADLINE_EXCEEDED, trailers);
+                  return;
+                }
+
                 logger.debug(
                     "Retrying request {} on error code {} with delay {} milliseconds",
                     method.getFullMethodName(),


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1207

Assigns the Min(retry deadline, overall deadline) on each retry attempt to ensure we don't exceed the client's overall deadline.

Ended up removing the check for "if retry delay ms will cause retry attempt to exceed client timeout, then don't retry" since that's not included in any other implementations so far. Adjusted one test case to accommodate--depending on jitter, the test may make one retry attempt that will timeout before it can complete.
