### PR TITLE
chore: replace OSSRH endpoint with Sonatype Central endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,8 @@ if (sonatypeUsername != null && sonatypePassword != null) {
         nexusPublishing {
             repositories {
                 sonatype {
-                    nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-                    snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+                    nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+                    snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
                     username.set(System.getenv("SONATYPE_USERNAME"))
                     password.set(System.getenv("SONATYPE_PASSWORD"))
                 }


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1236

OSSRH is reaching end of life on June 30, 2025, so we migrated our namespace to Sonatype Central namespace.

I think we only need to update the URLs to switch from publishing to OSSRH to Sonatype Central according to these sources [[1](https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central)] [[2](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#plugins-tested-for-compatibility)]

Did a dry-run to confirm the new URLs work